### PR TITLE
Implement start screen and drag-drop playlist scanning

### DIFF
--- a/include/App.h
+++ b/include/App.h
@@ -43,7 +43,7 @@ const int MAX_FRAMES_IN_FLIGHT = 2;
 
 class App {
 public:
-    explicit App(const std::string& filePath);
+    explicit App(const std::string& filePath = "");
     ~App();
     bool run();
 

--- a/src/App.cpp
+++ b/src/App.cpp
@@ -293,38 +293,45 @@ App::App(const std::string& filePath) : m_filePath(filePath) {
 
     LogToFile(std::string("[App::App] Constructor called for file: ") + this->m_filePath);
     std::cout << "[App::App] Constructor called for file: " << this->m_filePath << std::endl;
-    if (!fs::exists(this->m_filePath)) {
-        LogToFile(std::string("[App::App] ERROR: File does not exist: ") + this->m_filePath);
-        throw std::runtime_error("[App::App] File does not exist: " + this->m_filePath);
-    }
-    auto target = fs::absolute(this->m_filePath);
-    auto folder = target.parent_path();
-    for (const auto& e : fs::directory_iterator(folder)) {
-        if (e.is_regular_file() && e.path().extension() == ".mcraw") {
-            m_fileList.push_back(e.path().string());
+
+    if (!m_filePath.empty()) {
+        if (!fs::exists(this->m_filePath)) {
+            LogToFile(std::string("[App::App] ERROR: File does not exist: ") + this->m_filePath);
+            throw std::runtime_error("[App::App] File does not exist: " + this->m_filePath);
         }
-    }
-    std::sort(m_fileList.begin(), m_fileList.end());
-    m_fileThumbIDs.resize(m_fileList.size(), 0); // thumbnails loaded lazily
-    auto it = std::find(m_fileList.begin(), m_fileList.end(), target.string());
-    if (it == m_fileList.end()) {
-        m_fileList.push_back(target.string());
-        m_fileThumbIDs.push_back(0);
+
+        auto target = fs::absolute(this->m_filePath);
+        auto folder = target.parent_path();
+        for (const auto& e : fs::directory_iterator(folder)) {
+            if (e.is_regular_file() && e.path().extension() == ".mcraw") {
+                m_fileList.push_back(e.path().string());
+            }
+        }
         std::sort(m_fileList.begin(), m_fileList.end());
-        // keep thumbnails vector aligned after sort
-        std::vector<std::pair<std::string,uint64_t>> pairs;
-        pairs.reserve(m_fileList.size());
-        for (size_t i=0;i<m_fileList.size();++i)
-            pairs.emplace_back(m_fileList[i], m_fileThumbIDs[i]);
-        std::sort(pairs.begin(), pairs.end(), [](auto&a,auto&b){return a.first<b.first;});
-        for (size_t i=0;i<pairs.size();++i){m_fileList[i]=pairs[i].first;m_fileThumbIDs[i]=pairs[i].second;}
-        it = std::find(m_fileList.begin(), m_fileList.end(), target.string());
+        m_fileThumbIDs.resize(m_fileList.size(), 0); // thumbnails loaded lazily
+        auto it = std::find(m_fileList.begin(), m_fileList.end(), target.string());
         if (it == m_fileList.end()) {
-            LogToFile(std::string("[App::App] ERROR: Catastrophic: Initial file not in playlist: ") + this->m_filePath);
-            throw std::runtime_error("[App::App] Catastrophic: Initial file not in playlist: " + this->m_filePath);
+            m_fileList.push_back(target.string());
+            m_fileThumbIDs.push_back(0);
+            std::sort(m_fileList.begin(), m_fileList.end());
+            // keep thumbnails vector aligned after sort
+            std::vector<std::pair<std::string,uint64_t>> pairs;
+            pairs.reserve(m_fileList.size());
+            for (size_t i=0;i<m_fileList.size();++i)
+                pairs.emplace_back(m_fileList[i], m_fileThumbIDs[i]);
+            std::sort(pairs.begin(), pairs.end(), [](auto&a,auto&b){return a.first<b.first;});
+            for (size_t i=0;i<pairs.size();++i){m_fileList[i]=pairs[i].first;m_fileThumbIDs[i]=pairs[i].second;}
+            it = std::find(m_fileList.begin(), m_fileList.end(), target.string());
+            if (it == m_fileList.end()) {
+                LogToFile(std::string("[App::App] ERROR: Catastrophic: Initial file not in playlist: ") + this->m_filePath);
+                throw std::runtime_error("[App::App] Catastrophic: Initial file not in playlist: " + this->m_filePath);
+            }
         }
+        m_currentFileIndex = static_cast<int>(std::distance(m_fileList.begin(), it));
+    } else {
+        m_currentFileIndex = 0;
     }
-    m_currentFileIndex = static_cast<int>(std::distance(m_fileList.begin(), it));
+
     LogToFile(std::string("[App::App] Constructor finished. Current file index: ") + std::to_string(m_currentFileIndex));
     std::cout << "[App::App] Constructor finished. Current file index: " << m_currentFileIndex << std::endl;
 }
@@ -360,6 +367,14 @@ void App::framebuffer_size_callback_static(GLFWwindow* window, int width, int he
 }
 void App::key_callback_static(GLFWwindow* window, int key, int scancode, int action, int mods) {
     ImGuiIO& io = ImGui::GetIO();
+    if (action == GLFW_PRESS || action == GLFW_REPEAT) {
+        if (auto app = static_cast<App*>(glfwGetWindowUserPointer(window))) {
+            if ((mods & GLFW_MOD_CONTROL) && (key == GLFW_KEY_O || key == GLFW_KEY_Q)) {
+                app->handleKey(key, mods);
+                return;
+            }
+        }
+    }
     if (io.WantCaptureKeyboard && key != GLFW_KEY_TAB) { return; }
     if (action == GLFW_PRESS || action == GLFW_REPEAT) {
         if (auto app = static_cast<App*>(glfwGetWindowUserPointer(window))) {
@@ -432,9 +447,9 @@ bool App::run() {
 
     LogToFile("[App::run] Initializing Vulkan...");
     std::cout << "[App::run] Initializing Vulkan..." << std::endl;
-    if (!initVulkan() || m_fileList.empty()) {
-        LogToFile("[App::run] ERROR: initVulkan() failed or file list empty. Exiting App::run().");
-        std::cerr << "[App::run] initVulkan() failed or file list empty. Exiting App::run()." << std::endl;
+    if (!initVulkan()) {
+        LogToFile("[App::run] ERROR: initVulkan() failed. Exiting App::run().");
+        std::cerr << "[App::run] initVulkan() failed. Exiting App::run()." << std::endl;
         return false;
     }
     LogToFile("[App::run] Vulkan initialized.");
@@ -474,14 +489,16 @@ bool App::run() {
     LogToFile("[App::run] ImGui Vulkan initialized.");
     std::cout << "[App::run] ImGui Vulkan initialized." << std::endl;
 
-    LogToFile("[App::run] Loading initial file...");
-    std::cout << "[App::run] Loading initial file..." << std::endl;
-    loadFileAtIndex(m_currentFileIndex);
-    m_firstFileLoaded = true;
-    LogToFile("[App::run] Initial file loaded.");
-    std::cout << "[App::run] Initial file loaded." << std::endl;
+    if (!m_fileList.empty()) {
+        LogToFile("[App::run] Loading initial file...");
+        std::cout << "[App::run] Loading initial file..." << std::endl;
+        loadFileAtIndex(m_currentFileIndex);
+        m_firstFileLoaded = true;
+        LogToFile("[App::run] Initial file loaded.");
+        std::cout << "[App::run] Initial file loaded." << std::endl;
+    }
 
-    if (!m_window || !m_decoderWrapper || !m_rendererVk || !m_playbackController) {
+    if (!m_window || !m_rendererVk || (!m_fileList.empty() && (!m_decoderWrapper || !m_playbackController))) {
         LogToFile("[App::run] ERROR: Critical component missing after initial load. Exiting App::run().");
         std::cerr << "[App::run] Critical component missing after initial load. Exiting App::run()." << std::endl;
         if(m_rendererVk) m_rendererVk->cleanup();
@@ -505,20 +522,27 @@ bool App::run() {
         }
 #endif
 
-        bool paused = m_playbackController->isPaused();
+        bool paused = true;
         bool segment_looped_or_ended = false;
-        if (!paused) {
-            if (m_decoderWrapper && m_decoderWrapper->getDecoder()) {
-                const auto& frames = m_decoderWrapper->getDecoder()->getFrames();
-                segment_looped_or_ended = m_playbackController->updatePlayhead(steady_clock::now(), frames);
-            } else { m_playbackController->updatePlayhead(steady_clock::now(), {}); }
-        } else {
-             if (m_decoderWrapper && m_decoderWrapper->getDecoder()) {
-                m_playbackController->updatePlayhead(steady_clock::now(), m_decoderWrapper->getDecoder()->getFrames());
-            } else { m_playbackController->updatePlayhead(steady_clock::now(), {});}
+        if (m_playbackController) {
+            paused = m_playbackController->isPaused();
+            if (!paused) {
+                if (m_decoderWrapper && m_decoderWrapper->getDecoder()) {
+                    const auto& frames = m_decoderWrapper->getDecoder()->getFrames();
+                    segment_looped_or_ended = m_playbackController->updatePlayhead(steady_clock::now(), frames);
+                } else {
+                    m_playbackController->updatePlayhead(steady_clock::now(), {});
+                }
+            } else {
+                if (m_decoderWrapper && m_decoderWrapper->getDecoder()) {
+                    m_playbackController->updatePlayhead(steady_clock::now(), m_decoderWrapper->getDecoder()->getFrames());
+                } else {
+                    m_playbackController->updatePlayhead(steady_clock::now(), {});
+                }
+            }
         }
         m_sleepTimeMs = 0.0;
-        if (!m_decoderWrapper || !m_decoderWrapper->getDecoder()) {
+        if (!m_fileList.empty() && (!m_decoderWrapper || !m_decoderWrapper->getDecoder())) {
             loadFileAtIndex(m_currentFileIndex);
             if (!m_decoderWrapper || !m_decoderWrapper->getDecoder()) {
                  LogToFile("[App::run] ERROR: Decoder became invalid in main loop. Breaking.");
@@ -532,12 +556,12 @@ bool App::run() {
         auto t1_render_submit = steady_clock::now();
         m_renderSubmitTimeMs = std::chrono::duration<double, std::milli>(t1_render_submit - t0_render_submit).count();
 
-        if (m_audio && !paused && m_playbackController->getFirstFrameMediaTimestampOfSegment()) {
+        if (m_audio && m_playbackController && !paused && m_playbackController->getFirstFrameMediaTimestampOfSegment()) {
             auto elapsed = std::chrono::duration_cast<std::chrono::nanoseconds>(steady_clock::now() - m_playbackStartTime).count();
             m_audio->updatePlayback(elapsed);
         }
 
-        if (!paused && segment_looped_or_ended) {
+        if (m_playbackController && !paused && segment_looped_or_ended) {
             if (m_fileList.size() > 1) {
                 loadFileAtIndex((m_currentFileIndex + 1) % (int)m_fileList.size());
             } else {
@@ -1313,7 +1337,8 @@ void App::drawFrame() {
     renderPassInfo.framebuffer = m_swapChainFramebuffers[imageIndex];
     renderPassInfo.renderArea.offset = {0, 0};
     renderPassInfo.renderArea.extent = m_swapChainExtent;
-    VkClearValue clearColor = { {{0.05f, 0.05f, 0.05f, 1.0f}} };
+    float bg = m_firstFileLoaded ? 0.05f : 40.0f / 255.0f;
+    VkClearValue clearColor = { {{bg, bg, bg, 1.0f}} };
     renderPassInfo.clearValueCount = 1;
     renderPassInfo.pClearValues = &clearColor;
 
@@ -1774,9 +1799,28 @@ std::string App::openMcrawDialog() {
 void App::triggerOpenFileViaDialog() {
     std::string newPath = openMcrawDialog();
     if (!newPath.empty()) {
-        auto it_existing = std::find(m_fileList.begin(), m_fileList.end(), newPath);
-        if (it_existing == m_fileList.end()) { m_fileList.push_back(newPath); std::sort(m_fileList.begin(), m_fileList.end()); it_existing = std::find(m_fileList.begin(), m_fileList.end(), newPath); }
-        if (it_existing != m_fileList.end()) { m_firstFileLoaded = false; loadFileAtIndex(static_cast<int>(std::distance(m_fileList.begin(), it_existing))); m_firstFileLoaded = true; }
+        fs::path absPath = fs::absolute(newPath);
+        fs::path dir = absPath.parent_path();
+        bool playlistModified = false;
+        for (const auto& e : fs::directory_iterator(dir)) {
+            if (e.is_regular_file() && e.path().extension() == ".mcraw") {
+                std::string s = e.path().string();
+                if (std::find(m_fileList.begin(), m_fileList.end(), s) == m_fileList.end()) {
+                    m_fileList.push_back(s);
+                    playlistModified = true;
+                }
+            }
+        }
+        if (playlistModified) {
+            std::sort(m_fileList.begin(), m_fileList.end());
+            m_fileThumbIDs.resize(m_fileList.size(), 0);
+        }
+        auto it_existing = std::find(m_fileList.begin(), m_fileList.end(), absPath.string());
+        if (it_existing != m_fileList.end()) {
+            m_firstFileLoaded = false;
+            loadFileAtIndex(static_cast<int>(std::distance(m_fileList.begin(), it_existing)));
+            m_firstFileLoaded = true;
+        }
     }
 }
 void App::recordPauseTime() { m_pauseBegan = std::chrono::steady_clock::now(); }
@@ -1802,10 +1846,40 @@ void App::anchorPlaybackTimeForResume() {
     }
 }
 void App::handleDrop(int count, const char** paths) {
-    if (count <= 0) return; std::string firstValidPathDropped; bool newFilesAddedToPlaylist = false;
-    for (int i = 0; i < count; ++i) { if (paths[i] == nullptr) continue; try { fs::path p = fs::absolute(paths[i]); if (p.extension() == ".mcraw" && fs::is_regular_file(p)) { std::string s = p.string(); if (firstValidPathDropped.empty()) { firstValidPathDropped = s; } if (std::find(m_fileList.begin(), m_fileList.end(), s) == m_fileList.end()) { m_fileList.push_back(s); newFilesAddedToPlaylist = true; } } } catch (const fs::filesystem_error&) {} }
-    if (newFilesAddedToPlaylist) { std::sort(m_fileList.begin(), m_fileList.end()); }
-    if (!firstValidPathDropped.empty()) { auto it = std::find(m_fileList.begin(), m_fileList.end(), firstValidPathDropped); if (it != m_fileList.end()) { m_firstFileLoaded = false; loadFileAtIndex(static_cast<int>(std::distance(m_fileList.begin(), it))); m_firstFileLoaded = true; } }
+    if (count <= 0) return;
+    std::string firstValidPathDropped;
+    bool playlistModified = false;
+    for (int i = 0; i < count; ++i) {
+        if (paths[i] == nullptr) continue;
+        try {
+            fs::path p = fs::absolute(paths[i]);
+            if (p.extension() == ".mcraw" && fs::is_regular_file(p)) {
+                if (firstValidPathDropped.empty()) firstValidPathDropped = p.string();
+                fs::path dir = p.parent_path();
+                for (const auto& e : fs::directory_iterator(dir)) {
+                    if (e.is_regular_file() && e.path().extension() == ".mcraw") {
+                        std::string s = e.path().string();
+                        if (std::find(m_fileList.begin(), m_fileList.end(), s) == m_fileList.end()) {
+                            m_fileList.push_back(s);
+                            playlistModified = true;
+                        }
+                    }
+                }
+            }
+        } catch (const fs::filesystem_error&) {}
+    }
+    if (playlistModified) {
+        std::sort(m_fileList.begin(), m_fileList.end());
+        m_fileThumbIDs.resize(m_fileList.size(), 0);
+    }
+    if (!firstValidPathDropped.empty()) {
+        auto it = std::find(m_fileList.begin(), m_fileList.end(), fs::absolute(firstValidPathDropped).string());
+        if (it != m_fileList.end()) {
+            m_firstFileLoaded = false;
+            loadFileAtIndex(static_cast<int>(std::distance(m_fileList.begin(), it)));
+            m_firstFileLoaded = true;
+        }
+    }
 }
 void App::softDeleteCurrentFile() {
     if (m_fileList.empty() || m_currentFileIndex < 0 || static_cast<size_t>(m_currentFileIndex) >= m_fileList.size()) return;

--- a/src/GuiOverlay.cpp
+++ b/src/GuiOverlay.cpp
@@ -306,6 +306,26 @@ void GuiOverlay::render(App* appInstance) {
     bool playlist_window_is_visible = false;
 
     ImGuiViewport* viewport = ImGui::GetMainViewport();
+    if (!appInstance->m_firstFileLoaded) {
+        ImGui::SetNextWindowPos(ImVec2(viewport->WorkPos.x + viewport->WorkSize.x * 0.5f,
+                                       viewport->WorkPos.y + viewport->WorkSize.y * 0.5f),
+                               ImGuiCond_Always, ImVec2(0.5f,0.5f));
+        ImGui::SetNextWindowBgAlpha(0.0f);
+        if (ImGui::Begin("StartupScreen", nullptr, ImGuiWindowFlags_NoDecoration | ImGuiWindowFlags_NoSavedSettings | ImGuiWindowFlags_AlwaysAutoResize)) {
+            ImGui::PushStyleVar(ImGuiStyleVar_FrameRounding, 8.0f);
+            ImGui::PushStyleColor(ImGuiCol_Text, ImVec4(1.0f,1.0f,1.0f,1.0f));
+            ImGui::PushStyleColor(ImGuiCol_Button, ImVec4(60/255.0f,60/255.0f,60/255.0f,1.0f));
+            ImGui::PushStyleColor(ImGuiCol_ButtonHovered, ImVec4(80/255.0f,80/255.0f,80/255.0f,1.0f));
+            ImGui::PushStyleColor(ImGuiCol_ButtonActive, ImVec4(80/255.0f,80/255.0f,80/255.0f,1.0f));
+            if (ImGui::Button("Open or drag a MCRAW file")) {
+                appInstance->triggerOpenFileViaDialog();
+            }
+            ImGui::PopStyleColor(4);
+            ImGui::PopStyleVar();
+        }
+        ImGui::End();
+        return;
+    }
 
     if (GuiOverlay::show_playlist_aux) {
         const float initial_playlist_width = 320.0f * io.FontGlobalScale; float default_playlist_height = viewport->WorkSize.y * 0.80f;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -254,20 +254,7 @@ int main(int argc, char* argv[]) {
         LogToFile(std::string("[main] Input file from command line: ") + inPath);
         fprintf(stderr, "[main] Input file from command line: %s\n", inPath.c_str()); fflush(stderr);
     }
-    if (inPath.empty()) {
-        LogToFile("[main] No input argument or open event, opening file dialog...");
-        fprintf(stderr, "[main] No input argument or open event, opening file dialog...\n"); fflush(stderr);
-        inPath = OpenMcrawDialog();
-        if (inPath.empty()) {
-            LogToFile("[main] No input file selected or dialog cancelled. Exiting.");
-            fprintf(stderr, "[main] No input file selected or dialog cancelled. Exiting.\n"); fflush(stderr);
-            return 0;
-        }
-        LogToFile(std::string("[main] Input file from dialog: ") + inPath);
-        fprintf(stderr, "[main] Input file from dialog: %s\n", inPath.c_str()); fflush(stderr);
-    }
-
-    if (!fs::exists(inPath) || !fs::is_regular_file(inPath)) {
+    if (!inPath.empty() && (!fs::exists(inPath) || !fs::is_regular_file(inPath))) {
         std::string errorMsg = "[main] Input file not found: " + inPath;
         LogToFile(errorMsg); fprintf(stderr, "%s\n", errorMsg.c_str()); fflush(stderr);
 #ifdef _WIN32
@@ -275,7 +262,7 @@ int main(int argc, char* argv[]) {
 #endif
         return 1;
     }
-    if (fs::path(inPath).extension() != ".mcraw") {
+    if (!inPath.empty() && fs::path(inPath).extension() != ".mcraw") {
         std::string errorMsg = "[main] Input must have .mcraw extension: " + inPath;
         LogToFile(errorMsg); fprintf(stderr, "%s\n", errorMsg.c_str()); fflush(stderr);
 #ifdef _WIN32


### PR DESCRIPTION
## Summary
- allow `App` to be constructed without a file path
- skip playlist scanning and playback init unless a file is provided
- keep Ctrl+O / Ctrl+Q shortcuts working even when ImGui wants keyboard
- scan the dropped file's folder for additional `.mcraw` files
- scan folder when opening files via dialog
- show a centered "Open or drag a MCRAW file" button on startup
- clear background to dark gray before any file is loaded
- stop opening a file dialog automatically on startup

## Testing
- `cmake -S . -B build` *(fails: FATPREFIX environment variable not set)*

------
https://chatgpt.com/codex/tasks/task_e_685fc0b9403883278704746411ef4519