### PR TITLE
Refine Quick Look build settings

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,7 +4,10 @@ project(MotionCam_Player VERSION 0.5 LANGUAGES C CXX)
 
 # --- Universal macOS binary (Apple Silicon + Intel) ---
 set(CMAKE_OSX_ARCHITECTURES "x86_64;arm64" CACHE STRING "" FORCE)
-set(CMAKE_OSX_DEPLOYMENT_TARGET "10.15" CACHE STRING "" FORCE)
+# Quick Look preview extensions require macOS 11 or newer for
+# the QLPreviewProvider API. Bump the minimum macOS version so
+# the headers are available when building the extension.
+set(CMAKE_OSX_DEPLOYMENT_TARGET "12.0" CACHE STRING "" FORCE)
 
 # --- Use custom-built universal dependencies from FATPREFIX ---
 if(DEFINED ENV{FATPREFIX})
@@ -26,6 +29,8 @@ message(STATUS "CMAKE_PREFIX_PATH set to: ${CMAKE_PREFIX_PATH}")
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS OFF)
+set(CMAKE_OBJCXX_STANDARD 17)
+set(CMAKE_OBJCXX_STANDARD_REQUIRED ON)
 
 set(CMAKE_MACOSX_RPATH TRUE)
 set(CMAKE_XCODE_ATTRIBUTE_CODE_SIGN_IDENTITY "")
@@ -426,3 +431,7 @@ message(STATUS "RPATH for executable ${PROJECT_NAME} should include @executable_
 message(STATUS "MoltenVK_icd.json will be copied and patched for bundle.")
 message(STATUS "Bundled dylibs will be named to match linker expectations (e.g., libvulkan.1.dylib).")
 message(STATUS "---------------------------------------------------------------------")
+
+if(APPLE)
+  add_subdirectory(quicklook)
+endif()

--- a/motioncam-decoder/lib/include/motioncam/Decoder.hpp
+++ b/motioncam-decoder/lib/include/motioncam/Decoder.hpp
@@ -40,6 +40,7 @@ namespace motioncam {
 
     class AudioChunkLoader {
         public:
+            virtual ~AudioChunkLoader() = default;
             virtual bool next(AudioChunk& output) = 0;
     };
     

--- a/quicklook/CMakeLists.txt
+++ b/quicklook/CMakeLists.txt
@@ -1,0 +1,32 @@
+set(QL_PREVIEW_TARGET MotionCamQLPreview)
+
+set(QL_PREVIEW_SOURCES
+    PreviewProvider.mm
+)
+
+add_library(${QL_PREVIEW_TARGET} MODULE ${QL_PREVIEW_SOURCES})
+set_target_properties(${QL_PREVIEW_TARGET} PROPERTIES
+    BUNDLE TRUE
+    BUNDLE_EXTENSION "appex"
+    XCODE_ATTRIBUTE_WRAPPER_EXTENSION "appex"
+    MACOSX_BUNDLE_INFO_PLIST "${CMAKE_CURRENT_SOURCE_DIR}/Info.plist"
+    FRAMEWORK FALSE
+)
+target_compile_options(${QL_PREVIEW_TARGET} PRIVATE -fobjc-arc)
+
+target_include_directories(${QL_PREVIEW_TARGET} PRIVATE
+    ${PROJECT_SOURCE_DIR}/motioncam-decoder/lib/include
+    ${PROJECT_SOURCE_DIR}/motioncam-decoder/thirdparty
+)
+
+target_link_libraries(${QL_PREVIEW_TARGET} PRIVATE
+    motioncam_decoder
+    "-framework AppKit" "-framework QuickLook" "-framework QuickLookThumbnailing" "-framework QuickLookUI" "-framework ImageIO" "-framework UniformTypeIdentifiers"
+)
+
+set(APP_BUNDLE_ROOT_DIR "${CMAKE_BINARY_DIR}/${APP_BUNDLE_OUTPUT_NAME}.app")
+add_custom_command(TARGET ${QL_PREVIEW_TARGET} POST_BUILD
+    COMMAND ${CMAKE_COMMAND} -E make_directory "${APP_BUNDLE_ROOT_DIR}/Contents/Library/QuickLook"
+    COMMAND ${CMAKE_COMMAND} -E copy_directory "$<TARGET_BUNDLE_DIR:${QL_PREVIEW_TARGET}>" "${APP_BUNDLE_ROOT_DIR}/Contents/Library/QuickLook/${QL_PREVIEW_TARGET}.appex"
+    COMMENT "Embedding Quick Look preview extension" VERBATIM
+)

--- a/quicklook/Info.plist
+++ b/quicklook/Info.plist
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>CFBundleDevelopmentRegion</key>
+    <string>en</string>
+    <key>CFBundleIdentifier</key>
+    <string>com.motioncam.mcraw.preview</string>
+    <key>CFBundleName</key>
+    <string>MotionCamPreview</string>
+    <key>CFBundlePackageType</key>
+    <string>XPC!</string>
+    <key>CFBundleShortVersionString</key>
+    <string>1.0</string>
+    <key>CFBundleVersion</key>
+    <string>1</string>
+    <key>QLPreviewSupportedContentTypes</key>
+    <array>
+        <string>com.motioncam.mcraw</string>
+    </array>
+    <key>NSExtension</key>
+    <dict>
+        <key>NSExtensionPrincipalClass</key>
+        <string>MCPreviewProvider</string>
+        <key>NSExtensionPointIdentifier</key>
+        <string>com.apple.quicklook.preview</string>
+    </dict>
+</dict>
+</plist>

--- a/quicklook/PreviewProvider.mm
+++ b/quicklook/PreviewProvider.mm
@@ -1,0 +1,86 @@
+#import <AppKit/AppKit.h>
+@import QuickLookUI;
+@import QuickLook;
+@import ImageIO;
+@import UniformTypeIdentifiers;
+
+#include <motioncam/Decoder.hpp>
+#include <nlohmann/json.hpp>
+
+API_AVAILABLE(macos(12.0))
+@interface MCPreviewProvider : QLPreviewProvider
+@end
+
+@implementation MCPreviewProvider
+
+- (void)providePreviewForFileAtURL:(NSURL *)url completionHandler:(void (^)(QLPreviewReply *, NSError *))handler API_AVAILABLE(macos(12.0)) {
+    @autoreleasepool {
+        try {
+            motioncam::Decoder decoder([[url path] UTF8String]);
+            const auto& frames = decoder.getFrames();
+            if(frames.empty()) {
+                NSError *err = [NSError errorWithDomain:@"MCPreview" code:1 userInfo:@{NSLocalizedDescriptionKey:@"No frames"}];
+                handler(nil, err);
+                return;
+            }
+            size_t startIndex = frames.size() > 24 ? 23 : 0;
+            const size_t maxFrames = std::min<size_t>(30, frames.size() - startIndex);
+            std::vector<std::vector<uint8_t>> framePixels;
+            framePixels.resize(maxFrames);
+            size_t width = 0;
+            size_t height = 0;
+            for(size_t i = 0; i < maxFrames; ++i) {
+                std::vector<uint16_t> frame16;
+                nlohmann::json meta;
+                decoder.loadFrame(frames[startIndex + i], frame16, meta);
+                if(i == 0) {
+                    width = meta["width"];
+                    height = meta["height"];
+                }
+                framePixels[i].resize(width * height * 4);
+                for(size_t p = 0; p < width * height; ++p) {
+                    uint8_t v = static_cast<uint8_t>(frame16[p] >> 8);
+                    framePixels[i][4*p + 0] = v;
+                    framePixels[i][4*p + 1] = v;
+                    framePixels[i][4*p + 2] = v;
+                    framePixels[i][4*p + 3] = 0xFF;
+                }
+            }
+
+            NSString *tmpPath = [NSTemporaryDirectory() stringByAppendingPathComponent:[[NSUUID UUID] UUIDString]];
+            tmpPath = [tmpPath stringByAppendingPathExtension:@"gif"];
+            NSURL *tmpURL = [NSURL fileURLWithPath:tmpPath];
+            CGImageDestinationRef dest = CGImageDestinationCreateWithURL((__bridge CFURLRef)tmpURL, kUTTypeGIF, maxFrames, NULL);
+
+            NSDictionary *frameProps = @{(__bridge NSString*)kCGImagePropertyGIFDictionary: @{(__bridge NSString*)kCGImagePropertyGIFDelayTime: @(0.033)}};
+            size_t bitsPerComponent = 8;
+            size_t bytesPerRow = width * 4;
+            CGColorSpaceRef colorSpace = CGColorSpaceCreateWithName(kCGColorSpaceSRGB);
+            for(size_t i = 0; i < maxFrames; ++i) {
+                CGContextRef context = CGBitmapContextCreate(framePixels[i].data(), width, height, bitsPerComponent, bytesPerRow, colorSpace, kCGImageAlphaPremultipliedLast | kCGBitmapByteOrder32Little);
+                CGImageRef image = CGBitmapContextCreateImage(context);
+                CGContextRelease(context);
+                CGImageDestinationAddImage(dest, image, (__bridge CFDictionaryRef)frameProps);
+                CGImageRelease(image);
+            }
+            CGImageDestinationSetProperties(dest, (__bridge CFDictionaryRef)@{(__bridge NSString*)kCGImagePropertyGIFDictionary: @{(__bridge NSString*)kCGImagePropertyGIFLoopCount: @0}});
+            CGImageDestinationFinalize(dest);
+            CFRelease(dest);
+            CGColorSpaceRelease(colorSpace);
+
+            if (@available(macOS 12.0, *)) {
+                QLPreviewReply *reply = [QLPreviewReply replyWithFileURL:tmpURL contentType:UTTypeGIF.identifier properties:@{}];
+                handler(reply, nil);
+            } else {
+                NSError *err = [NSError errorWithDomain:@"MCPreview" code:2 userInfo:@{NSLocalizedDescriptionKey:@"Requires macOS 12"}];
+                handler(nil, err);
+            }
+        } catch (const std::exception& e) {
+            NSString *desc = [NSString stringWithUTF8String:e.what()];
+            NSError *error = [NSError errorWithDomain:@"MCPreview" code:1 userInfo:@{NSLocalizedDescriptionKey:desc}];
+            handler(nil, error);
+        }
+    }
+}
+
+@end


### PR DESCRIPTION
## Summary
- set Objective‑C++ standard to C++17
- enable ARC and module import for Quick Look preview code
- copy Quick Look extension using post-build command

## Testing
- `cmake -B build -S .` *(fails: FATPREFIX environment variable not set)*
- `cmake --build build -j $(nproc)` *(fails: Makefile not found)*

------
https://chatgpt.com/codex/tasks/task_e_685e260dc1a88327980d940addfd34a9