### PR TITLE
Refine playlist UI and quiet logging

### DIFF
--- a/include/App.h
+++ b/include/App.h
@@ -114,6 +114,9 @@ public:
     bool m_firstFileLoaded;
     bool m_isFullscreen;
 
+    std::string m_lastWindowTitle;
+    std::chrono::steady_clock::time_point m_lastTitleUpdate;
+
     void handleKey(int key, int mods);
     void handleDrop(int count, const char** paths);
     void loadFileAtIndex(int index);

--- a/src/App.cpp
+++ b/src/App.cpp
@@ -288,6 +288,8 @@ App::App(const std::string& filePath) : m_filePath(filePath) {
     m_sleepTimeMs = 0.0; m_totalLoopTimeMs = 0.0; m_showUI = true;
     m_isPanning = false; m_lastMouseX = 0.0; m_lastMouseY = 0.0;
     m_firstFileLoaded = false;
+    m_lastWindowTitle = "";
+    m_lastTitleUpdate = std::chrono::steady_clock::now();
 
     LogToFile(std::string("[App::App] Constructor called for file: ") + this->m_filePath);
     std::cout << "[App::App] Constructor called for file: " << this->m_filePath << std::endl;
@@ -558,10 +560,24 @@ bool App::run() {
                 if (m_playbackController && m_decoderWrapper && m_decoderWrapper->getDecoder()) {
                     size_t cur = m_playbackController->getCurrentFrameIndex() + 1;
                     size_t tot = m_decoderWrapper->getDecoder()->getFrames().size();
-                    if (tot > 0) ss << " (" << cur << "/" << tot << ")"; else ss << " (0 frames)";
+                    if (tot > 0) {
+                        size_t width = std::max<size_t>(6, std::to_string(tot).size());
+                        ss << " (" << std::setfill('0') << std::setw(static_cast<int>(width)) << cur
+                           << "/" << std::setfill('0') << std::setw(static_cast<int>(width)) << tot << ")";
+                    } else {
+                        ss << " (0 frames)";
+                    }
                 }
             } else { ss << "(no file)"; }
-            glfwSetWindowTitle(m_window, ss.str().c_str());
+
+            auto newTitle = ss.str();
+            auto now = steady_clock::now();
+            if (newTitle != m_lastWindowTitle &&
+                std::chrono::duration_cast<std::chrono::milliseconds>(now - m_lastTitleUpdate).count() > 200) {
+                glfwSetWindowTitle(m_window, newTitle.c_str());
+                m_lastWindowTitle = std::move(newTitle);
+                m_lastTitleUpdate = now;
+            }
         }
     }
     LogToFile("[App::run] Exited main loop.");
@@ -1302,8 +1318,6 @@ void App::drawFrame() {
         if (frame_meta_for_render.contains("orientation")) {
             orientationTag = computeOrientationTag(frame_meta_for_render["orientation"], m_containerFlipped, m_containerOrientationTag);
         }
-        LogToFile(std::string("[App::drawFrame] orientation tag: ") + std::to_string(orientationTag));
-        std::cout << "[App::drawFrame] orientation tag: " << orientationTag << std::endl;
 
         m_rendererVk->recordRenderCommands(currentCommandBuffer, m_currentFrame,
                                            frame_meta_for_render,
@@ -1569,8 +1583,6 @@ void App::loadFileAtIndex(int index) {
     if (meta.contains("orientation")) {
         m_containerOrientationTag = computeOrientationTag(meta["orientation"], m_containerFlipped, tinydngwriter::ORIENTATION_TOPLEFT);
     }
-    LogToFile(std::string("[App::loadFileAtIndex] container orientation tag: ") + std::to_string(m_containerOrientationTag));
-    std::cout << "[App::loadFileAtIndex] container orientation tag: " << m_containerOrientationTag << std::endl;
     auto blackLevelVec = meta.value("blackLevel", std::vector<double>{0.0});
     m_staticBlack = blackLevelVec.empty() ? 0.0 : std::accumulate(blackLevelVec.begin(), blackLevelVec.end(), 0.0) / blackLevelVec.size();
     m_staticWhite = meta.value("whiteLevel", 65535.0);

--- a/src/GuiOverlay.cpp
+++ b/src/GuiOverlay.cpp
@@ -313,7 +313,7 @@ void GuiOverlay::render(App* appInstance) {
         ImGui::SetNextWindowSize(ImVec2(initial_playlist_width, default_playlist_height), ImGuiCond_Appearing);
         ImGui::SetNextWindowSizeConstraints(ImVec2(initial_playlist_width * 0.5f, 100.0f * io.FontGlobalScale), ImVec2(viewport->WorkSize.x * 0.5f, viewport->WorkSize.y - 2 * style.WindowPadding.y));
         ImGui::PushStyleVar(ImGuiStyleVar_ItemSpacing, ImVec2(4,4)); ImGui::PushStyleVar(ImGuiStyleVar_FramePadding, ImVec2(6,4)); ImGui::PushStyleColor(ImGuiCol_WindowBg, ImVec4(0.07f, 0.08f, 0.09f, 0.95f));
-        if (ImGui::Begin("PLAYLIST_AUX_TOGGLED", &GuiOverlay::show_playlist_aux, ImGuiWindowFlags_NoCollapse | ImGuiWindowFlags_NoSavedSettings )) {
+        if (ImGui::Begin("Playlist", &GuiOverlay::show_playlist_aux, ImGuiWindowFlags_NoCollapse | ImGuiWindowFlags_NoSavedSettings )) {
             current_playlist_window_width = ImGui::GetWindowSize().x; playlist_window_is_visible = true;
             if (appInstance->m_fileList.empty()) ImGui::TextDisabled(" (empty)");
             else { for (int i = 0; i < static_cast<int>(appInstance->m_fileList.size()); ++i) { const std::string& filePath = appInstance->m_fileList[i]; std::string filename_to_display = fs::path(filePath).stem().string(); bool is_selected = (appInstance->m_currentFileIndex == i); char entry_buf[512]; snprintf(entry_buf, sizeof(entry_buf), "%2d. %s ", i+1, filename_to_display.c_str()); if (is_selected) ImGui::PushStyleColor(ImGuiCol_Header, style.Colors[ImGuiCol_HeaderActive]); if (ImGui::Selectable(entry_buf, is_selected, ImGuiSelectableFlags_SpanAllColumns)) { if (!is_selected) { appInstance->m_firstFileLoaded = false; appInstance->loadFileAtIndex(i); appInstance->m_firstFileLoaded = true; } } if (is_selected) ImGui::PopStyleColor(); } }
@@ -327,10 +327,30 @@ void GuiOverlay::render(App* appInstance) {
 
         bool help_open_flag = ui.showHelpPage;
         if (ImGui::Begin("Help - Keyboard Shortcuts", &help_open_flag, ImGuiWindowFlags_NoCollapse | ImGuiWindowFlags_NoSavedSettings)) {
-            ImGui::Text("Playback Controls:"); ImGui::BulletText("[Space]        : Play / Pause"); ImGui::BulletText("[Left Arrow]   : Previous Frame (Step Back)"); ImGui::BulletText("[Right Arrow]  : Next Frame (Step Forward)"); ImGui::BulletText("[Home]         : Go to First Frame"); ImGui::BulletText("[End]          : Go to Last Frame");
-            ImGui::Separator(); ImGui::Text("File Navigation:"); ImGui::BulletText("[[ (L-Bracket)]: Previous File in Playlist"); ImGui::BulletText("[] (R-Bracket)]: Next File in Playlist"); ImGui::BulletText("[Ctrl + O]     : Open File Dialog");
-            ImGui::Separator(); ImGui::Text("Display & UI:"); ImGui::BulletText("[F] or [F11]   : Toggle Fullscreen"); ImGui::BulletText("[Z]            : Toggle Zoom (Native Pixels / Fit to Window)"); ImGui::BulletText("[M]            : Toggle Metrics Overlay"); ImGui::BulletText("[H] or [F1]    : Toggle This Help Page"); ImGui::BulletText("[Tab]          : Toggle Main UI Controls"); ImGui::BulletText("[Esc]          : Exit Fullscreen / Close Popups / Quit");
-            ImGui::Separator(); ImGui::Text("Application:"); ImGui::BulletText("[Ctrl + Q]     : Quit Application");
+            ImGui::Text("Playback Controls:");
+            ImGui::BulletText("[Space]        : Play / Pause");
+            ImGui::BulletText("[Left Arrow]   : Previous Frame (Step Back)");
+            ImGui::BulletText("[Right Arrow]  : Next Frame (Step Forward)");
+            ImGui::BulletText("[Home]         : Go to First Frame");
+            ImGui::BulletText("[End]          : Go to Last Frame");
+            ImGui::Separator();
+            ImGui::Text("File Navigation:");
+            ImGui::BulletText("[[ (L-Bracket)]: Previous File in Playlist");
+            ImGui::BulletText("] (R-Bracket)]: Next File in Playlist");
+            ImGui::BulletText("[⌘O]           : Open File Dialog");
+            ImGui::BulletText("[Delete] or [Backspace] : Delete Current File");
+            ImGui::Separator();
+            ImGui::Text("Display & UI:");
+            ImGui::BulletText("[F] or [F11]   : Toggle Fullscreen");
+            ImGui::BulletText("[Z]            : Toggle Zoom (Native Pixels / Fit to Window)");
+            ImGui::BulletText("[M]            : Toggle Metrics Overlay");
+            ImGui::BulletText("[H] or [F1]    : Toggle This Help Page");
+            ImGui::BulletText("[Tab]          : Toggle Main UI Controls");
+            ImGui::BulletText("[Esc]          : Exit Fullscreen / Close Popups / Quit");
+            ImGui::Separator();
+            ImGui::Text("Application:");
+            ImGui::BulletText("[⌘Q]           : Quit Application");
+            ImGui::BulletText("[0-4]          : Set CFA Override (0 to reset)");
         }
         ImGui::End();
         if (!help_open_flag && ui.showHelpPage) { appInstance->toggleHelpPage(); }


### PR DESCRIPTION
## Summary
- rename playlist window to "Playlist"
- update help menu shortcuts for macOS style
- keep window title stable with throttled updates and six-digit frame formatting
- remove verbose orientation tag logs

## Testing
- `cmake ..` *(fails: FATPREFIX not set)*

------
https://chatgpt.com/codex/tasks/task_e_685d721e6184832798395332cae42698