### PR TITLE
Add Quick Look preview extension

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,7 +4,10 @@ project(MotionCam_Player VERSION 0.5 LANGUAGES C CXX)
 
 # --- Universal macOS binary (Apple Silicon + Intel) ---
 set(CMAKE_OSX_ARCHITECTURES "x86_64;arm64" CACHE STRING "" FORCE)
-set(CMAKE_OSX_DEPLOYMENT_TARGET "10.15" CACHE STRING "" FORCE)
+# Quick Look preview extensions require macOS 11 or newer for
+# the QLPreviewProvider API. Bump the minimum macOS version so
+# the headers are available when building the extension.
+set(CMAKE_OSX_DEPLOYMENT_TARGET "11.0" CACHE STRING "" FORCE)
 
 # --- Use custom-built universal dependencies from FATPREFIX ---
 if(DEFINED ENV{FATPREFIX})
@@ -426,3 +429,7 @@ message(STATUS "RPATH for executable ${PROJECT_NAME} should include @executable_
 message(STATUS "MoltenVK_icd.json will be copied and patched for bundle.")
 message(STATUS "Bundled dylibs will be named to match linker expectations (e.g., libvulkan.1.dylib).")
 message(STATUS "---------------------------------------------------------------------")
+
+if(APPLE)
+  add_subdirectory(quicklook)
+endif()

--- a/quicklook/CMakeLists.txt
+++ b/quicklook/CMakeLists.txt
@@ -1,0 +1,31 @@
+set(QL_PREVIEW_TARGET MotionCamQLPreview)
+
+set(QL_PREVIEW_SOURCES
+    PreviewProvider.mm
+)
+
+add_library(${QL_PREVIEW_TARGET} MODULE ${QL_PREVIEW_SOURCES})
+set_target_properties(${QL_PREVIEW_TARGET} PROPERTIES
+    BUNDLE TRUE
+    BUNDLE_EXTENSION "appex"
+    XCODE_ATTRIBUTE_WRAPPER_EXTENSION "appex"
+    MACOSX_BUNDLE_INFO_PLIST "${CMAKE_CURRENT_SOURCE_DIR}/Info.plist"
+    FRAMEWORK FALSE
+)
+
+target_include_directories(${QL_PREVIEW_TARGET} PRIVATE
+    ${PROJECT_SOURCE_DIR}/motioncam-decoder/lib/include
+    ${PROJECT_SOURCE_DIR}/motioncam-decoder/thirdparty
+)
+
+target_link_libraries(${QL_PREVIEW_TARGET} PRIVATE
+    motioncam_decoder
+    "-framework AppKit" "-framework QuickLook" "-framework QuickLookThumbnailing"
+)
+
+set(APP_BUNDLE_ROOT_DIR "${CMAKE_BINARY_DIR}/${APP_BUNDLE_OUTPUT_NAME}.app")
+add_custom_command(TARGET ${QL_PREVIEW_TARGET} POST_BUILD
+    COMMAND ${CMAKE_COMMAND} -E make_directory "${APP_BUNDLE_ROOT_DIR}/Contents/Library/QuickLook"
+    COMMAND ${CMAKE_COMMAND} -E copy_directory "$<TARGET_BUNDLE_DIR:${QL_PREVIEW_TARGET}>" "${APP_BUNDLE_ROOT_DIR}/Contents/Library/QuickLook/${QL_PREVIEW_TARGET}.appex"
+    COMMENT "Embedding Quick Look preview extension" VERBATIM
+)

--- a/quicklook/Info.plist
+++ b/quicklook/Info.plist
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>CFBundleDevelopmentRegion</key>
+    <string>en</string>
+    <key>CFBundleIdentifier</key>
+    <string>com.motioncam.mcraw.preview</string>
+    <key>CFBundleName</key>
+    <string>MotionCamPreview</string>
+    <key>CFBundlePackageType</key>
+    <string>BNDL</string>
+    <key>CFBundleShortVersionString</key>
+    <string>1.0</string>
+    <key>CFBundleVersion</key>
+    <string>1</string>
+    <key>QLPreviewSupportedContentTypes</key>
+    <array>
+        <string>com.motioncam.mcraw</string>
+    </array>
+    <key>NSExtension</key>
+    <dict>
+        <key>NSExtensionPrincipalClass</key>
+        <string>MCPreviewProvider</string>
+        <key>NSExtensionPointIdentifier</key>
+        <string>com.apple.quicklook.preview</string>
+    </dict>
+</dict>
+</plist>

--- a/quicklook/PreviewProvider.mm
+++ b/quicklook/PreviewProvider.mm
@@ -1,0 +1,49 @@
+#import <QuickLook/QuickLook.h>
+#import <QuickLook/QLPreviewProvider.h>
+#import <QuickLook/QLPreviewReply.h>
+#import <AppKit/AppKit.h>
+#import <Foundation/Foundation.h>
+
+#include <motioncam/Decoder.hpp>
+#include <nlohmann/json.hpp>
+
+@interface MCPreviewProvider : QLPreviewProvider
+@end
+
+@implementation MCPreviewProvider
+
+- (void)providePreviewForFileAtURL:(NSURL *)url completionHandler:(void (^)(QLPreviewReply *, NSError *))handler {
+    @autoreleasepool {
+        try {
+            motioncam::Decoder decoder([[url path] UTF8String]);
+            const auto& frames = decoder.getFrames();
+            if(frames.empty()) {
+                NSError *err = [NSError errorWithDomain:@"MCPreview" code:1 userInfo:@{NSLocalizedDescriptionKey:@"No frames"}];
+                handler(nil, err);
+                return;
+            }
+            std::vector<uint16_t> data;
+            nlohmann::json metadata;
+            decoder.loadFrame(frames[0], data, metadata);
+            unsigned width = metadata["width"];
+            unsigned height = metadata["height"];
+
+            size_t bitsPerComponent = 16;
+            size_t bytesPerRow = width * sizeof(uint16_t);
+            CGColorSpaceRef colorSpace = CGColorSpaceCreateWithName(kCGColorSpaceGenericGrayGamma2_2);
+            CGContextRef context = CGBitmapContextCreate(data.data(), width, height, bitsPerComponent, bytesPerRow, colorSpace, kCGImageAlphaNone);
+            CGColorSpaceRelease(colorSpace);
+            CGImageRef cgImage = CGBitmapContextCreateImage(context);
+            CGContextRelease(context);
+            QLPreviewReply *reply = [QLPreviewReply replyWithImage:cgImage properties:@{}];
+            CGImageRelease(cgImage);
+            handler(reply, nil);
+        } catch (const std::exception& e) {
+            NSString *desc = [NSString stringWithUTF8String:e.what()];
+            NSError *error = [NSError errorWithDomain:@"MCPreview" code:1 userInfo:@{NSLocalizedDescriptionKey:desc}];
+            handler(nil, error);
+        }
+    }
+}
+
+@end


### PR DESCRIPTION
## Summary
- add a macOS Quick Look preview extension to show `.mcraw` files
- include Objective‑C++ provider that decodes the first frame
- embed the extension bundle in the main application
- ensure provider includes Quick Look headers
- bump macOS deployment target to 11.0 for Quick Look APIs

## Testing
- `cmake -B build -S .` *(fails: FATPREFIX env variable not set)*


------
https://chatgpt.com/codex/tasks/task_e_685e260dc1a88327980d940addfd34a9