### PR TITLE
Handle macOS file opens after launch

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -49,7 +49,11 @@ function(copy_and_fixup_dylib)
         return()
     endif()
 
-    set(BUNDLE_LIB_DIR "${CMAKE_BINARY_DIR}/${ARG_TARGET_NAME}.app/Contents/Frameworks")
+    get_target_property(_bundle_output_name ${ARG_TARGET_NAME} OUTPUT_NAME)
+    if(NOT _bundle_output_name)
+        set(_bundle_output_name ${ARG_TARGET_NAME})
+    endif()
+    set(BUNDLE_LIB_DIR "${CMAKE_BINARY_DIR}/${_bundle_output_name}.app/Contents/Frameworks")
     set(FINAL_BUNDLE_PATH "${BUNDLE_LIB_DIR}/${ARG_BUNDLE_LINK_NAME}") # File in bundle will have this name
     set(TARGET_EXECUTABLE_PATH "$<TARGET_FILE:${ARG_TARGET_NAME}>")
 
@@ -226,10 +230,13 @@ add_subdirectory(motioncam-decoder           EXCLUDE_FROM_ALL)
 set(APP_SOURCES
   src/main.cpp src/App.cpp src/Renderer_VK.cpp src/GuiOverlay.cpp
   src/PlaybackController.cpp src/AudioController.cpp src/DecoderWrapper.cpp
-  src/Logger.cpp src/DebugLog.cpp
+  src/Logger.cpp src/DebugLog.cpp src/SingleInstance.cpp
   ${EXTERNAL_DIR}/imgui/backends/imgui_impl_glfw.cpp
   ${EXTERNAL_DIR}/imgui/backends/imgui_impl_vulkan.cpp
 )
+if(APPLE)
+  list(APPEND APP_SOURCES src/MacOpenFile.mm)
+endif()
 add_executable(${PROJECT_NAME} MACOSX_BUNDLE ${APP_SOURCES})
 add_dependencies(${PROJECT_NAME} CompileShaders glm motioncam_decoder imgui)
 target_compile_definitions(${PROJECT_NAME} PRIVATE SDL_MAIN_HANDLED)
@@ -237,6 +244,7 @@ target_compile_definitions(${PROJECT_NAME} PRIVATE SDL_MAIN_HANDLED)
 set_target_properties(${PROJECT_NAME} PROPERTIES
     MACOSX_BUNDLE_INFO_PLIST "${PROJECT_SOURCE_DIR}/macos/Info.plist"
     MACOSX_BUNDLE_GUI_IDENTIFIER "com.motioncamapp.mcrawplayer"
+    OUTPUT_NAME "MotionCam Player"
     MACOSX_RPATH TRUE
     BUILD_RPATH "@executable_path/../Frameworks"
     INSTALL_RPATH "@executable_path/../Frameworks"
@@ -302,7 +310,11 @@ else()
     message(WARNING "MoltenVK library (MOLTENVK_LIBRARY_TO_BUNDLE) not found or variable empty.")
 endif()
 
-set(MACOS_BUNDLE_FRAMEWORKS_DIR "${CMAKE_BINARY_DIR}/${PROJECT_NAME}.app/Contents/Frameworks")
+get_target_property(APP_BUNDLE_OUTPUT_NAME ${PROJECT_NAME} OUTPUT_NAME)
+if(NOT APP_BUNDLE_OUTPUT_NAME)
+    set(APP_BUNDLE_OUTPUT_NAME ${PROJECT_NAME})
+endif()
+set(MACOS_BUNDLE_FRAMEWORKS_DIR "${CMAKE_BINARY_DIR}/${APP_BUNDLE_OUTPUT_NAME}.app/Contents/Frameworks")
 add_custom_command(TARGET ${PROJECT_NAME} POST_BUILD
     COMMAND ${CMAKE_COMMAND} -E make_directory "${MACOS_BUNDLE_FRAMEWORKS_DIR}"
     COMMENT "Ensuring Frameworks directory exists")
@@ -313,7 +325,7 @@ target_sources(${PROJECT_NAME} PRIVATE "${PROJECT_SOURCE_DIR}/mcraw_player.icns"
 set_target_properties(${PROJECT_NAME} PROPERTIES MACOSX_BUNDLE_ICON_FILE "mcraw_player.icns")
 
 # --- Resource copy ---
-set(APP_BUNDLE_ROOT_DIR "${CMAKE_BINARY_DIR}/${PROJECT_NAME}.app")
+set(APP_BUNDLE_ROOT_DIR "${CMAKE_BINARY_DIR}/${APP_BUNDLE_OUTPUT_NAME}.app")
 set(APP_BUNDLE_RESOURCES_DIR "${APP_BUNDLE_ROOT_DIR}/Contents/Resources")
 
 add_custom_command(TARGET ${PROJECT_NAME} POST_BUILD

--- a/Info.plist
+++ b/Info.plist
@@ -28,6 +28,26 @@
     <true/>
     <key>NSSupportsAutomaticGraphicsSwitching</key>
     <true/>
+    <key>UTExportedTypeDeclarations</key>
+    <array>
+        <dict>
+            <key>UTTypeIdentifier</key>
+            <string>com.motioncam.mcraw</string>
+            <key>UTTypeDescription</key>
+            <string>MotionCam RAW File</string>
+            <key>UTTypeConformsTo</key>
+            <array>
+                <string>public.data</string>
+            </array>
+            <key>UTTypeTagSpecification</key>
+            <dict>
+                <key>public.filename-extension</key>
+                <string>mcraw</string>
+                <key>public.mime-type</key>
+                <string>application/octet-stream</string>
+            </dict>
+        </dict>
+    </array>
     <!-- For file drag-and-drop -->
     <key>CFBundleDocumentTypes</key>
     <array>
@@ -46,6 +66,8 @@
             <array>
                 <string>mcraw</string>
             </array>
+            <key>CFBundleTypeIconFile</key>
+            <string>mcraw_player.icns</string>
         </dict>
     </array>
 </dict>

--- a/include/MacOpenFile.h
+++ b/include/MacOpenFile.h
@@ -1,0 +1,10 @@
+#ifndef MAC_OPEN_FILE_H
+#define MAC_OPEN_FILE_H
+
+#include <string>
+#include <vector>
+
+std::vector<std::string> GetStartupOpenFiles();
+std::vector<std::string> GetPendingOpenFiles();
+
+#endif // MAC_OPEN_FILE_H

--- a/include/SingleInstance.h
+++ b/include/SingleInstance.h
@@ -1,0 +1,12 @@
+#ifndef SINGLE_INSTANCE_H
+#define SINGLE_INSTANCE_H
+
+struct SingleInstanceGuard {
+    bool acquired;
+    SingleInstanceGuard();
+    ~SingleInstanceGuard();
+    SingleInstanceGuard(const SingleInstanceGuard&) = delete;
+    SingleInstanceGuard& operator=(const SingleInstanceGuard&) = delete;
+};
+
+#endif // SINGLE_INSTANCE_H

--- a/macos/Info.plist
+++ b/macos/Info.plist
@@ -38,7 +38,48 @@
         <string>MotionCam Player needs access to your Downloads to open .mcraw files.</string>
 	<key>NSSupportsSuddenTermination</key>
 	<false/>
-	<key>CFBundleDevelopmentRegion</key>
-	<string>en</string>
+        <key>CFBundleDevelopmentRegion</key>
+        <string>en</string>
+        <key>UTExportedTypeDeclarations</key>
+        <array>
+            <dict>
+                <key>UTTypeIdentifier</key>
+                <string>com.motioncam.mcraw</string>
+                <key>UTTypeDescription</key>
+                <string>MotionCam RAW File</string>
+                <key>UTTypeConformsTo</key>
+                <array>
+                    <string>public.data</string>
+                </array>
+                <key>UTTypeTagSpecification</key>
+                <dict>
+                    <key>public.filename-extension</key>
+                    <string>mcraw</string>
+                    <key>public.mime-type</key>
+                    <string>application/octet-stream</string>
+                </dict>
+            </dict>
+        </array>
+        <key>CFBundleDocumentTypes</key>
+        <array>
+            <dict>
+                <key>CFBundleTypeName</key>
+                <string>MotionCam RAW File</string>
+                <key>CFBundleTypeRole</key>
+                <string>Viewer</string>
+                <key>LSItemContentTypes</key>
+                <array>
+                    <string>com.motioncam.mcraw</string>
+                </array>
+                <key>CFBundleTypeExtensions</key>
+                <array>
+                    <string>mcraw</string>
+                </array>
+                <key>LSHandlerRank</key>
+                <string>Owner</string>
+                <key>CFBundleTypeIconFile</key>
+                <string>mcraw_player.icns</string>
+            </dict>
+        </array>
 </dict>
 </plist>

--- a/src/App.cpp
+++ b/src/App.cpp
@@ -27,6 +27,10 @@
 // GuiOverlay.h is included via App.h
 #include <imgui_impl_vulkan.h> // For ImGui_ImplVulkan_Shutdown
 
+#if defined(__APPLE__)
+#include "MacOpenFile.h"
+#endif
+
 #include <imgui.h>
 #include <nlohmann/json.hpp>
 #include <filesystem>
@@ -481,6 +485,14 @@ bool App::run() {
 
     while (!glfwWindowShouldClose(m_window)) {
         glfwPollEvents();
+
+#if defined(__APPLE__)
+        auto newlyOpened = GetPendingOpenFiles();
+        for (const std::string& p : newlyOpened) {
+            const char* paths[1] = { p.c_str() };
+            handleDrop(1, paths);
+        }
+#endif
 
         bool paused = m_playbackController->isPaused();
         bool segment_looped_or_ended = false;

--- a/src/MacOpenFile.mm
+++ b/src/MacOpenFile.mm
@@ -1,0 +1,73 @@
+#ifdef __APPLE__
+#import <Cocoa/Cocoa.h>
+#include "MacOpenFile.h"
+
+static NSMutableArray<NSString*>* gPendingFiles = nil;
+static id<NSApplicationDelegate> gPrevDelegate = nil;
+
+@interface MCOpenFileDelegate : NSObject <NSApplicationDelegate>
+@end
+
+@implementation MCOpenFileDelegate
+- (void)application:(NSApplication*)sender openFiles:(NSArray<NSString*>*)filenames {
+    if (!gPendingFiles) gPendingFiles = [[NSMutableArray alloc] init];
+    [gPendingFiles addObjectsFromArray:filenames];
+    [sender replyToOpenOrPrint:NSApplicationDelegateReplySuccess];
+}
+- (id)forwardingTargetForSelector:(SEL)aSelector {
+    if (gPrevDelegate && [gPrevDelegate respondsToSelector:aSelector]) {
+        return gPrevDelegate;
+    }
+    return [super forwardingTargetForSelector:aSelector];
+}
+@end
+
+static void InstallDelegate() {
+    NSApplication* app = [NSApplication sharedApplication];
+    id<NSApplicationDelegate> current = [app delegate];
+    if (![current isKindOfClass:[MCOpenFileDelegate class]]) {
+        gPrevDelegate = current;
+        MCOpenFileDelegate* delegate = [[MCOpenFileDelegate alloc] init];
+        [app setDelegate:delegate];
+    }
+}
+
+std::vector<std::string> GetStartupOpenFiles() {
+    std::vector<std::string> result;
+    @autoreleasepool {
+        NSApplication* app = [NSApplication sharedApplication];
+        InstallDelegate();
+        [app finishLaunching];
+        NSDate* end = [NSDate dateWithTimeIntervalSinceNow:2.0];
+        while ([end timeIntervalSinceNow] > 0 && (!gPendingFiles || [gPendingFiles count] == 0)) {
+            NSEvent* event = [app nextEventMatchingMask:NSEventMaskAny
+                                          untilDate:[NSDate dateWithTimeIntervalSinceNow:0.1]
+                                             inMode:NSDefaultRunLoopMode
+                                            dequeue:YES];
+            if (event) [app sendEvent:event];
+        }
+
+        if (gPendingFiles) {
+            for (NSString* name in gPendingFiles) {
+                result.emplace_back([name UTF8String]);
+            }
+            [gPendingFiles removeAllObjects];
+        }
+    }
+    return result;
+}
+
+std::vector<std::string> GetPendingOpenFiles() {
+    std::vector<std::string> result;
+    @autoreleasepool {
+        InstallDelegate();
+        if (gPendingFiles) {
+            for (NSString* name in gPendingFiles) {
+                result.emplace_back([name UTF8String]);
+            }
+            [gPendingFiles removeAllObjects];
+        }
+    }
+    return result;
+}
+#endif

--- a/src/SingleInstance.cpp
+++ b/src/SingleInstance.cpp
@@ -1,0 +1,54 @@
+#include "SingleInstance.h"
+
+#if defined(_WIN32)
+#include <windows.h>
+static HANDLE g_mutex = NULL;
+SingleInstanceGuard::SingleInstanceGuard() {
+    g_mutex = CreateMutexA(NULL, TRUE, "MotionCamPlayerSingletonMutex");
+    if (!g_mutex || GetLastError() == ERROR_ALREADY_EXISTS) {
+        acquired = false;
+        if (g_mutex) {
+            CloseHandle(g_mutex);
+            g_mutex = NULL;
+        }
+    } else {
+        acquired = true;
+    }
+}
+SingleInstanceGuard::~SingleInstanceGuard() {
+    if (g_mutex) {
+        ReleaseMutex(g_mutex);
+        CloseHandle(g_mutex);
+        g_mutex = NULL;
+    }
+}
+
+#elif defined(__APPLE__) || defined(__linux__)
+#include <fcntl.h>
+#include <unistd.h>
+#include <sys/file.h>
+static int g_lock_fd = -1;
+SingleInstanceGuard::SingleInstanceGuard() {
+    const char* lockPath = "/tmp/motioncam_player.lock";
+    g_lock_fd = open(lockPath, O_RDWR | O_CREAT, 0666);
+    if (g_lock_fd == -1) {
+        acquired = false;
+    } else if (flock(g_lock_fd, LOCK_EX | LOCK_NB) == -1) {
+        close(g_lock_fd);
+        g_lock_fd = -1;
+        acquired = false;
+    } else {
+        acquired = true;
+    }
+}
+SingleInstanceGuard::~SingleInstanceGuard() {
+    if (g_lock_fd != -1) {
+        flock(g_lock_fd, LOCK_UN);
+        close(g_lock_fd);
+        g_lock_fd = -1;
+    }
+}
+#else
+SingleInstanceGuard::SingleInstanceGuard() { acquired = true; }
+SingleInstanceGuard::~SingleInstanceGuard() {}
+#endif

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -33,6 +33,10 @@
 // 4. Your Project's Headers
 #include "App.h"
 #include "DebugLog.h"
+#include "SingleInstance.h"
+#if defined(__APPLE__)
+#include "MacOpenFile.h"
+#endif
 
 namespace fs = std::filesystem;
 
@@ -201,6 +205,12 @@ int main(int argc, char* argv[]) {
     fprintf(stderr, "[MAIN_VERY_EARLY] After macOS CWD trick attempt.\n"); fflush(stderr);
 #endif
 
+    SingleInstanceGuard instanceGuard;
+    if (!instanceGuard.acquired) {
+        fprintf(stderr, "[main] Another instance is already running. Exiting.\n");
+        return 0;
+    }
+
 #if defined(_WIN32) && !defined(NDEBUG)
     fprintf(stderr, "[MAIN_VERY_EARLY] Attempting Windows IO redirection.\n"); fflush(stderr);
     RedirectIOToConsole();
@@ -232,13 +242,21 @@ int main(int argc, char* argv[]) {
     if (argc > 0) LogToFile(std::string("[main] argv[0]: ") + argv[0]);
 
     std::string inPath;
-    if (argc == 2) {
+#if defined(__APPLE__)
+    auto openFiles = GetStartupOpenFiles();
+    if (!openFiles.empty()) {
+        inPath = openFiles.front();
+        LogToFile(std::string("[main] File from macOS open event: ") + inPath);
+    }
+#endif
+    if (inPath.empty() && argc >= 2 && strncmp(argv[1], "-psn", 4) != 0) {
         inPath = argv[1];
         LogToFile(std::string("[main] Input file from command line: ") + inPath);
         fprintf(stderr, "[main] Input file from command line: %s\n", inPath.c_str()); fflush(stderr);
-    } else {
-        LogToFile("[main] No command line argument, opening file dialog...");
-        fprintf(stderr, "[main] No command line argument, opening file dialog...\n"); fflush(stderr);
+    }
+    if (inPath.empty()) {
+        LogToFile("[main] No input argument or open event, opening file dialog...");
+        fprintf(stderr, "[main] No input argument or open event, opening file dialog...\n"); fflush(stderr);
         inPath = OpenMcrawDialog();
         if (inPath.empty()) {
             LogToFile("[main] No input file selected or dialog cancelled. Exiting.");


### PR DESCRIPTION
## Summary
- reply to Finder with success when a file-open event occurs on macOS
- expose `GetPendingOpenFiles` for events received while running
- poll for new open-file events inside `App::run`
- install open-file delegate whenever checking for macOS open events so Finder requests work after launch

## Testing
- `cmake -S . -B build` *(fails: FATPREFIX environment variable not set)*

------
https://chatgpt.com/codex/tasks/task_e_685d2d50826c8327a82d4fe41b23a61d