### PR TITLE
Enable orientation-aware playback

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -147,6 +147,7 @@ set(APP_SOURCES
   src/Playback/PlaybackController.cpp
 
   src/Utils/DebugLog.cpp
+  src/Utils/OrientationUtils.cpp
 
   src/main.cpp
 )

--- a/include/App/App.h
+++ b/include/App/App.h
@@ -31,6 +31,7 @@
 #include "App/AppConfig.h"
 #include "App/AppState.h"
 #include "Playback/PlaybackController.h" // Included for PlaybackController::PlaybackMode
+#include "Utils/OrientationUtils.h"
 
 class AudioController;
 class DecoderWrapper;
@@ -188,6 +189,8 @@ private:
     double m_staticBlack = 0.0;
     double m_staticWhite = 65535.0;
     bool m_dumpMetadata = false;
+    OrientationTag m_containerOrientationTag = OrientationTag::kNormal;
+    bool m_containerFlipped = false;
 
     std::chrono::steady_clock::time_point m_playbackStartTime;
     std::chrono::steady_clock::time_point m_pauseBegan;

--- a/include/Graphics/Renderer_VK.h
+++ b/include/Graphics/Renderer_VK.h
@@ -21,6 +21,7 @@
 #include "Graphics/ImageResource.h" // ADD THIS LINE
 #include "Graphics/Pipeline.h"      // ADD THIS LINE
 #include "Graphics/Descriptor.h"    // ADD THIS LINE
+#include "Utils/OrientationUtils.h"
 // For VK_CHECK_RENDERER, if used, and helper function declarations
 // Other headers like ImageResource.h, Pipeline.h, Descriptor.h are not directly included here
 // as their functions are called from Renderer_VK.cpp via namespaces.
@@ -49,7 +50,9 @@ public:
         int frameWidth, int frameHeight,
         const nlohmann::json& frameMetadata,
         double staticBlack, double staticWhite, int cfaTypeOverride,
-        bool forceUpload
+        bool forceUpload,
+        OrientationTag defaultOrientation,
+        bool containerFlipped
     );
 
     void recordDrawCommands(
@@ -109,11 +112,13 @@ private:
         alignas(4) float gainB;
         alignas(16) glm::mat4 CCM;
         alignas(4) float saturationAdjustment;
+        alignas(4) int orientationDegrees;
     };
 
     // Internal state not directly manipulated by namespaced helpers
     int m_currentRawW = 0;
     int m_currentRawH = 0;
+    int m_currentOrientationDegrees = 0;
     bool m_zoomNativePixels = false;
     float m_panX = 0.0f;
     float m_panY = 0.0f;

--- a/include/Utils/OrientationUtils.h
+++ b/include/Utils/OrientationUtils.h
@@ -1,0 +1,24 @@
+#ifndef ORIENTATION_UTILS_H
+#define ORIENTATION_UTILS_H
+
+#include <nlohmann/json.hpp>
+
+enum class OrientationTag {
+    kUnknown = 0,
+    kNormal = 1,
+    kMirror = 2,
+    kRotate180 = 3,
+    kMirror180 = 4,
+    kMirror90CW = 5,
+    kRotate90CW = 6,
+    kMirror90CCW = 7,
+    kRotate90CCW = 8
+};
+
+OrientationTag computeOrientationTag(const nlohmann::json& orientationValue,
+                                     bool isFlipped,
+                                     OrientationTag defaultTag = OrientationTag::kNormal);
+
+int orientationDegreesFromTag(OrientationTag tag);
+
+#endif // ORIENTATION_UTILS_H

--- a/shaders/fullscreen_quad.vert
+++ b/shaders/fullscreen_quad.vert
@@ -3,6 +3,13 @@
 
 layout(location = 0) out vec2 outTexCoord;
 
+layout(binding = 1) uniform ShaderParams {
+    int W; int H; int cfaType; float exposure;
+    float blackLevel; float whiteLevel; float invBlackWhiteRange;
+    float gainR; float gainG; float gainB;
+    mat4 CCM; float saturationAdjustment; int orientationDegrees;
+} params;
+
 // Fullscreen quad/triangle vertices. No actual vertex buffer needed.
 // Two triangles covering the screen.
 vec2 positions[6] = vec2[](
@@ -26,6 +33,14 @@ vec2 texCoords[6] = vec2[](
 
 void main() {
     gl_Position = vec4(positions[gl_VertexIndex], 0.0, 1.0);
-    outTexCoord = texCoords[gl_VertexIndex];
+    vec2 tc = texCoords[gl_VertexIndex];
+    if (params.orientationDegrees == 90) {
+        tc = vec2(tc.y, 1.0 - tc.x);
+    } else if (params.orientationDegrees == 180) {
+        tc = vec2(1.0 - tc.x, 1.0 - tc.y);
+    } else if (params.orientationDegrees == 270) {
+        tc = vec2(1.0 - tc.y, tc.x);
+    }
+    outTexCoord = tc;
 }
 // --- END OF FILE shaders/fullscreen_quad.vert ---

--- a/shaders/image_process.frag
+++ b/shaders/image_process.frag
@@ -20,6 +20,7 @@ layout(binding = 1) uniform ShaderParams {
     mat4 CCM; // Pass as mat4, use top-left 3x3
     // --- ADD SATURATION UNIFORM ---
     float saturationAdjustment; // e.g., 1.0 for no change, 1.25 for +25%
+    int orientationDegrees;
 } params;
 
 // sRGB EOTF (gamma correction)

--- a/src/App/AppIO.cpp
+++ b/src/App/AppIO.cpp
@@ -6,6 +6,7 @@
 #include "Graphics/Renderer_VK.h"
 #include "Utils/DebugLog.h"
 #include "Utils/RawFrameBuffer.h"
+#include "Utils/OrientationUtils.h"
 #include <motioncam/Decoder.hpp>
 #include <motioncam/RawData.hpp>
 
@@ -429,6 +430,14 @@ void App::loadFileAtIndex(int index) {
     m_staticWhite = containerMetaForFile.value("whiteLevel", 65535.0);
     m_cfaStringFromMetadata = containerMetaForFile.value("sensorArrangment", containerMetaForFile.value("sensorArrangement", "BGGR"));
     m_cfaTypeFromMetadata = Renderer_VK::getCfaType(m_cfaStringFromMetadata);
+    m_containerFlipped = containerMetaForFile.value("flipped", false);
+    m_containerOrientationTag = computeOrientationTag(
+        containerMetaForFile.value("orientation", nlohmann::json()),
+        m_containerFlipped,
+        OrientationTag::kNormal);
+    LogToFile(std::string("[App::loadFileAtIndex] Container orientation deg: ") +
+        std::to_string(orientationDegreesFromTag(m_containerOrientationTag)) +
+        ", flipped: " + (m_containerFlipped ? "true" : "false"));
     LogToFile(std::string("[App::loadFileAtIndex] Metadata parsed: Black=") + std::to_string(m_staticBlack) + ", White=" + std::to_string(m_staticWhite) + ", CFA=" + m_cfaStringFromMetadata + " (type " + std::to_string(m_cfaTypeFromMetadata) + ")");
 
     if (!m_firstFileLoaded && !m_isFullscreen && m_window) {

--- a/src/App/AppLoop.cpp
+++ b/src/App/AppLoop.cpp
@@ -389,7 +389,9 @@ void App::drawFrame() {
                 stagingBufferToUseForUpload,
                 packetToRender.width, packetToRender.height, packetToRender.metadata,
                 m_staticBlack, m_staticWhite, m_cfaOverride.value_or(m_cfaTypeFromMetadata),
-                needsFreshUploadFromStaging
+                needsFreshUploadFromStaging,
+                m_containerOrientationTag,
+                m_containerFlipped
             );
             clearColorValue.color = { {0.0f, 0.0f, 0.0f, 1.0f} };
         }

--- a/src/Graphics/Descriptor.cpp
+++ b/src/Graphics/Descriptor.cpp
@@ -68,7 +68,7 @@ namespace Descriptor {
             alignas(4) int W; alignas(4) int H; alignas(4) int cfaType; alignas(4) float exposure;
             alignas(4) float blackLevel; alignas(4) float whiteLevel; alignas(4) float invBlackWhiteRange;
             alignas(4) float gainR; alignas(4) float gainG; alignas(4) float gainB;
-            alignas(16) glm::mat4 CCM; alignas(4) float saturationAdjustment;
+            alignas(16) glm::mat4 CCM; alignas(4) float saturationAdjustment; alignas(4) int orientationDegrees;
         };
         VkDeviceSize bufferSize = sizeof(TempShaderParamsUBO);
 
@@ -214,7 +214,7 @@ namespace Descriptor {
             alignas(4) int W; alignas(4) int H; alignas(4) int cfaType; alignas(4) float exposure;
             alignas(4) float blackLevel; alignas(4) float whiteLevel; alignas(4) float invBlackWhiteRange;
             alignas(4) float gainR; alignas(4) float gainG; alignas(4) float gainB;
-            alignas(16) glm::mat4 CCM; alignas(4) float saturationAdjustment;
+            alignas(16) glm::mat4 CCM; alignas(4) float saturationAdjustment; alignas(4) int orientationDegrees;
         };
 
         for (size_t i = 0; i < renderer->m_descriptorSets.size(); ++i) {

--- a/src/Graphics/Renderer_VK.cpp
+++ b/src/Graphics/Renderer_VK.cpp
@@ -8,6 +8,7 @@
 #include "Graphics/VulkanHelpers.h"
 #include "Utils/DebugLog.h"
 #include "Utils/RawFrameBuffer.h"
+#include "Utils/OrientationUtils.h"
 
 #include <nlohmann/json.hpp>
 #include <stdexcept>
@@ -104,7 +105,9 @@ void Renderer_VK::prepareAndUploadFrameData(
     int frameWidth, int frameHeight,
     const nlohmann::json& frameMetadata,
     double staticBlack, double staticWhite, int cfaTypeOverride,
-    bool forceUpload
+    bool forceUpload,
+    OrientationTag defaultOrientation,
+    bool containerFlipped
 ) {
     if (frameWidth <= 0 || frameHeight <= 0) {
         LogToFile(std::string("[Renderer_VK::prepareAndUploadFrameData] Invalid dimensions ") + std::to_string(frameWidth) + "x" + std::to_string(frameHeight) + ". Skipping upload.");
@@ -246,6 +249,13 @@ void Renderer_VK::prepareAndUploadFrameData(
     }
     ubo.CCM = glm::mat4(ccm3x3_glm);
     ubo.saturationAdjustment = 1.50f;
+    OrientationTag tag = computeOrientationTag(
+        frameMetadata.contains("orientation") ? frameMetadata.at("orientation") : nlohmann::json(),
+        frameMetadata.value("flipped", containerFlipped),
+        defaultOrientation);
+    ubo.orientationDegrees = orientationDegreesFromTag(tag);
+    m_currentOrientationDegrees = ubo.orientationDegrees;
+    LogToFile(std::string("[Renderer_VK::prepareAndUploadFrameData] Orientation degrees: ") + std::to_string(ubo.orientationDegrees));
 
     updateUniformBuffer(uboBindingIndex, ubo);
 }
@@ -269,12 +279,18 @@ void Renderer_VK::recordDrawCommands(
     }
     else if (m_zoomNativePixels) {
         viewport.x = m_panX; viewport.y = m_panY;
-        viewport.width = (float)m_currentRawW; viewport.height = (float)m_currentRawH;
+        float w = (float)m_currentRawW;
+        float h = (float)m_currentRawH;
+        if (m_currentOrientationDegrees == 90 || m_currentOrientationDegrees == 270) {
+            std::swap(w, h);
+        }
+        viewport.width = w; viewport.height = h;
         viewport.minDepth = 0.0f; viewport.maxDepth = 1.0f;
         scissor.offset = { 0, 0 }; scissor.extent = { (uint32_t)windowWidth, (uint32_t)windowHeight };
     }
     else {
-        float imgAspect = (float)m_currentRawW / (float)m_currentRawH;
+        float imgAspect = (m_currentOrientationDegrees == 90 || m_currentOrientationDegrees == 270) ?
+            (float)m_currentRawH / (float)m_currentRawW : (float)m_currentRawW / (float)m_currentRawH;
         float winAspect = (float)windowWidth / (float)windowHeight;
         float vpWidth, vpHeight, vpX, vpY;
         if (imgAspect > winAspect) {
@@ -328,6 +344,7 @@ void Renderer_VK::resetDimensions() {
     LogToFile("[Renderer_VK::resetDimensions] Resetting current raw dimensions to 0x0.");
     m_currentRawW = 0;
     m_currentRawH = 0;
+    m_currentOrientationDegrees = 0;
 }
 
 void Renderer_VK::ensureRawImageCapacity(uint32_t w, uint32_t h)

--- a/src/Utils/OrientationUtils.cpp
+++ b/src/Utils/OrientationUtils.cpp
@@ -1,0 +1,65 @@
+#include "Utils/OrientationUtils.h"
+#include <string>
+#include <algorithm>
+
+static OrientationTag degreesToTag(int deg, bool flipped) {
+    int norm = ((deg % 360) + 360) % 360;
+    switch(norm) {
+        case 0:   return flipped ? OrientationTag::kMirror : OrientationTag::kNormal;
+        case 90:  return flipped ? OrientationTag::kMirror90CW : OrientationTag::kRotate90CW;
+        case 180: return flipped ? OrientationTag::kMirror180 : OrientationTag::kRotate180;
+        case 270: return flipped ? OrientationTag::kMirror90CCW : OrientationTag::kRotate90CCW;
+        default:  return OrientationTag::kUnknown;
+    }
+}
+
+OrientationTag computeOrientationTag(const nlohmann::json& orientationValue,
+                                     bool isFlipped,
+                                     OrientationTag defaultTag) {
+    if (orientationValue.is_number_integer()) {
+        int val = orientationValue.get<int>();
+        if (val >= 1 && val <= 8) {
+            return static_cast<OrientationTag>(val);
+        }
+        // interpret common degree values
+        if (val == 0 || val == 90 || val == 180 || val == 270) {
+            OrientationTag t = degreesToTag(val, isFlipped);
+            if (t != OrientationTag::kUnknown) return t;
+        }
+    } else if (orientationValue.is_string()) {
+        std::string s = orientationValue.get<std::string>();
+        std::string lower; lower.reserve(s.size());
+        std::transform(s.begin(), s.end(), std::back_inserter(lower), [](unsigned char c){return static_cast<char>(std::tolower(c));});
+        // try parse numeric string
+        try {
+            int val = std::stoi(lower);
+            OrientationTag t = degreesToTag(val, isFlipped);
+            if (t != OrientationTag::kUnknown) return t;
+        } catch(...){}
+        if (lower.find("90") != std::string::npos) return degreesToTag(90, isFlipped);
+        if (lower.find("270") != std::string::npos) return degreesToTag(270, isFlipped);
+        if (lower.find("180") != std::string::npos) return degreesToTag(180, isFlipped);
+        if (lower.find("mirror") != std::string::npos && lower.find("180") == std::string::npos && lower.find("90") == std::string::npos && lower.find("270") == std::string::npos)
+            return degreesToTag(0, true);
+    }
+    return defaultTag;
+}
+
+int orientationDegreesFromTag(OrientationTag tag) {
+    switch(tag) {
+        case OrientationTag::kRotate90CW:
+        case OrientationTag::kMirror90CW:
+            return 90;
+        case OrientationTag::kRotate180:
+        case OrientationTag::kMirror180:
+            return 180;
+        case OrientationTag::kRotate90CCW:
+        case OrientationTag::kMirror90CCW:
+            return 270;
+        case OrientationTag::kNormal:
+        case OrientationTag::kMirror:
+            return 0;
+        default:
+            return 0;
+    }
+}


### PR DESCRIPTION
## Summary
- add orientation utilities for DNG orientation tags
- store container orientation metadata and pass to renderer
- extend uniform buffer with orientationDegrees
- rotate texture coordinates in vertex shader according to orientation
- adjust viewport calculations for rotated images

## Testing
- `cmake -S . -B build` *(fails: Threads::Threads target not found)*
- `cmake --build build` *(fails: error building motioncam-decoder)*

------
https://chatgpt.com/codex/tasks/task_e_685ee61280ec83279e70dc44082be639