### PR TITLE
Add folder scan for drag-drop and fix shortcut

### DIFF
--- a/include/App/App.h
+++ b/include/App/App.h
@@ -45,7 +45,7 @@ class Renderer_VK;
 
 class App {
 public:
-    explicit App(const std::string& filePath);
+    explicit App(const std::string& filePath = "");
     ~App();
 
     App(const App&) = delete;

--- a/src/App/AppInit.cpp
+++ b/src/App/AppInit.cpp
@@ -156,33 +156,35 @@ App::App(const std::string& filePath) :
     LogToFile(std::string("App::App Available Staging Buffer Indices Queue MaxSize (actual from queue): ") + std::to_string(m_availableStagingBufferIndices.get_max_size_debug()));
 
 
-    if (!fs::exists(this->m_filePath)) {
-        LogToFile(std::string("App::App ERROR: File does not exist: ") + this->m_filePath);
-        throw std::runtime_error("App::App File does not exist: " + this->m_filePath);
-    }
-    auto target = fs::absolute(this->m_filePath);
-    auto folder = target.parent_path();
-    for (const auto& e : fs::directory_iterator(folder)) {
-        if (e.is_regular_file() && e.path().extension() == ".mcraw") {
-            m_fileList.push_back(e.path().string());
+    if (!m_filePath.empty()) {
+        if (!fs::exists(this->m_filePath)) {
+            LogToFile(std::string("App::App ERROR: File does not exist: ") + this->m_filePath);
+            throw std::runtime_error("App::App File does not exist: " + this->m_filePath);
         }
-    }
-    if (!m_fileList.empty()) {
-        std::sort(m_fileList.begin(), m_fileList.end());
-    }
+        auto target = fs::absolute(this->m_filePath);
+        auto folder = target.parent_path();
+        for (const auto& e : fs::directory_iterator(folder)) {
+            if (e.is_regular_file() && e.path().extension() == ".mcraw") {
+                m_fileList.push_back(e.path().string());
+            }
+        }
+        if (!m_fileList.empty()) {
+            std::sort(m_fileList.begin(), m_fileList.end());
+        }
 
-    auto it = std::find(m_fileList.begin(), m_fileList.end(), target.string());
-    if (it == m_fileList.end()) {
-        LogToFile("App::App Initial file not found in directory scan, adding it to list: " + target.string());
-        m_fileList.push_back(target.string());
-        std::sort(m_fileList.begin(), m_fileList.end());
-        it = std::find(m_fileList.begin(), m_fileList.end(), target.string());
+        auto it = std::find(m_fileList.begin(), m_fileList.end(), target.string());
         if (it == m_fileList.end()) {
-            LogToFile(std::string("App::App ERROR: Catastrophic: Initial file still not in playlist after adding: ") + this->m_filePath);
-            throw std::runtime_error("App::App Catastrophic: Initial file not in playlist: " + this->m_filePath);
+            LogToFile("App::App Initial file not found in directory scan, adding it to list: " + target.string());
+            m_fileList.push_back(target.string());
+            std::sort(m_fileList.begin(), m_fileList.end());
+            it = std::find(m_fileList.begin(), m_fileList.end(), target.string());
+            if (it == m_fileList.end()) {
+                LogToFile(std::string("App::App ERROR: Catastrophic: Initial file still not in playlist after adding: ") + this->m_filePath);
+                throw std::runtime_error("App::App Catastrophic: Initial file not in playlist: " + this->m_filePath);
+            }
         }
+        m_currentFileIndex = static_cast<int>(std::distance(m_fileList.begin(), it));
     }
-    m_currentFileIndex = static_cast<int>(std::distance(m_fileList.begin(), it));
 
     m_inFlightStagingBufferIndices.resize(MAX_FRAMES_IN_FLIGHT, std::nullopt);
 
@@ -206,7 +208,7 @@ App::App(const std::string& filePath) :
     }
     LogToFile("App::App constr Vulkan initialized by initVulkan().");
 
-    if (m_fileList.empty()) {
+    if (!m_filePath.empty() && m_fileList.empty()) {
         LogToFile("App::App constr ERROR: File list empty after init. Aborting constructor.");
         throw std::runtime_error("File list empty after App initialization.");
     }
@@ -223,14 +225,16 @@ App::App(const std::string& filePath) :
     this->initImGuiVulkan();
     LogToFile("App::App constr ImGui Vulkan initialized.");
 
-    m_playbackController = std::make_unique<PlaybackController>();
-    m_playbackController_ptr = m_playbackController.get();
-    LogToFile("App::App constr PlaybackController created.");
+    if (!m_filePath.empty()) {
+        m_playbackController = std::make_unique<PlaybackController>();
+        m_playbackController_ptr = m_playbackController.get();
+        LogToFile("App::App constr PlaybackController created.");
 
-    LogToFile("App::App constr Loading initial file...");
-    this->loadFileAtIndex(m_currentFileIndex);
-    m_firstFileLoaded = true;
-    LogToFile("App::App constr Initial file load process initiated.");
+        LogToFile("App::App constr Loading initial file...");
+        this->loadFileAtIndex(m_currentFileIndex);
+        m_firstFileLoaded = true;
+        LogToFile("App::App constr Initial file load process initiated.");
+    }
     LogToFile(std::string("App::App Constructor fully finished. Current file index: ") + std::to_string(m_currentFileIndex));
 
 #ifndef NDEBUG

--- a/src/App/AppInput.cpp
+++ b/src/App/AppInput.cpp
@@ -33,7 +33,9 @@ void App::framebuffer_size_callback_static(GLFWwindow* window, int width, int he
 
 void App::key_callback_static(GLFWwindow* window, int key, int scancode, int action, int mods) {
     ImGuiIO& io = ImGui::GetIO();
-    if (io.WantCaptureKeyboard && key != GLFW_KEY_TAB) {
+    bool ctrlCombo = (mods & GLFW_MOD_CONTROL) &&
+                     (key == GLFW_KEY_O || key == GLFW_KEY_Q);
+    if (io.WantCaptureKeyboard && key != GLFW_KEY_TAB && !ctrlCombo) {
         return;
     }
     if (action == GLFW_PRESS || action == GLFW_REPEAT) {
@@ -360,6 +362,7 @@ void App::handleDrop(int count, const char** paths) {
     if (count <= 0) return;
     std::string firstValidPathDropped;
     bool newFilesAddedToPlaylist = false;
+    fs::path firstFolder;
 
     for (int i = 0; i < count; ++i) {
         if (paths[i] == nullptr) continue;
@@ -369,6 +372,7 @@ void App::handleDrop(int count, const char** paths) {
                 std::string s = p.string();
                 if (firstValidPathDropped.empty()) {
                     firstValidPathDropped = s;
+                    firstFolder = p.parent_path();
                 }
                 if (std::find(m_fileList.begin(), m_fileList.end(), s) == m_fileList.end()) {
                     m_fileList.push_back(s);
@@ -382,6 +386,22 @@ void App::handleDrop(int count, const char** paths) {
         }
     }
 
+    if (!firstFolder.empty()) {
+        try {
+            for (const auto& e : fs::directory_iterator(firstFolder)) {
+                if (e.is_regular_file() && e.path().extension() == ".mcraw") {
+                    std::string s = e.path().string();
+                    if (std::find(m_fileList.begin(), m_fileList.end(), s) == m_fileList.end()) {
+                        m_fileList.push_back(s);
+                        newFilesAddedToPlaylist = true;
+                    }
+                }
+            }
+        } catch (const fs::filesystem_error& e) {
+            LogToFile(std::string("[App::handleDrop] Directory scan error: ") + e.what());
+        }
+    }
+
     if (newFilesAddedToPlaylist) {
         std::sort(m_fileList.begin(), m_fileList.end());
         LogToFile("[App::handleDrop] New files added to playlist and sorted.");
@@ -390,10 +410,9 @@ void App::handleDrop(int count, const char** paths) {
     if (!firstValidPathDropped.empty()) {
         auto it = std::find(m_fileList.begin(), m_fileList.end(), firstValidPathDropped);
         if (it != m_fileList.end()) {
-            bool tempFirstLoaded = m_firstFileLoaded;
             m_firstFileLoaded = false;
             loadFileAtIndex(static_cast<int>(std::distance(m_fileList.begin(), it)));
-            m_firstFileLoaded = tempFirstLoaded;
+            m_firstFileLoaded = true;
             LogToFile(std::string("[App::handleDrop] Loaded dropped file: ") + firstValidPathDropped);
         }
     }
@@ -466,17 +485,36 @@ std::string App::openMcrawDialog() {
 void App::triggerOpenFileViaDialog() {
     std::string newPath = openMcrawDialog();
     if (!newPath.empty()) {
-        auto it_existing = std::find(m_fileList.begin(), m_fileList.end(), newPath);
-        if (it_existing == m_fileList.end()) {
-            m_fileList.push_back(newPath);
-            std::sort(m_fileList.begin(), m_fileList.end());
-            it_existing = std::find(m_fileList.begin(), m_fileList.end(), newPath);
+        fs::path target = fs::absolute(newPath);
+        fs::path folder = target.parent_path();
+        bool added = false;
+        try {
+            for (const auto& e : fs::directory_iterator(folder)) {
+                if (e.is_regular_file() && e.path().extension() == ".mcraw") {
+                    std::string s = e.path().string();
+                    if (std::find(m_fileList.begin(), m_fileList.end(), s) == m_fileList.end()) {
+                        m_fileList.push_back(s);
+                        added = true;
+                    }
+                }
+            }
+        } catch (const fs::filesystem_error& e) {
+            LogToFile(std::string("[App::triggerOpenFileViaDialog] Directory scan error: ") + e.what());
         }
+        if (added) {
+            std::sort(m_fileList.begin(), m_fileList.end());
+        }
+        auto it_existing = std::find(m_fileList.begin(), m_fileList.end(), target.string());
         if (it_existing != m_fileList.end()) {
-            bool tempFirstLoaded = m_firstFileLoaded;
-            m_firstFileLoaded = false;
-            loadFileAtIndex(static_cast<int>(std::distance(m_fileList.begin(), it_existing)));
-            m_firstFileLoaded = tempFirstLoaded;
+            if (m_firstFileLoaded) {
+                bool tempFirstLoaded = m_firstFileLoaded;
+                m_firstFileLoaded = true;
+                loadFileAtIndex(static_cast<int>(std::distance(m_fileList.begin(), it_existing)));
+                m_firstFileLoaded = tempFirstLoaded;
+            } else {
+                loadFileAtIndex(static_cast<int>(std::distance(m_fileList.begin(), it_existing)));
+                m_firstFileLoaded = true;
+            }
         }
     }
 }

--- a/src/App/AppLoop.cpp
+++ b/src/App/AppLoop.cpp
@@ -396,11 +396,13 @@ void App::drawFrame() {
             clearColorValue.color = { {0.0f, 0.0f, 0.0f, 1.0f} };
         }
         else {
-            clearColorValue.color = { {0.1f, 0.1f, 0.1f, 1.0f} };
+            float bg = m_firstFileLoaded ? 0.1f : (40.0f/255.0f);
+            clearColorValue.color = { {bg, bg, bg, 1.0f} };
         }
     }
     else {
-        clearColorValue.color = { {0.1f, 0.1f, 0.1f, 1.0f} };
+        float bg = m_firstFileLoaded ? 0.1f : (40.0f/255.0f);
+        clearColorValue.color = { {bg, bg, bg, 1.0f} };
         if (m_inFlightStagingBufferIndices[m_currentFrame].has_value()) {
             m_availableStagingBufferIndices.push(m_inFlightStagingBufferIndices[m_currentFrame].value());
             m_inFlightStagingBufferIndices[m_currentFrame] = std::nullopt;

--- a/src/Gui/GuiRender.cpp
+++ b/src/Gui/GuiRender.cpp
@@ -189,6 +189,29 @@ namespace GuiOverlay {
         ImGuiStyle& style = ImGui::GetStyle();
         ImGuiIO& io = ImGui::GetIO();
 
+        if (!appInstance->m_firstFileLoaded) {
+            ImGuiViewport* viewport = ImGui::GetMainViewport();
+            ImGui::SetNextWindowPos(ImVec2(viewport->WorkPos.x + viewport->WorkSize.x * 0.5f,
+                                           viewport->WorkPos.y + viewport->WorkSize.y * 0.5f),
+                                   ImGuiCond_Always, ImVec2(0.5f, 0.5f));
+            ImGui::SetNextWindowBgAlpha(0.f);
+            ImGui::Begin("OPEN_PROMPT", nullptr,
+                        ImGuiWindowFlags_NoDecoration | ImGuiWindowFlags_NoMove |
+                        ImGuiWindowFlags_NoSavedSettings | ImGuiWindowFlags_AlwaysAutoResize);
+            ImGui::PushStyleColor(ImGuiCol_Button, ImVec4(60.0f/255.0f, 60.0f/255.0f, 60.0f/255.0f, 1.0f));
+            ImGui::PushStyleColor(ImGuiCol_ButtonHovered, ImVec4(80.0f/255.0f, 80.0f/255.0f, 80.0f/255.0f, 1.0f));
+            ImGui::PushStyleColor(ImGuiCol_ButtonActive, ImVec4(80.0f/255.0f, 80.0f/255.0f, 80.0f/255.0f, 1.0f));
+            ImGui::PushStyleColor(ImGuiCol_Text, ImVec4(1.0f, 1.0f, 1.0f, 1.0f));
+            ImGui::PushStyleVar(ImGuiStyleVar_FrameRounding, 6.0f);
+            if (ImGui::Button("Open or drag a MCRAW file", ImVec2(220, 40))) {
+                appInstance->triggerOpenFileViaDialog();
+            }
+            ImGui::PopStyleVar();
+            ImGui::PopStyleColor(4);
+            ImGui::End();
+            return;
+        }
+
         if (ImGui::IsMouseReleased(ImGuiMouseButton_Right) && !io.WantCaptureMouse) {
             ImGui::OpenPopup("AppContextMenu");
         }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -261,18 +261,11 @@ int main(int argc, char* argv[]) {
     if (argc >= 2 && argv[1] != nullptr) {
         inPath = argv[1];
         LogToFile(std::string("[main] Input file from command line: ") + inPath);
-    }
-    else {
-        LogToFile("[main] No command line argument provided or argv[1] is null, opening file dialog...");
-        inPath = OpenMcrawDialog();
-        if (inPath.empty()) {
-            LogToFile("[main] No input file selected from dialog or dialog cancelled. Exiting.");
-            return 0;
-        }
-        LogToFile(std::string("[main] Input file from dialog: ") + inPath);
+    } else {
+        LogToFile("[main] No command line argument provided. Starting without file.");
     }
 
-    if (!fs::exists(inPath) || !fs::is_regular_file(inPath)) {
+    if (!inPath.empty() && (!fs::exists(inPath) || !fs::is_regular_file(inPath))) {
         std::string errorMsg = "[main] Input file not found or not a regular file: " + inPath;
         LogToFile(errorMsg);
 #ifdef _WIN32
@@ -281,7 +274,7 @@ int main(int argc, char* argv[]) {
         std::cerr << errorMsg << std::endl;
         return 1;
     }
-    if (fs::path(inPath).extension() != ".mcraw") {
+    if (!inPath.empty() && fs::path(inPath).extension() != ".mcraw") {
         std::string errorMsg = "[main] Input file must have a .mcraw extension: " + inPath;
         LogToFile(errorMsg);
 #ifdef _WIN32


### PR DESCRIPTION
## Summary
- allow Ctrl+O/Ctrl+Q shortcuts even when ImGui captures keyboard
- build playlist by scanning folder when opening a file
- drag-and-drop now also scans the folder of the dropped file

## Testing
- `cmake ..`
- `make -j$(nproc)` *(fails: GL/gl.h missing)*


------
https://chatgpt.com/codex/tasks/task_e_685fb4dac16c8327a93d7688a4e192a9