### PR TITLE
Add UTI for mcraw files

### DIFF
--- a/Info.plist
+++ b/Info.plist
@@ -28,6 +28,26 @@
     <true/>
     <key>NSSupportsAutomaticGraphicsSwitching</key>
     <true/>
+    <key>UTExportedTypeDeclarations</key>
+    <array>
+        <dict>
+            <key>UTTypeIdentifier</key>
+            <string>com.motioncam.mcraw</string>
+            <key>UTTypeDescription</key>
+            <string>MotionCam RAW File</string>
+            <key>UTTypeConformsTo</key>
+            <array>
+                <string>public.data</string>
+            </array>
+            <key>UTTypeTagSpecification</key>
+            <dict>
+                <key>public.filename-extension</key>
+                <string>mcraw</string>
+                <key>public.mime-type</key>
+                <string>application/octet-stream</string>
+            </dict>
+        </dict>
+    </array>
     <!-- For file drag-and-drop -->
     <key>CFBundleDocumentTypes</key>
     <array>

--- a/macos/Info.plist
+++ b/macos/Info.plist
@@ -38,7 +38,46 @@
         <string>MotionCam Player needs access to your Downloads to open .mcraw files.</string>
 	<key>NSSupportsSuddenTermination</key>
 	<false/>
-	<key>CFBundleDevelopmentRegion</key>
-	<string>en</string>
+        <key>CFBundleDevelopmentRegion</key>
+        <string>en</string>
+        <key>UTExportedTypeDeclarations</key>
+        <array>
+            <dict>
+                <key>UTTypeIdentifier</key>
+                <string>com.motioncam.mcraw</string>
+                <key>UTTypeDescription</key>
+                <string>MotionCam RAW File</string>
+                <key>UTTypeConformsTo</key>
+                <array>
+                    <string>public.data</string>
+                </array>
+                <key>UTTypeTagSpecification</key>
+                <dict>
+                    <key>public.filename-extension</key>
+                    <string>mcraw</string>
+                    <key>public.mime-type</key>
+                    <string>application/octet-stream</string>
+                </dict>
+            </dict>
+        </array>
+        <key>CFBundleDocumentTypes</key>
+        <array>
+            <dict>
+                <key>CFBundleTypeName</key>
+                <string>MotionCam RAW File</string>
+                <key>CFBundleTypeRole</key>
+                <string>Viewer</string>
+                <key>LSItemContentTypes</key>
+                <array>
+                    <string>com.motioncam.mcraw</string>
+                </array>
+                <key>CFBundleTypeExtensions</key>
+                <array>
+                    <string>mcraw</string>
+                </array>
+                <key>LSHandlerRank</key>
+                <string>Owner</string>
+            </dict>
+        </array>
 </dict>
 </plist>


### PR DESCRIPTION
## Summary
- declare `com.motioncam.mcraw` UTI in both Info.plist files
- register `.mcraw` file association for the macOS bundle

## Testing
- `cmake -S . -B build` *(fails: FATPREFIX environment variable not set)*

------
https://chatgpt.com/codex/tasks/task_e_685d2d50826c8327a82d4fe41b23a61d