### PR TITLE
Register mcraw extension on macOS

### DIFF
--- a/macos/Info.plist
+++ b/macos/Info.plist
@@ -40,5 +40,24 @@
 	<false/>
 	<key>CFBundleDevelopmentRegion</key>
 	<string>en</string>
+    <key>CFBundleDocumentTypes</key>
+    <array>
+        <dict>
+            <key>CFBundleTypeName</key>
+            <string>MotionCam RAW File</string>
+            <key>CFBundleTypeRole</key>
+            <string>Viewer</string>
+            <key>LSItemContentTypes</key>
+            <array>
+                <string>com.motioncam.mcraw</string>
+            </array>
+            <key>LSHandlerRank</key>
+            <string>Owner</string>
+            <key>CFBundleTypeExtensions</key>
+            <array>
+                <string>mcraw</string>
+            </array>
+        </dict>
+    </array>
 </dict>
 </plist>


### PR DESCRIPTION
## Summary
- register `.mcraw` as a supported document type in `macos/Info.plist`

## Testing
- `cmake ..` *(fails: FATPREFIX not set)*

------
https://chatgpt.com/codex/tasks/task_e_685d2829bf648327b6af563ecbf3c726