### PR TITLE
Rename Fuse actions and fix variable names

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -229,7 +229,10 @@ elseif(MSVC)
 endif()
 
 
-set_target_properties(${PROJECT_NAME} PROPERTIES RUNTIME_OUTPUT_DIRECTORY "${CMAKE_RUNTIME_OUTPUT_DIRECTORY}")
+set_target_properties(${PROJECT_NAME} PROPERTIES
+    RUNTIME_OUTPUT_DIRECTORY "${CMAKE_RUNTIME_OUTPUT_DIRECTORY}"
+    OUTPUT_NAME "MotionCam Player"
+)
 
 add_custom_command(TARGET ${PROJECT_NAME} POST_BUILD
     COMMAND ${CMAKE_COMMAND} -E copy_directory
@@ -255,7 +258,7 @@ endif()
 
 message(STATUS "---------------------------------------------------------------------")
 message(STATUS "Final Configuration Summary:")
-message(STATUS "  Target Executable: ${PROJECT_NAME}")
+message(STATUS "  Target Executable: MotionCam Player")
 message(STATUS "  Output Directory:  ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${CMAKE_CFG_INTDIR}")
-message(STATUS "  Output Executable: ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${CMAKE_CFG_INTDIR}/${PROJECT_NAME}${CMAKE_EXECUTABLE_SUFFIX}")
+message(STATUS "  Output Executable: ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${CMAKE_CFG_INTDIR}/MotionCam Player${CMAKE_EXECUTABLE_SUFFIX}")
 message(STATUS "---------------------------------------------------------------------")

--- a/src/App/AppIO.cpp
+++ b/src/App/AppIO.cpp
@@ -1007,7 +1007,7 @@ void App::sendCurrentFileToMotionCamFS()
         static_cast<size_t>(m_currentFileIndex) >= m_fileList.size())
     {
         LogToFile("[App::sendToMotionCamFS] No valid file to send.");
-        std::cerr << "Send to motioncam-fs: no valid file selected.\n";
+        std::cerr << "Send to MotionCam Fuse: no valid file selected.\n";
         return;
     }
 
@@ -1021,18 +1021,18 @@ void App::sendCurrentFileToMotionCamFS()
     GetModuleFileNameA(nullptr, modulePathChars, MAX_PATH);
     fs::path currentExePath(modulePathChars);
     motionCamFsExePath =
-        (currentExePath.parent_path() / "motioncam-fs.exe").string();
+        (currentExePath.parent_path() / "MotionCam Fuse.exe").string();
 #else
     char result[PATH_MAX];
     ssize_t count = readlink("/proc/self/exe", result, PATH_MAX);
     fs::path currentExePath = (count > 0) ? fs::path(std::string(result, count)) : fs::path("");
 
-    fs::path рядом_exe = currentExePath.parent_path() / "motioncam-fs";
-    if (fs::exists(рядом_exe)) {
-        motionCamFsExePath = рядом_exe.string();
+    fs::path nearby_exe = currentExePath.parent_path() / "MotionCam Fuse";
+    if (fs::exists(nearby_exe)) {
+        motionCamFsExePath = nearby_exe.string();
     }
     else {
-        motionCamFsExePath = "motioncam-fs"; // Try PATH
+        motionCamFsExePath = "MotionCam Fuse"; // Try PATH
     }
 #endif
 
@@ -1040,14 +1040,13 @@ void App::sendCurrentFileToMotionCamFS()
 #ifndef _WIN32
     // If not found via relative path, try checking if it's in PATH
     if (!motionCamFsFound && motionCamFsExePath.find('/') == std::string::npos) {
-        motionCamFsFound = (system(("command -v " + motionCamFsExePath + " >/dev/null 2>&1").c_str()) == 0);
+        motionCamFsFound = (system(("command -v \"" + motionCamFsExePath + "\" >/dev/null 2>&1").c_str()) == 0);
     }
 #endif
 
     if (!motionCamFsFound)
     {
-        LogToFile(std::string("[App::sendToMotionCamFS] ERROR: motioncam-fs not "
-            "found at expected location or in system PATH. Tried: ") + motionCamFsExePath);
+        LogToFile(std::string("[App::sendToMotionCamFS] ERROR: MotionCam Fuse not found at expected location or in system PATH. Tried: ") + motionCamFsExePath);
         return;
     }
 
@@ -1093,18 +1092,18 @@ void App::sendAllPlaylistFilesToMotionCamFS()
     GetModuleFileNameA(nullptr, modulePathChars, MAX_PATH);
     fs::path exeDir(modulePathChars);
     motionCamFsExePath =
-        (exeDir.parent_path() / "motioncam-fs.exe").string();
+        (exeDir.parent_path() / "MotionCam Fuse.exe").string();
 #else
     char result[PATH_MAX];
     ssize_t count = readlink("/proc/self/exe", result, PATH_MAX);
     fs::path currentExePath = (count > 0) ? fs::path(std::string(result, count)) : fs::path("");
 
-    fs::path рядом_exe = currentExePath.parent_path() / "motioncam-fs";
-    if (fs::exists(рядом_exe)) {
-        motionCamFsExePath = рядом_exe.string();
+    fs::path nearby_exe = currentExePath.parent_path() / "MotionCam Fuse";
+    if (fs::exists(nearby_exe)) {
+        motionCamFsExePath = nearby_exe.string();
     }
     else {
-        motionCamFsExePath = "motioncam-fs"; // Try PATH
+        motionCamFsExePath = "MotionCam Fuse"; // Try PATH
     }
 #endif
 
@@ -1112,14 +1111,13 @@ void App::sendAllPlaylistFilesToMotionCamFS()
 #ifndef _WIN32
     // If not found via relative path, try checking if it's in PATH
     if (!motionCamFsFound && motionCamFsExePath.find('/') == std::string::npos) {
-        motionCamFsFound = (system(("command -v " + motionCamFsExePath + " >/dev/null 2>&1").c_str()) == 0);
+        motionCamFsFound = (system(("command -v \"" + motionCamFsExePath + "\" >/dev/null 2>&1").c_str()) == 0);
     }
 #endif
 
     if (!motionCamFsFound)
     {
-        LogToFile(std::string("[App::sendAllToMotionCamFS] ERROR: motioncam-fs "
-            "not found at expected location or in system PATH. Tried: ") + motionCamFsExePath);
+        LogToFile(std::string("[App::sendAllToMotionCamFS] ERROR: MotionCam Fuse not found at expected location or in system PATH. Tried: ") + motionCamFsExePath);
         return;
     }
 
@@ -1159,7 +1157,7 @@ void App::sendAllPlaylistFilesToMotionCamFS()
         if (system((command + " &").c_str()) == 0) ++ok;
         else { ++fail; LogToFile("[App::sendAllToMotionCamFS] system() call failed for: " + mcrawPathStr); }
 #endif
-        // Optional: Small delay to avoid overwhelming system or motioncam-fs if it's not handling rapid launches well
+        // Optional: Small delay to avoid overwhelming system or MotionCam Fuse if it's not handling rapid launches well
         // std::this_thread::sleep_for(std::chrono::milliseconds(100));
     }
 

--- a/src/Gui/GuiRender.cpp
+++ b/src/Gui/GuiRender.cpp
@@ -206,10 +206,10 @@ namespace GuiOverlay {
                 if (appInstance) appInstance->softDeleteCurrentFile();
             }
             ImGui::Separator();
-            if (ImGui::MenuItem("Send Current to motioncam-fs", nullptr, false, canOperateOnCurrentFile)) {
+            if (ImGui::MenuItem("Send Current to MotionCam Fuse", nullptr, false, canOperateOnCurrentFile)) {
                 if (appInstance) appInstance->sendCurrentFileToMotionCamFS();
             }
-            if (ImGui::MenuItem("Send All in Playlist to motioncam-fs", nullptr, false, playlistNotEmpty)) {
+            if (ImGui::MenuItem("Send All in Playlist to MotionCam Fuse", nullptr, false, playlistNotEmpty)) {
                 if (appInstance) appInstance->sendAllPlaylistFilesToMotionCamFS();
             }
             ImGui::EndPopup();
@@ -231,7 +231,7 @@ namespace GuiOverlay {
             ImGui::PushStyleVar(ImGuiStyleVar_FramePadding, ImVec2(6, 4));
             ImGui::PushStyleColor(ImGuiCol_WindowBg, ImVec4(0.07f, 0.08f, 0.09f, 0.95f));
 
-            if (ImGui::Begin("PLAYLIST_AUX_TOGGLED", &GuiOverlay::show_playlist_aux, ImGuiWindowFlags_NoCollapse | ImGuiWindowFlags_NoSavedSettings)) {
+            if (ImGui::Begin("Playlist", &GuiOverlay::show_playlist_aux, ImGuiWindowFlags_NoCollapse | ImGuiWindowFlags_NoSavedSettings)) {
                 current_playlist_window_width = ImGui::GetWindowSize().x;
                 playlist_window_is_visible = true;
                 if (appInstance->m_fileList.empty()) {


### PR DESCRIPTION
## Summary
- Windows build exports **MotionCam Player.exe**
- menu items send files to **MotionCam Fuse** instead of `motioncam-fs`
- playlist overlay window is titled **Playlist**
- fixed variable names when searching for "MotionCam Fuse" executable

## Testing
- `cmake -S . -B build`
- `cmake --build build` *(fails: GL/gl.h not found)*

------
https://chatgpt.com/codex/tasks/task_e_685f8ba73f0c8327aa84834b088e2ac3