### PR TITLE
Add folder scan, improved shortcuts, blank startup

### DIFF
--- a/include/App.h
+++ b/include/App.h
@@ -43,7 +43,7 @@ const int MAX_FRAMES_IN_FLIGHT = 2;
 
 class App {
 public:
-    explicit App(const std::string& filePath);
+    explicit App(const std::string& filePath = "");
     ~App();
     bool run();
 

--- a/src/App.cpp
+++ b/src/App.cpp
@@ -8,6 +8,7 @@
 #include <shlwapi.h>
 #include <dwmapi.h>
 #include <commdlg.h>
+#include <shobjidl.h>
 #pragma comment(lib, "Shlwapi.lib")
 #pragma comment(lib, "dwmapi.lib")
 #pragma comment(lib, "comdlg32.lib")
@@ -17,6 +18,8 @@
 
 #ifdef _WIN32
 #include <GLFW/glfw3native.h>
+#elif defined(__APPLE__)
+#include <sys/wait.h>
 #endif
 
 #include "AudioController.h"
@@ -293,29 +296,31 @@ App::App(const std::string& filePath) : m_filePath(filePath) {
 
     LogToFile(std::string("[App::App] Constructor called for file: ") + this->m_filePath);
     std::cout << "[App::App] Constructor called for file: " << this->m_filePath << std::endl;
-    if (!fs::exists(this->m_filePath)) {
-        LogToFile(std::string("[App::App] ERROR: File does not exist: ") + this->m_filePath);
-        throw std::runtime_error("[App::App] File does not exist: " + this->m_filePath);
-    }
-    auto target = fs::absolute(this->m_filePath);
-    auto folder = target.parent_path();
-    for (const auto& e : fs::directory_iterator(folder)) {
-        if (e.is_regular_file() && e.path().extension() == ".mcraw") {
-            m_fileList.push_back(e.path().string());
+    if (!m_filePath.empty()) {
+        if (!fs::exists(this->m_filePath)) {
+            LogToFile(std::string("[App::App] ERROR: File does not exist: ") + this->m_filePath);
+            throw std::runtime_error("[App::App] File does not exist: " + this->m_filePath);
         }
-    }
-    std::sort(m_fileList.begin(), m_fileList.end());
-    auto it = std::find(m_fileList.begin(), m_fileList.end(), target.string());
-    if (it == m_fileList.end()) {
-        m_fileList.push_back(target.string());
+        auto target = fs::absolute(this->m_filePath);
+        auto folder = target.parent_path();
+        for (const auto& e : fs::directory_iterator(folder)) {
+            if (e.is_regular_file() && e.path().extension() == ".mcraw") {
+                m_fileList.push_back(e.path().string());
+            }
+        }
         std::sort(m_fileList.begin(), m_fileList.end());
-        it = std::find(m_fileList.begin(), m_fileList.end(), target.string());
+        auto it = std::find(m_fileList.begin(), m_fileList.end(), target.string());
         if (it == m_fileList.end()) {
-            LogToFile(std::string("[App::App] ERROR: Catastrophic: Initial file not in playlist: ") + this->m_filePath);
-            throw std::runtime_error("[App::App] Catastrophic: Initial file not in playlist: " + this->m_filePath);
+            m_fileList.push_back(target.string());
+            std::sort(m_fileList.begin(), m_fileList.end());
+            it = std::find(m_fileList.begin(), m_fileList.end(), target.string());
+            if (it == m_fileList.end()) {
+                LogToFile(std::string("[App::App] ERROR: Catastrophic: Initial file not in playlist: ") + this->m_filePath);
+                throw std::runtime_error("[App::App] Catastrophic: Initial file not in playlist: " + this->m_filePath);
+            }
         }
+        m_currentFileIndex = static_cast<int>(std::distance(m_fileList.begin(), it));
     }
-    m_currentFileIndex = static_cast<int>(std::distance(m_fileList.begin(), it));
     LogToFile(std::string("[App::App] Constructor finished. Current file index: ") + std::to_string(m_currentFileIndex));
     std::cout << "[App::App] Constructor finished. Current file index: " << m_currentFileIndex << std::endl;
 }
@@ -350,10 +355,17 @@ void App::framebuffer_size_callback_static(GLFWwindow* window, int width, int he
     app->m_framebufferResized = true;
 }
 void App::key_callback_static(GLFWwindow* window, int key, int scancode, int action, int mods) {
+    auto app = static_cast<App*>(glfwGetWindowUserPointer(window));
+    if (action == GLFW_PRESS || action == GLFW_REPEAT) {
+        if (app) {
+            if (key == GLFW_KEY_O && (mods & GLFW_MOD_CONTROL)) { app->triggerOpenFileViaDialog(); return; }
+            if (key == GLFW_KEY_Q && (mods & GLFW_MOD_CONTROL)) { glfwSetWindowShouldClose(window, GLFW_TRUE); return; }
+        }
+    }
     ImGuiIO& io = ImGui::GetIO();
     if (io.WantCaptureKeyboard && key != GLFW_KEY_TAB) { return; }
     if (action == GLFW_PRESS || action == GLFW_REPEAT) {
-        if (auto app = static_cast<App*>(glfwGetWindowUserPointer(window))) {
+        if (app) {
             app->handleKey(key, mods);
         }
     }
@@ -423,9 +435,9 @@ bool App::run() {
 
     LogToFile("[App::run] Initializing Vulkan...");
     std::cout << "[App::run] Initializing Vulkan..." << std::endl;
-    if (!initVulkan() || m_fileList.empty()) {
-        LogToFile("[App::run] ERROR: initVulkan() failed or file list empty. Exiting App::run().");
-        std::cerr << "[App::run] initVulkan() failed or file list empty. Exiting App::run()." << std::endl;
+    if (!initVulkan()) {
+        LogToFile("[App::run] ERROR: initVulkan() failed. Exiting App::run().");
+        std::cerr << "[App::run] initVulkan() failed. Exiting App::run()." << std::endl;
         return false;
     }
     LogToFile("[App::run] Vulkan initialized.");
@@ -465,19 +477,20 @@ bool App::run() {
     LogToFile("[App::run] ImGui Vulkan initialized.");
     std::cout << "[App::run] ImGui Vulkan initialized." << std::endl;
 
-    LogToFile("[App::run] Loading initial file...");
-    std::cout << "[App::run] Loading initial file..." << std::endl;
-    loadFileAtIndex(m_currentFileIndex);
-    m_firstFileLoaded = true;
-    LogToFile("[App::run] Initial file loaded.");
-    std::cout << "[App::run] Initial file loaded." << std::endl;
-
-    if (!m_window || !m_decoderWrapper || !m_rendererVk || !m_playbackController) {
-        LogToFile("[App::run] ERROR: Critical component missing after initial load. Exiting App::run().");
-        std::cerr << "[App::run] Critical component missing after initial load. Exiting App::run()." << std::endl;
-        if(m_rendererVk) m_rendererVk->cleanup();
-        vmaDestroyAllocator(vmaAllocator);
-        return false;
+    if (!m_fileList.empty()) {
+        LogToFile("[App::run] Loading initial file...");
+        std::cout << "[App::run] Loading initial file..." << std::endl;
+        loadFileAtIndex(m_currentFileIndex);
+        m_firstFileLoaded = true;
+        LogToFile("[App::run] Initial file loaded.");
+        std::cout << "[App::run] Initial file loaded." << std::endl;
+        if (!m_decoderWrapper || !m_playbackController) {
+            LogToFile("[App::run] ERROR: Critical component missing after initial load. Exiting App::run().");
+            std::cerr << "[App::run] Critical component missing after initial load. Exiting App::run()." << std::endl;
+            if(m_rendererVk) m_rendererVk->cleanup();
+            vmaDestroyAllocator(vmaAllocator);
+            return false;
+        }
     }
 
     LogToFile("[App::run] Entering main loop...");
@@ -496,20 +509,27 @@ bool App::run() {
         }
 #endif
 
-        bool paused = m_playbackController->isPaused();
+        bool paused = true;
         bool segment_looped_or_ended = false;
-        if (!paused) {
-            if (m_decoderWrapper && m_decoderWrapper->getDecoder()) {
-                const auto& frames = m_decoderWrapper->getDecoder()->getFrames();
-                segment_looped_or_ended = m_playbackController->updatePlayhead(steady_clock::now(), frames);
-            } else { m_playbackController->updatePlayhead(steady_clock::now(), {}); }
-        } else {
-             if (m_decoderWrapper && m_decoderWrapper->getDecoder()) {
-                m_playbackController->updatePlayhead(steady_clock::now(), m_decoderWrapper->getDecoder()->getFrames());
-            } else { m_playbackController->updatePlayhead(steady_clock::now(), {});}
+        if (m_playbackController) {
+            paused = m_playbackController->isPaused();
+            if (!paused) {
+                if (m_decoderWrapper && m_decoderWrapper->getDecoder()) {
+                    const auto& frames = m_decoderWrapper->getDecoder()->getFrames();
+                    segment_looped_or_ended = m_playbackController->updatePlayhead(steady_clock::now(), frames);
+                } else {
+                    m_playbackController->updatePlayhead(steady_clock::now(), {});
+                }
+            } else {
+                if (m_decoderWrapper && m_decoderWrapper->getDecoder()) {
+                    m_playbackController->updatePlayhead(steady_clock::now(), m_decoderWrapper->getDecoder()->getFrames());
+                } else {
+                    m_playbackController->updatePlayhead(steady_clock::now(), {});
+                }
+            }
         }
         m_sleepTimeMs = 0.0;
-        if (!m_decoderWrapper || !m_decoderWrapper->getDecoder()) {
+        if ((!m_decoderWrapper || !m_decoderWrapper->getDecoder()) && !m_fileList.empty()) {
             loadFileAtIndex(m_currentFileIndex);
             if (!m_decoderWrapper || !m_decoderWrapper->getDecoder()) {
                  LogToFile("[App::run] ERROR: Decoder became invalid in main loop. Breaking.");
@@ -523,12 +543,12 @@ bool App::run() {
         auto t1_render_submit = steady_clock::now();
         m_renderSubmitTimeMs = std::chrono::duration<double, std::milli>(t1_render_submit - t0_render_submit).count();
 
-        if (m_audio && !paused && m_playbackController->getFirstFrameMediaTimestampOfSegment()) {
+        if (m_audio && m_playbackController && !paused && m_playbackController->getFirstFrameMediaTimestampOfSegment()) {
             auto elapsed = std::chrono::duration_cast<std::chrono::nanoseconds>(steady_clock::now() - m_playbackStartTime).count();
             m_audio->updatePlayback(elapsed);
         }
 
-        if (!paused && segment_looped_or_ended) {
+        if (m_playbackController && !paused && segment_looped_or_ended) {
             if (m_fileList.size() > 1) {
                 loadFileAtIndex((m_currentFileIndex + 1) % (int)m_fileList.size());
             } else {
@@ -1305,6 +1325,9 @@ void App::drawFrame() {
     renderPassInfo.renderArea.offset = {0, 0};
     renderPassInfo.renderArea.extent = m_swapChainExtent;
     VkClearValue clearColor = { {{0.05f, 0.05f, 0.05f, 1.0f}} };
+    if (!m_firstFileLoaded) {
+        clearColor = { {{40.0f/255.0f, 40.0f/255.0f, 40.0f/255.0f, 1.0f}} };
+    }
     renderPassInfo.clearValueCount = 1;
     renderPassInfo.pClearValues = &clearColor;
 
@@ -1750,24 +1773,81 @@ void App::handleCursorPos(double xpos, double ypos) {
     }
 }
 std::string App::openMcrawDialog() {
-#ifdef _WIN32
-    OPENFILENAMEW ofn{}; wchar_t szFile[MAX_PATH] = {0}; ofn.lStructSize = sizeof(ofn);
-    GLFWwindow* currentCtx = glfwGetCurrentContext();
-    ofn.hwndOwner = currentCtx ? glfwGetWin32Window(currentCtx) : NULL;
-    ofn.lpstrFilter = L"MotionCam RAW files\0*.mcraw\0All Files\0*.*\0"; ofn.lpstrFile = szFile; ofn.nMaxFile = MAX_PATH;
-    ofn.Flags = OFN_FILEMUSTEXIST | OFN_PATHMUSTEXIST | OFN_NOCHANGEDIR; ofn.lpstrDefExt = L"mcraw";
-    if (GetOpenFileNameW(&ofn)) { char buf[MAX_PATH]; WideCharToMultiByte(CP_UTF8, 0, szFile, -1, buf, MAX_PATH, nullptr, nullptr); return std::string(buf); }
+#if defined(_WIN32)
+    HRESULT hr = CoInitializeEx(NULL, COINIT_APARTMENTTHREADED | COINIT_DISABLE_OLE1DDE);
+    std::string path;
+    if (SUCCEEDED(hr)) {
+        IFileOpenDialog* dlg = nullptr;
+        if (SUCCEEDED(CoCreateInstance(CLSID_FileOpenDialog, NULL, CLSCTX_ALL, IID_IFileOpenDialog, (void**)&dlg))) {
+            const COMDLG_FILTERSPEC filter[] = { { L"MotionCam RAW", L"*.mcraw" } };
+            dlg->SetFileTypes(1, filter);
+            HWND owner = NULL;
+            if (m_window) owner = glfwGetWin32Window(m_window);
+            if (SUCCEEDED(dlg->Show(owner))) {
+                IShellItem* item = nullptr;
+                if (SUCCEEDED(dlg->GetResult(&item))) {
+                    PWSTR wpath = nullptr;
+                    if (SUCCEEDED(item->GetDisplayName(SIGDN_FILESYSPATH, &wpath))) {
+                        int n = WideCharToMultiByte(CP_UTF8, 0, wpath, -1, nullptr, 0, nullptr, nullptr);
+                        if (n > 0) {
+                            std::vector<char> buf(n);
+                            WideCharToMultiByte(CP_UTF8, 0, wpath, -1, buf.data(), n, nullptr, nullptr);
+                            path = buf.data();
+                        }
+                        CoTaskMemFree(wpath);
+                    }
+                    if (item) item->Release();
+                }
+            }
+            if (dlg) dlg->Release();
+        }
+        CoUninitialize();
+    }
+    return path;
+#elif defined(__APPLE__)
+    const char* cmd = "osascript -e 'set f to choose file of type {\"mcraw\"} with prompt \"Select MotionCam RAW file\"' -e 'POSIX path of f'";
+    FILE* pipe = popen(cmd, "r");
+    if (!pipe) return {};
+    char buf[1024];
+    std::string path;
+    if (fgets(buf, sizeof(buf), pipe)) {
+        path = buf;
+        if (!path.empty() && path.back() == '\n') path.pop_back();
+    }
+    int status = pclose(pipe);
+    if (status == -1 || (WIFEXITED(status) && WEXITSTATUS(status) != 0)) {
+        path.clear();
+    }
+    return path;
 #else
     std::cerr << "File dialog not implemented for this platform. Drag-and-drop or use command line." << std::endl;
-#endif
     return {};
+#endif
 }
 void App::triggerOpenFileViaDialog() {
     std::string newPath = openMcrawDialog();
     if (!newPath.empty()) {
-        auto it_existing = std::find(m_fileList.begin(), m_fileList.end(), newPath);
-        if (it_existing == m_fileList.end()) { m_fileList.push_back(newPath); std::sort(m_fileList.begin(), m_fileList.end()); it_existing = std::find(m_fileList.begin(), m_fileList.end(), newPath); }
-        if (it_existing != m_fileList.end()) { m_firstFileLoaded = false; loadFileAtIndex(static_cast<int>(std::distance(m_fileList.begin(), it_existing))); m_firstFileLoaded = true; }
+        fs::path absPath = fs::absolute(newPath);
+        fs::path dir = absPath.parent_path();
+        bool modified = false;
+        try {
+            for (const auto& e : fs::directory_iterator(dir)) {
+                if (e.is_regular_file() && e.path().extension() == ".mcraw") {
+                    std::string s = e.path().string();
+                    if (std::find(m_fileList.begin(), m_fileList.end(), s) == m_fileList.end()) {
+                        m_fileList.push_back(s);
+                        modified = true;
+                    }
+                }
+            }
+        } catch (const fs::filesystem_error&) {}
+        if (modified) std::sort(m_fileList.begin(), m_fileList.end());
+        auto it_existing = std::find(m_fileList.begin(), m_fileList.end(), absPath.string());
+        if (it_existing != m_fileList.end()) {
+            m_firstFileLoaded = false;
+            loadFileAtIndex(static_cast<int>(std::distance(m_fileList.begin(), it_existing)));
+            m_firstFileLoaded = true;
+        }
     }
 }
 void App::recordPauseTime() { m_pauseBegan = std::chrono::steady_clock::now(); }
@@ -1793,11 +1873,44 @@ void App::anchorPlaybackTimeForResume() {
     }
 }
 void App::handleDrop(int count, const char** paths) {
-    if (count <= 0) return; std::string firstValidPathDropped; bool newFilesAddedToPlaylist = false;
-    for (int i = 0; i < count; ++i) { if (paths[i] == nullptr) continue; try { fs::path p = fs::absolute(paths[i]); if (p.extension() == ".mcraw" && fs::is_regular_file(p)) { std::string s = p.string(); if (firstValidPathDropped.empty()) { firstValidPathDropped = s; } if (std::find(m_fileList.begin(), m_fileList.end(), s) == m_fileList.end()) { m_fileList.push_back(s); newFilesAddedToPlaylist = true; } } } catch (const fs::filesystem_error&) {} }
-    if (newFilesAddedToPlaylist) { std::sort(m_fileList.begin(), m_fileList.end()); }
-    if (!firstValidPathDropped.empty()) { auto it = std::find(m_fileList.begin(), m_fileList.end(), firstValidPathDropped); if (it != m_fileList.end()) { m_firstFileLoaded = false; loadFileAtIndex(static_cast<int>(std::distance(m_fileList.begin(), it))); m_firstFileLoaded = true; } }
+    if (count <= 0) return;
+    std::string firstPath;
+    fs::path scanDir;
+    for (int i = 0; i < count; ++i) {
+        if (!paths[i]) continue;
+        try {
+            fs::path p = fs::absolute(paths[i]);
+            if (p.extension() == ".mcraw" && fs::is_regular_file(p)) {
+                if (firstPath.empty()) {
+                    firstPath = p.string();
+                    scanDir = p.parent_path();
+                }
+            }
+        } catch (const fs::filesystem_error&) {}
+    }
+    bool modified = false;
+    if (!firstPath.empty()) {
+        try {
+            for (const auto& e : fs::directory_iterator(scanDir)) {
+                if (e.is_regular_file() && e.path().extension() == ".mcraw") {
+                    std::string s = e.path().string();
+                    if (std::find(m_fileList.begin(), m_fileList.end(), s) == m_fileList.end()) {
+                        m_fileList.push_back(s);
+                        modified = true;
+                    }
+                }
+            }
+        } catch (const fs::filesystem_error&) {}
+        if (modified) std::sort(m_fileList.begin(), m_fileList.end());
+        auto it = std::find(m_fileList.begin(), m_fileList.end(), firstPath);
+        if (it != m_fileList.end()) {
+            m_firstFileLoaded = false;
+            loadFileAtIndex(static_cast<int>(std::distance(m_fileList.begin(), it)));
+            m_firstFileLoaded = true;
+        }
+    }
 }
+
 void App::softDeleteCurrentFile() {
     if (m_fileList.empty() || m_currentFileIndex < 0 || static_cast<size_t>(m_currentFileIndex) >= m_fileList.size()) return;
     fs::path currentFilePath = m_fileList[m_currentFileIndex];

--- a/src/GuiOverlay.cpp
+++ b/src/GuiOverlay.cpp
@@ -307,6 +307,24 @@ void GuiOverlay::render(App* appInstance) {
 
     ImGuiViewport* viewport = ImGui::GetMainViewport();
 
+    if (!appInstance->m_firstFileLoaded) {
+        ImVec2 center = ImVec2(viewport->WorkPos.x + viewport->WorkSize.x * 0.5f,
+                               viewport->WorkPos.y + viewport->WorkSize.y * 0.5f);
+        ImGui::SetNextWindowPos(center, ImGuiCond_Always, ImVec2(0.5f, 0.5f));
+        ImGui::SetNextWindowBgAlpha(0.0f);
+        ImGui::Begin("STARTUP_SCREEN", nullptr, ImGuiWindowFlags_NoDecoration | ImGuiWindowFlags_NoMove | ImGuiWindowFlags_NoSavedSettings);
+        ImGui::PushStyleVar(ImGuiStyleVar_FrameRounding, 8.0f);
+        ImGui::PushStyleColor(ImGuiCol_Button, ImVec4(60/255.0f,60/255.0f,60/255.0f,1.0f));
+        ImGui::PushStyleColor(ImGuiCol_ButtonHovered, ImVec4(80/255.0f,80/255.0f,80/255.0f,1.0f));
+        ImGui::PushStyleColor(ImGuiCol_ButtonActive, ImVec4(80/255.0f,80/255.0f,80/255.0f,1.0f));
+        ImGui::PushStyleColor(ImGuiCol_Text, ImVec4(1.0f,1.0f,1.0f,1.0f));
+        if (ImGui::Button("Open or drag a MCRAW file")) { appInstance->triggerOpenFileViaDialog(); }
+        ImGui::PopStyleColor(4);
+        ImGui::PopStyleVar();
+        ImGui::End();
+        return;
+    }
+
     if (GuiOverlay::show_playlist_aux) {
         const float initial_playlist_width = 320.0f * io.FontGlobalScale; float default_playlist_height = viewport->WorkSize.y * 0.80f;
         ImGui::SetNextWindowPos(ImVec2(viewport->WorkPos.x + viewport->WorkSize.x - initial_playlist_width - style.WindowPadding.x, viewport->WorkPos.y + style.WindowPadding.y), ImGuiCond_Appearing);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -254,20 +254,7 @@ int main(int argc, char* argv[]) {
         LogToFile(std::string("[main] Input file from command line: ") + inPath);
         fprintf(stderr, "[main] Input file from command line: %s\n", inPath.c_str()); fflush(stderr);
     }
-    if (inPath.empty()) {
-        LogToFile("[main] No input argument or open event, opening file dialog...");
-        fprintf(stderr, "[main] No input argument or open event, opening file dialog...\n"); fflush(stderr);
-        inPath = OpenMcrawDialog();
-        if (inPath.empty()) {
-            LogToFile("[main] No input file selected or dialog cancelled. Exiting.");
-            fprintf(stderr, "[main] No input file selected or dialog cancelled. Exiting.\n"); fflush(stderr);
-            return 0;
-        }
-        LogToFile(std::string("[main] Input file from dialog: ") + inPath);
-        fprintf(stderr, "[main] Input file from dialog: %s\n", inPath.c_str()); fflush(stderr);
-    }
-
-    if (!fs::exists(inPath) || !fs::is_regular_file(inPath)) {
+    if (!inPath.empty() && (!fs::exists(inPath) || !fs::is_regular_file(inPath))) {
         std::string errorMsg = "[main] Input file not found: " + inPath;
         LogToFile(errorMsg); fprintf(stderr, "%s\n", errorMsg.c_str()); fflush(stderr);
 #ifdef _WIN32
@@ -275,7 +262,7 @@ int main(int argc, char* argv[]) {
 #endif
         return 1;
     }
-    if (fs::path(inPath).extension() != ".mcraw") {
+    if (!inPath.empty() && fs::path(inPath).extension() != ".mcraw") {
         std::string errorMsg = "[main] Input must have .mcraw extension: " + inPath;
         LogToFile(errorMsg); fprintf(stderr, "%s\n", errorMsg.c_str()); fflush(stderr);
 #ifdef _WIN32
@@ -285,7 +272,7 @@ int main(int argc, char* argv[]) {
     }
 
     LogToFile(std::string("[main] Initializing App with file: ") + inPath);
-    fprintf(stderr, "[main] Initializing App with file: %s\n", inPath.c_str()); fflush(stderr);
+    if(!inPath.empty()) fprintf(stderr, "[main] Initializing App with file: %s\n", inPath.c_str());
     try {
         App app(inPath);
         LogToFile("[main] App object created. Calling app.run()...");


### PR DESCRIPTION
## Summary
- allow starting the app with no initial file
- scan folder for playlist when opening or dragging files
- update keyboard callback for Ctrl+O/Ctrl+Q regardless of ImGui focus
- show startup button when no file loaded
- adjust clear color for blank screen and startup handling
- parse optional file path from command line
- fix missing closing brace after handleDrop
- fix open dialog on macOS/Windows and hide controls until a file is loaded

## Testing
- `cmake ..` *(fails: FATPREFIX not set)*

------
https://chatgpt.com/codex/tasks/task_e_686007dd235483279daf0719a2b860ba