### PR TITLE
Fix orientation tag detection and add debug logging

### DIFF
--- a/include/App.h
+++ b/include/App.h
@@ -92,6 +92,8 @@ public:
     int m_cfaTypeFromMetadata;
     double m_staticBlack;
     double m_staticWhite;
+    bool m_containerFlipped;
+    int m_containerOrientationTag;
     bool m_dumpMetadata;
     std::vector<std::string> m_fileList;
     int m_currentFileIndex;

--- a/include/Renderer_VK.h
+++ b/include/Renderer_VK.h
@@ -32,10 +32,9 @@ public:
 
     // CORRECTED: Removed rawData from recordRenderCommands declaration
     void recordRenderCommands(VkCommandBuffer commandBuffer, uint32_t currentFrameIndex,
-        // const std::vector<uint16_t>& rawData, // REMOVED
         const nlohmann::json& frameMetadata,
         double staticBlack, double staticWhite, int cfaTypeOverride,
-        int windowWidth, int windowHeight);
+        int windowWidth, int windowHeight, int orientationTag);
 
     static int getCfaType(const std::string& cfa);
     void setZoomNativePixels(bool nativePixels);
@@ -61,6 +60,7 @@ private:
         alignas(4) float gainB;
         alignas(16) glm::mat4 CCM;
         alignas(4) float saturationAdjustment;
+        alignas(4) int   orientation;
     };
 
     VkPhysicalDevice m_physicalDevice;

--- a/shaders/image_process.frag
+++ b/shaders/image_process.frag
@@ -20,6 +20,7 @@ layout(binding = 1) uniform ShaderParams {
     mat4 CCM; // Pass as mat4, use top-left 3x3
     // --- ADD SATURATION UNIFORM ---
     float saturationAdjustment; // e.g., 1.0 for no change, 1.25 for +25%
+    int orientation;
 } params;
 
 // sRGB EOTF (gamma correction)
@@ -32,6 +33,19 @@ uint readU16_val(int x, int y) {
     x = clamp(x, 0, params.W - 1);
     y = clamp(y, 0, params.H - 1);
     return texelFetch(rawImageBufferTexture, ivec2(x, y), 0).r;
+}
+
+vec2 applyOrientation(vec2 uv) {
+    int o = params.orientation;
+    if (o == 1) return uv;
+    if (o == 2) return vec2(1.0 - uv.x, uv.y);
+    if (o == 3) return vec2(1.0 - uv.x, 1.0 - uv.y);
+    if (o == 4) return vec2(uv.x, 1.0 - uv.y);
+    if (o == 5) return vec2(uv.y, uv.x);
+    if (o == 6) return vec2(uv.y, 1.0 - uv.x);
+    if (o == 7) return vec2(1.0 - uv.y, 1.0 - uv.x);
+    if (o == 8) return vec2(1.0 - uv.y, uv.x);
+    return uv;
 }
 
 float lin(uint v_u16) {
@@ -55,7 +69,8 @@ float interpD(int x, int y) {
 }
 
 void main() {
-    ivec2 p = ivec2(inTexCoord * vec2(params.W, params.H));
+    vec2 oriented = applyOrientation(inTexCoord);
+    ivec2 p = ivec2(oriented * vec2(params.W, params.H));
     
     if (p.x >= params.W || p.y >= params.H || p.x < 0 || p.y < 0) {
         outColor = vec4(0.0, 0.0, 0.0, 1.0); 

--- a/src/App.cpp
+++ b/src/App.cpp
@@ -48,6 +48,29 @@
 namespace fs = std::filesystem;
 
 namespace {
+    int computeOrientationTag(const nlohmann::json& j, bool flipped, int defTag) {
+        if (!j.is_null()) {
+            if (j.is_number_integer()) {
+                int v = j.get<int>();
+                if (v >= 1 && v <= 8) return v;
+                switch (v) {
+                    case 0: return flipped ? tinydngwriter::ORIENTATION_LEFTTOP : tinydngwriter::ORIENTATION_RIGHTTOP; // PORTRAIT
+                    case 1: return flipped ? tinydngwriter::ORIENTATION_RIGHTBOT : tinydngwriter::ORIENTATION_LEFTBOT; // REVERSE_PORTRAIT
+                    case 2: return flipped ? tinydngwriter::ORIENTATION_BOTLEFT : tinydngwriter::ORIENTATION_BOTRIGHT; // REVERSE_LANDSCAPE
+                    case 3: return flipped ? tinydngwriter::ORIENTATION_TOPRIGHT : tinydngwriter::ORIENTATION_TOPLEFT; // LANDSCAPE
+                }
+            } else if (j.is_string()) {
+                std::string o = j.get<std::string>();
+                std::transform(o.begin(), o.end(), o.begin(), ::toupper);
+                if (o == "PORTRAIT") return flipped ? tinydngwriter::ORIENTATION_LEFTTOP : tinydngwriter::ORIENTATION_RIGHTTOP;
+                if (o == "REVERSE_PORTRAIT") return flipped ? tinydngwriter::ORIENTATION_RIGHTBOT : tinydngwriter::ORIENTATION_LEFTBOT;
+                if (o == "REVERSE_LANDSCAPE") return flipped ? tinydngwriter::ORIENTATION_BOTLEFT : tinydngwriter::ORIENTATION_BOTRIGHT;
+                if (o == "LANDSCAPE") return flipped ? tinydngwriter::ORIENTATION_TOPRIGHT : tinydngwriter::ORIENTATION_TOPLEFT;
+            }
+        }
+        return defTag;
+    }
+
     bool writeDngInternal(
         const std::string& outputPath,
         const std::vector<uint16_t>& data,
@@ -118,10 +141,27 @@ namespace {
         if (fwd2_json.is_array() && fwd2_json.size() == 9) {
             for (size_t i = 0; i < 9; ++i) forwardMatrix2[i] = fwd2_json[i].get<float>();
         }
+
+        bool isFlipped = false;
+        if (containerMetadata.contains("extraData") &&
+            containerMetadata["extraData"].contains("postProcessSettings") &&
+            containerMetadata["extraData"]["postProcessSettings"].contains("flipped")) {
+            isFlipped = containerMetadata["extraData"]["postProcessSettings"]["flipped"].get<bool>();
+        }
+
+        int containerTag = computeOrientationTag(
+            containerMetadata.contains("orientation") ? containerMetadata["orientation"] : nlohmann::json(),
+            isFlipped,
+            tinydngwriter::ORIENTATION_TOPLEFT);
+        unsigned short dngOrientation = static_cast<unsigned short>(computeOrientationTag(
+            frameMetadata.contains("orientation") ? frameMetadata["orientation"] : nlohmann::json(),
+            isFlipped,
+            containerTag));
         tinydngwriter::DNGImage dng;
         dng.SetBigEndian(false);
         dng.SetDNGVersion(1, 4, 0, 0);
         dng.SetDNGBackwardVersion(1, 1, 0, 0);
+        dng.SetOrientation(dngOrientation);
         dng.SetImageData(reinterpret_cast<const unsigned char*>(data.data()), static_cast<size_t>(width) * height * sizeof(uint16_t));
         dng.SetImageWidth(width);
         dng.SetImageLength(height);
@@ -238,7 +278,7 @@ App::App(const std::string& filePath) : m_filePath(filePath) {
     m_swapChain = VK_NULL_HANDLE; m_swapChainImageFormat = VK_FORMAT_UNDEFINED;
     m_renderPass = VK_NULL_HANDLE; m_commandPool = VK_NULL_HANDLE;
     m_currentFrame = 0; m_imguiDescriptorPool = VK_NULL_HANDLE;
-    m_isFullscreen = false; m_cfaTypeFromMetadata = 0; m_staticBlack = 0.0; m_staticWhite = 65535.0;
+    m_isFullscreen = false; m_cfaTypeFromMetadata = 0; m_staticBlack = 0.0; m_staticWhite = 65535.0; m_containerFlipped = false; m_containerOrientationTag = tinydngwriter::ORIENTATION_TOPLEFT;
     m_dumpMetadata = false; m_currentFileIndex = 0; m_showMetrics = false; m_showHelpPage = false;
     m_decodingTimeMs = 0.0; m_renderSubmitTimeMs = 0.0; m_gpuWaitTimeMs = 0.0;
     m_sleepTimeMs = 0.0; m_totalLoopTimeMs = 0.0; m_showUI = true;
@@ -1246,10 +1286,18 @@ void App::drawFrame() {
         int cfa = m_cfaOverride.value_or(m_cfaTypeFromMetadata);
         glfwGetFramebufferSize(m_window, &m_windowWidth, &m_windowHeight);
         
+        int orientationTag = m_containerOrientationTag;
+        if (frame_meta_for_render.contains("orientation")) {
+            orientationTag = computeOrientationTag(frame_meta_for_render["orientation"], m_containerFlipped, m_containerOrientationTag);
+        }
+        LogToFile(std::string("[App::drawFrame] orientation tag: ") + std::to_string(orientationTag));
+        std::cout << "[App::drawFrame] orientation tag: " << orientationTag << std::endl;
+
         m_rendererVk->recordRenderCommands(currentCommandBuffer, m_currentFrame,
                                            frame_meta_for_render,
                                            m_staticBlack, m_staticWhite, cfa,
-                                           m_windowWidth, m_windowHeight);
+                                           m_windowWidth, m_windowHeight,
+                                           orientationTag);
     }
 
     if (m_showUI) {
@@ -1500,6 +1548,17 @@ void App::loadFileAtIndex(int index) {
         return;
     }
     auto meta = m_decoderWrapper->getContainerMetadata();
+    m_containerFlipped = false;
+    if (meta.contains("extraData") && meta["extraData"].contains("postProcessSettings") &&
+        meta["extraData"]["postProcessSettings"].contains("flipped")) {
+        m_containerFlipped = meta["extraData"]["postProcessSettings"]["flipped"].get<bool>();
+    }
+    m_containerOrientationTag = tinydngwriter::ORIENTATION_TOPLEFT;
+    if (meta.contains("orientation")) {
+        m_containerOrientationTag = computeOrientationTag(meta["orientation"], m_containerFlipped, tinydngwriter::ORIENTATION_TOPLEFT);
+    }
+    LogToFile(std::string("[App::loadFileAtIndex] container orientation tag: ") + std::to_string(m_containerOrientationTag));
+    std::cout << "[App::loadFileAtIndex] container orientation tag: " << m_containerOrientationTag << std::endl;
     auto blackLevelVec = meta.value("blackLevel", std::vector<double>{0.0});
     m_staticBlack = blackLevelVec.empty() ? 0.0 : std::accumulate(blackLevelVec.begin(), blackLevelVec.end(), 0.0) / blackLevelVec.size();
     m_staticWhite = meta.value("whiteLevel", 65535.0);

--- a/src/Renderer_VK.cpp
+++ b/src/Renderer_VK.cpp
@@ -712,7 +712,7 @@ void Renderer_VK::updateUniformBuffer(uint32_t currentImageIndex, const ShaderPa
 void Renderer_VK::recordRenderCommands(VkCommandBuffer commandBuffer, uint32_t currentFrameIndex,
     const nlohmann::json& frameMetadata,
     double staticBlack, double staticWhite, int cfaTypeOverride,
-    int windowWidth, int windowHeight) {
+    int windowWidth, int windowHeight, int orientationTag) {
     
     int w = m_currentRawW;
     int h = m_currentRawH;
@@ -783,6 +783,7 @@ void Renderer_VK::recordRenderCommands(VkCommandBuffer commandBuffer, uint32_t c
     }
     ubo.CCM = glm::mat4(ccm3x3_glm);
     ubo.saturationAdjustment = 1.5f; // +50% saturation
+    ubo.orientation = orientationTag;
 
     updateUniformBuffer(currentFrameIndex, ubo);
 
@@ -802,7 +803,12 @@ void Renderer_VK::recordRenderCommands(VkCommandBuffer commandBuffer, uint32_t c
         scissor.extent = { (uint32_t)windowWidth, (uint32_t)windowHeight };
     }
     else {
-        float imgAspect = (m_currentRawH == 0) ? 1.0f : ((float)m_currentRawW / (float)m_currentRawH);
+        bool swapWH = (orientationTag >= 5 && orientationTag <= 8);
+        float imgAspect = 1.0f;
+        if (m_currentRawH != 0) {
+            imgAspect = swapWH ? ((float)m_currentRawH / (float)m_currentRawW)
+                               : ((float)m_currentRawW / (float)m_currentRawH);
+        }
         float winAspect = (windowHeight == 0) ? 1.0f : ((float)windowWidth / (float)windowHeight);
         float vpWidth = (float)windowWidth;
         float vpHeight = (float)windowHeight;


### PR DESCRIPTION
## Summary
- add containerOrientationTag member to track default orientation
- compute orientation tag from numeric or string metadata
- fall back to container orientation when frame orientation is missing
- log orientation tag used for rendering

## Testing
- `cmake -S . -B build` *(fails: FATPREFIX env var not set)*
- `cmake --build build` *(fails: no Makefile generated)*

------
https://chatgpt.com/codex/tasks/task_e_685d0928cc6483278d9a56dbe371d089