### PR TITLE
Add vertical orientation support

### DIFF
--- a/include/Renderer.h
+++ b/include/Renderer.h
@@ -28,6 +28,7 @@ public:
     void setZoomNativePixels(bool nativePixels);
     void setPanOffsets(float x, float y);
     void resetPanOffsets();
+    void setOrientation(int orientation);
     float getPanX() const;
     float getPanY() const;
     int getImageWidth()  const;
@@ -61,6 +62,7 @@ private:
     bool m_zoomNativePixels = false;
     float m_panX = 0.0f;
     float m_panY = 0.0f;
+    int m_orientation = 0;
 };
 
 #endif // RENDERER_H

--- a/include/Renderer_VK.h
+++ b/include/Renderer_VK.h
@@ -46,6 +46,7 @@ public:
     int getImageWidth() const;
     int getImageHeight() const;
     void resetDimensions();
+    void setOrientation(int orientation); // 0=none,1=90deg,2=180deg,3=270deg
 
 private:
     struct ShaderParamsUBO {
@@ -61,6 +62,7 @@ private:
         alignas(4) float gainB;
         alignas(16) glm::mat4 CCM;
         alignas(4) float saturationAdjustment;
+        alignas(4) int orientation;
     };
 
     VkPhysicalDevice m_physicalDevice;
@@ -91,6 +93,7 @@ private:
 
     int m_currentRawW;
     int m_currentRawH;
+    int m_orientation; // 0=none,1=90,2=180,3=270
     bool m_zoomNativePixels;
     float m_panX;
     float m_panY;

--- a/motioncam-decoder/lib/RawData_Legacy.cpp
+++ b/motioncam-decoder/lib/RawData_Legacy.cpp
@@ -1,5 +1,6 @@
 #include <motioncam/RawData.hpp>
 #include <vector>
+#include <cstring>
 
 namespace motioncam {
     namespace raw {

--- a/shaders/image_process.frag
+++ b/shaders/image_process.frag
@@ -20,6 +20,7 @@ layout(binding = 1) uniform ShaderParams {
     mat4 CCM; // Pass as mat4, use top-left 3x3
     // --- ADD SATURATION UNIFORM ---
     float saturationAdjustment; // e.g., 1.0 for no change, 1.25 for +25%
+    int orientation; // 0=none,1=90deg,2=180deg,3=270deg
 } params;
 
 // sRGB EOTF (gamma correction)
@@ -55,7 +56,15 @@ float interpD(int x, int y) {
 }
 
 void main() {
-    ivec2 p = ivec2(inTexCoord * vec2(params.W, params.H));
+    vec2 coord = inTexCoord;
+    if (params.orientation == 1) {
+        coord = vec2(inTexCoord.y, 1.0 - inTexCoord.x);
+    } else if (params.orientation == 2) {
+        coord = vec2(1.0 - inTexCoord.x, 1.0 - inTexCoord.y);
+    } else if (params.orientation == 3) {
+        coord = vec2(1.0 - inTexCoord.y, inTexCoord.x);
+    }
+    ivec2 p = ivec2(coord * vec2(params.W, params.H));
     
     if (p.x >= params.W || p.y >= params.H || p.x < 0 || p.y < 0) {
         outColor = vec4(0.0, 0.0, 0.0, 1.0); 

--- a/src/App.cpp
+++ b/src/App.cpp
@@ -1214,6 +1214,10 @@ void App::drawFrame() {
                 m_decoderWrapper->getDecoder()->loadFrame(dec_frames[idx], frame_data_for_render, frame_meta_for_render);
                 local_raw_width = frame_meta_for_render.value("width", 0);
                 local_raw_height = frame_meta_for_render.value("height", 0);
+                if (m_rendererVk) {
+                    int orient = (local_raw_width < local_raw_height) ? 1 : 0;
+                    m_rendererVk->setOrientation(orient);
+                }
             } catch (const std::exception& e) {
                 LogToFile(std::string("[App::drawFrame] Error loading frame ") + std::to_string(idx) + ": " + e.what());
                 std::cerr << "[App::drawFrame] Error loading frame " << idx << ": " << e.what() << std::endl;

--- a/src/Renderer.cpp
+++ b/src/Renderer.cpp
@@ -462,4 +462,5 @@ int Renderer::getCfaType(const std::string& c) {
 void Renderer::setZoomNativePixels(bool n) { m_zoomNativePixels = n; }
 void Renderer::setPanOffsets(float x, float y) { m_panX = x; m_panY = y; }
 void Renderer::resetPanOffsets() { m_panX = 0.0f; m_panY = 0.0f; }
+void Renderer::setOrientation(int orientation) { m_orientation = orientation % 4; }
 void Renderer::resetDimensions() { m_currentW = 0; m_currentH = 0; }

--- a/src/Renderer_VK.cpp
+++ b/src/Renderer_VK.cpp
@@ -44,6 +44,7 @@ Renderer_VK::Renderer_VK(VkPhysicalDevice physicalDevice, VkDevice device, VmaAl
     m_graphicsPipeline(VK_NULL_HANDLE),
     m_descriptorPool(VK_NULL_HANDLE),
     m_currentRawW(0), m_currentRawH(0),
+    m_orientation(0),
     m_zoomNativePixels(false),
     m_panX(0.0f), m_panY(0.0f),
     m_swapChainImageCount(0)
@@ -783,6 +784,7 @@ void Renderer_VK::recordRenderCommands(VkCommandBuffer commandBuffer, uint32_t c
     }
     ubo.CCM = glm::mat4(ccm3x3_glm);
     ubo.saturationAdjustment = 1.0f; // Default saturation
+    ubo.orientation = m_orientation;
 
     updateUniformBuffer(currentFrameIndex, ubo);
 
@@ -802,7 +804,9 @@ void Renderer_VK::recordRenderCommands(VkCommandBuffer commandBuffer, uint32_t c
         scissor.extent = { (uint32_t)windowWidth, (uint32_t)windowHeight };
     }
     else {
-        float imgAspect = (m_currentRawH == 0) ? 1.0f : ((float)m_currentRawW / (float)m_currentRawH);
+        float dispW = (m_orientation % 2 == 0) ? (float)m_currentRawW : (float)m_currentRawH;
+        float dispH = (m_orientation % 2 == 0) ? (float)m_currentRawH : (float)m_currentRawW;
+        float imgAspect = (dispH == 0.0f) ? 1.0f : (dispW / dispH);
         float winAspect = (windowHeight == 0) ? 1.0f : ((float)windowWidth / (float)windowHeight);
         float vpWidth = (float)windowWidth;
         float vpHeight = (float)windowHeight;
@@ -922,6 +926,7 @@ int Renderer_VK::getCfaType(const std::string& c) {
 }
 
 void Renderer_VK::setZoomNativePixels(bool n) { m_zoomNativePixels = n; }
+void Renderer_VK::setOrientation(int orientation) { m_orientation = orientation % 4; }
 void Renderer_VK::setPanOffsets(float x, float y) { m_panX = x; m_panY = y; }
 void Renderer_VK::resetPanOffsets() { m_panX = 0.0f; m_panY = 0.0f; }
 float Renderer_VK::getPanX() const { return m_panX; }


### PR DESCRIPTION
## Summary
- allow Renderer and Renderer_VK to store orientation
- rotate fragment shader output based on orientation
- detect vertical orientation in App when loading frames
- fix RawData_Legacy include for memset/memcpy

## Testing
- `cmake ..` *(fails: FATPREFIX environment variable not set)*

------
https://chatgpt.com/codex/tasks/task_e_685c25e4e958832790ddbd2e57eb8a48