### PR TITLE
Update to MotionCam Player branding and features

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.16)
 cmake_policy(SET CMP0111 NEW) # Important for MACOSX_RPATH behavior
-project(MCRAW_Player VERSION 0.5 LANGUAGES C CXX)
+project(MotionCam_Player VERSION 0.5 LANGUAGES C CXX)
 
 # --- Universal macOS binary (Apple Silicon + Intel) ---
 set(CMAKE_OSX_ARCHITECTURES "x86_64;arm64" CACHE STRING "" FORCE)

--- a/Info.plist
+++ b/Info.plist
@@ -7,7 +7,7 @@
 	<key>CFBundleIconFile</key>
 	<string>icon.icns</string> <!-- Make sure you have an icon.icns -->
 	<key>CFBundleIdentifier</key>
-	<string>com.yourcompany.${PRODUCT_NAME}</string> <!-- Change this -->
+        <string>com.motioncam.player</string>
 	<key>CFBundleInfoDictionaryVersion</key>
 	<string>6.0</string>
 	<key>CFBundleName</key>

--- a/PROJECT_OVERVIEW.md
+++ b/PROJECT_OVERVIEW.md
@@ -1,9 +1,9 @@
-Project Name: MCRAW Player
+Project Name: MotionCam Player
 
 ---
 
 🎯 What It Is:
-MCRAW Player is a modern C++ desktop application built for viewing, decoding, and playing `.mcraw` video files (raw video from MotionCam and similar tools). It will use:
+MotionCam Player is a modern C++ desktop application built for viewing, decoding, and playing `.mcraw` video files (raw video from MotionCam and similar tools). It will use:
 - **C++17**
 - **Qt 6** (Widgets + OpenGL)
 - **OpenGL 4.3+** (compute shader pipeline)
@@ -95,7 +95,7 @@ These come only after the solid MVP core (Phase 2) is complete and stable.
 ---
 
 🧠 SUMMARY:
-This is a Qt 6 + OpenGL C++17 application called **MCRAW Player**, focused first on doing a small number of things **extremely well**:
+This is a Qt 6 + OpenGL C++17 application called **MotionCam Player**, focused first on doing a small number of things **extremely well**:
 - Opening `.mcraw` videos
 - Playing and navigating them
 - Moving them to a rejected folder

--- a/include/App.h
+++ b/include/App.h
@@ -123,6 +123,7 @@ public:
     void handleCursorPos(double xpos, double ypos);
     void saveCurrentFrameAsDng();
     void convertCurrentFileToDngs();
+    void sendCurrentFileToMotionCamFuse();
 
     static void framebuffer_size_callback_static(GLFWwindow* window, int w, int h);
     static void key_callback_static(GLFWwindow* window, int key, int scancode, int action, int mods);

--- a/include/GuiOverlay.h
+++ b/include/GuiOverlay.h
@@ -12,6 +12,7 @@ class App;
 
 namespace GuiOverlay {
     extern bool show_playlist_aux;
+    void requestContextMenu(float x, float y);
 
     struct UIData {
         std::string currentFileName;

--- a/macos/Info.plist
+++ b/macos/Info.plist
@@ -5,13 +5,13 @@
 	<key>CFBundleExecutable</key>
 	<string>${MACOSX_BUNDLE_EXECUTABLE_NAME}</string>
 	<key>CFBundleIconFile</key>
-	<string>mcraw_player</string>
-	<key>CFBundleIdentifier</key>
-	<string>com.motioncamapp.mcrawplayer</string>
+        <string>MotionCam Player</string>
+        <key>CFBundleIdentifier</key>
+        <string>com.motioncam.player</string>
 	<key>CFBundleName</key>
-	<string>MCRAW Player</string>
-	<key>CFBundleDisplayName</key>
-	<string>MCRAW Player</string>
+        <string>MotionCam Player</string>
+        <key>CFBundleDisplayName</key>
+        <string>MotionCam Player</string>
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
@@ -30,12 +30,12 @@
 	<true/>
 	<key>MetalCaptureEnabled</key>
 	<true/>
-	<key>NSDesktopFolderUsageDescription</key>
-	<string>MCRAW Player needs access to your Desktop to open .mcraw files.</string>
-	<key>NSDocumentsFolderUsageDescription</key>
-	<string>MCRAW Player needs access to your Documents to open .mcraw files.</string>
-	<key>NSDownloadsFolderUsageDescription</key>
-	<string>MCRAW Player needs access to your Downloads to open .mcraw files.</string>
+        <key>NSDesktopFolderUsageDescription</key>
+        <string>MotionCam Player needs access to your Desktop to open .mcraw files.</string>
+        <key>NSDocumentsFolderUsageDescription</key>
+        <string>MotionCam Player needs access to your Documents to open .mcraw files.</string>
+        <key>NSDownloadsFolderUsageDescription</key>
+        <string>MotionCam Player needs access to your Downloads to open .mcraw files.</string>
 	<key>NSSupportsSuddenTermination</key>
 	<false/>
 	<key>CFBundleDevelopmentRegion</key>

--- a/src/App.cpp
+++ b/src/App.cpp
@@ -500,7 +500,7 @@ bool App::run() {
         m_totalLoopTimeMs = m_decodingTimeMs + m_renderSubmitTimeMs + m_gpuWaitTimeMs + m_sleepTimeMs;
 
         {
-            std::ostringstream ss; ss << "MCRAW Player (Vulkan) - ";
+            std::ostringstream ss; ss << "MotionCam Player (Vulkan) - ";
             if (m_currentFileIndex >= 0 && static_cast<size_t>(m_currentFileIndex) < m_fileList.size()) {
                 ss << fs::path(m_fileList[m_currentFileIndex]).filename().string();
                 if (m_playbackController && m_decoderWrapper && m_decoderWrapper->getDecoder()) {
@@ -545,7 +545,7 @@ bool App::initVulkan() {
     std::cout << "[App::initVulkan] GLFW initialized." << std::endl;
 
     glfwWindowHint(GLFW_CLIENT_API, GLFW_NO_API);
-    m_window = glfwCreateWindow(m_windowWidth, m_windowHeight, "MCRAW Player (Vulkan)", nullptr, nullptr);
+    m_window = glfwCreateWindow(m_windowWidth, m_windowHeight, "MotionCam Player (Vulkan)", nullptr, nullptr);
     if (!m_window) {
         LogToFile("[App::initVulkan] ERROR: Failed to create GLFW window");
         std::cerr << "[App::initVulkan] Failed to create GLFW window" << std::endl;
@@ -634,7 +634,7 @@ void App::createInstance() {
 
     VkApplicationInfo appInfo{};
     appInfo.sType = VK_STRUCTURE_TYPE_APPLICATION_INFO;
-    appInfo.pApplicationName = "MCRAW Player";
+    appInfo.pApplicationName = "MotionCam Player";
     appInfo.applicationVersion = VK_MAKE_VERSION(1, 2, 0);
     appInfo.pEngineName = "No Engine";
     appInfo.engineVersion = VK_MAKE_VERSION(1, 0, 0);
@@ -1634,6 +1634,11 @@ void App::handleKey(int key, int mods) {
 }
 
 void App::handleMouseButton(int button, int action, int mods) {
+    if (button == GLFW_MOUSE_BUTTON_RIGHT && action == GLFW_PRESS) {
+        double cx, cy; glfwGetCursorPos(m_window, &cx, &cy);
+        GuiOverlay::requestContextMenu(static_cast<float>(cx), static_cast<float>(cy));
+        return;
+    }
     if (!m_rendererVk || !m_playbackController || !m_playbackController->isZoomNativePixels()) { if(m_isPanning){ m_isPanning=false; } return; }
     if (button == GLFW_MOUSE_BUTTON_LEFT) { if (action == GLFW_PRESS) { m_isPanning = true; glfwGetCursorPos(m_window, &m_lastMouseX, &m_lastMouseY); } else if (action == GLFW_RELEASE) { if (m_isPanning) { m_isPanning = false; } } }
 }
@@ -1769,4 +1774,20 @@ void App::convertCurrentFileToDngs() {
     }
     std::cout << "DNG Export All: Conversion complete." << std::endl;
     if (m_playbackController && m_playbackController->isPaused() && !wasPausedOriginalState) { m_playbackController->togglePause(); if(!m_playbackController->isPaused()) anchorPlaybackTimeForResume(); }
+}
+
+void App::sendCurrentFileToMotionCamFuse() {
+#ifdef __APPLE__
+    if (m_fileList.empty() || m_currentFileIndex < 0 || static_cast<size_t>(m_currentFileIndex) >= m_fileList.size()) {
+        std::cerr << "MotionCam Fuse: No current file." << std::endl;
+        return;
+    }
+    std::string cmd = std::string("/usr/bin/open -a \"MotionCam Fuse\" --args -f \"") + m_fileList[m_currentFileIndex] + "\"";
+    int ret = std::system(cmd.c_str());
+    if (ret != 0) {
+        std::cerr << "MotionCam Fuse: launch failed." << std::endl;
+    }
+#else
+    std::cerr << "MotionCam Fuse integration is only available on macOS." << std::endl;
+#endif
 }

--- a/src/DebugLog.cpp
+++ b/src/DebugLog.cpp
@@ -13,7 +13,7 @@
 void LogToFile(const std::string& message) {
     // Static to ensure it's initialized once and persists.
     // `std::ios_base::app` ensures appending to the file.
-    static std::ofstream log_file("mcraw_player_debug_log.txt", std::ios_base::app | std::ios_base::out);
+    static std::ofstream log_file("motioncam_player_debug_log.txt", std::ios_base::app | std::ios_base::out);
 
     if (log_file.is_open()) {
         auto now = std::chrono::system_clock::now();

--- a/src/GuiOverlay.cpp
+++ b/src/GuiOverlay.cpp
@@ -85,6 +85,13 @@ namespace {
 
 
 bool GuiOverlay::show_playlist_aux = false;
+static bool g_show_context_menu = false;
+static ImVec2 g_context_menu_pos = ImVec2(0.0f, 0.0f);
+
+void GuiOverlay::requestContextMenu(float x, float y) {
+    g_show_context_menu = true;
+    g_context_menu_pos = ImVec2(x, y);
+}
 
 void GuiOverlay::setup(GLFWwindow* window, App* appInstance) {
     IMGUI_CHECKVERSION();
@@ -284,6 +291,17 @@ void GuiOverlay::render(App* appInstance) {
     ImGuiStyle& style = ImGui::GetStyle();
     ImGuiIO& io = ImGui::GetIO();
 
+    if (g_show_context_menu) {
+        ImGui::OpenPopup("RIGHT_CLICK_MENU");
+        ImGui::SetNextWindowPos(g_context_menu_pos);
+        g_show_context_menu = false;
+    }
+    if (ImGui::BeginPopup("RIGHT_CLICK_MENU")) {
+        if (ImGui::MenuItem("Save frame as DNG")) { appInstance->saveCurrentFrameAsDng(); }
+        if (ImGui::MenuItem("Send to MotionCam Fuse")) { appInstance->sendCurrentFileToMotionCamFuse(); }
+        ImGui::EndPopup();
+    }
+
     float current_playlist_window_width = 0.0f;
     bool playlist_window_is_visible = false;
 
@@ -455,11 +473,6 @@ void GuiOverlay::render(App* appInstance) {
             if (ImGui::Button(ICON_MD_HELP_OUTLINE, sizeAuxOverlayButton)) { appInstance->toggleHelpPage(); if (appInstance->m_showHelpPage) GuiOverlay::show_playlist_aux = false; }
             ImGui::SameLine(0.0f, aux_button_effective_item_spacing_x);
             if (ImGui::Button(ICON_MD_MENU, sizeAuxOverlayButton)) { GuiOverlay::show_playlist_aux = !GuiOverlay::show_playlist_aux; if (GuiOverlay::show_playlist_aux && appInstance->m_showHelpPage) appInstance->toggleHelpPage(); }
-            float screen_y_for_aux_grid_bottom_row = screen_y_for_aux_grid_middle_row + sizeAuxOverlayButton.y + aux_vertical_spacing_tight;
-            ImGui::SetCursorScreenPos(ImVec2(screen_x_for_aux_grid_left_col, screen_y_for_aux_grid_bottom_row));
-            if (ImGui::Button(ICON_MD_SAVE, sizeAuxOverlayButton)) { appInstance->saveCurrentFrameAsDng(); }
-            ImGui::SameLine(0.0f, aux_button_effective_item_spacing_x);
-            if (ImGui::Button(ICON_MD_COLLECTIONS, sizeAuxOverlayButton)) { appInstance->convertCurrentFileToDngs(); }
             ImGui::PopStyleVar(2); ImGui::PopStyleColor(); ImGui::PopFont();
         }
         ImGui::End();

--- a/src/Renderer_VK.cpp
+++ b/src/Renderer_VK.cpp
@@ -782,7 +782,7 @@ void Renderer_VK::recordRenderCommands(VkCommandBuffer commandBuffer, uint32_t c
         if (!valid_ccm) ccm3x3_glm = glm::mat3(1.0f);
     }
     ubo.CCM = glm::mat4(ccm3x3_glm);
-    ubo.saturationAdjustment = 1.0f; // Default saturation
+    ubo.saturationAdjustment = 1.5f; // +50% saturation
 
     updateUniformBuffer(currentFrameIndex, ubo);
 

--- a/tree.md
+++ b/tree.md
@@ -95,7 +95,7 @@ Module Details:
    *   Purpose: Simple static logging class.
    *   Responsibilities:
         *   Provides `log` function.
-        *   Writes timestamped messages to console (`std::cout`) and file (`mcraw_player_compute_log.txt`).
+       *   Writes timestamped messages to console (`std::cout`) and file (`motioncam_player_compute_log.txt`).
    *   Dependencies: `<iostream>`, `<fstream>`, `<chrono>`, `<iomanip>`.
 
 5. Module: PlaybackController


### PR DESCRIPTION
## Summary
- rename branding to **MotionCam Player**
- set bundle identifiers to `com.motioncam.player`
- increase viewport saturation by 50%
- remove DNG save buttons from GUI
- add right‑click context menu with options to save current frame or open in MotionCam Fuse

## Testing
- `cmake ..` *(fails: FATPREFIX environment variable not set)*

------
https://chatgpt.com/codex/tasks/task_e_685cfc467f48832790ee0a00878b9329