### PR TITLE
Improve right-click menu behavior

### DIFF
--- a/include/App.h
+++ b/include/App.h
@@ -129,6 +129,7 @@ public:
     void saveCurrentFrameAsDng();
     void convertCurrentFileToDngs();
     void sendCurrentFileToMotionCamFuse();
+    void sendPlaylistToMotionCamFuse();
 
     static void framebuffer_size_callback_static(GLFWwindow* window, int w, int h);
     static void key_callback_static(GLFWwindow* window, int key, int scancode, int action, int mods);

--- a/src/App.cpp
+++ b/src/App.cpp
@@ -1756,8 +1756,10 @@ void App::handleKey(int key, int mods) {
 
 void App::handleMouseButton(int button, int action, int mods) {
     if (button == GLFW_MOUSE_BUTTON_RIGHT && action == GLFW_PRESS) {
-        double cx, cy; glfwGetCursorPos(m_window, &cx, &cy);
-        GuiOverlay::requestContextMenu(static_cast<float>(cx), static_cast<float>(cy));
+        if (m_firstFileLoaded) {
+            double cx, cy; glfwGetCursorPos(m_window, &cx, &cy);
+            GuiOverlay::requestContextMenu(static_cast<float>(cx), static_cast<float>(cy));
+        }
         return;
     }
     if (!m_rendererVk || !m_playbackController || !m_playbackController->isZoomNativePixels()) { if(m_isPanning){ m_isPanning=false; } return; }
@@ -1994,6 +1996,25 @@ void App::sendCurrentFileToMotionCamFuse() {
         return;
     }
     std::string cmd = std::string("/usr/bin/open -na \"MotionCam Fuse\" --args -f \"") + m_fileList[m_currentFileIndex] + "\"";
+    int ret = std::system(cmd.c_str());
+    if (ret != 0) {
+        std::cerr << "MotionCam Fuse: launch failed." << std::endl;
+    }
+#else
+    std::cerr << "MotionCam Fuse integration is only available on macOS." << std::endl;
+#endif
+}
+
+void App::sendPlaylistToMotionCamFuse() {
+#ifdef __APPLE__
+    if (m_fileList.empty()) {
+        std::cerr << "MotionCam Fuse: Playlist empty." << std::endl;
+        return;
+    }
+    std::string cmd = "/usr/bin/open -na \"MotionCam Fuse\" --args";
+    for (const auto& f : m_fileList) {
+        cmd += " -f \"" + f + "\"";
+    }
     int ret = std::system(cmd.c_str());
     if (ret != 0) {
         std::cerr << "MotionCam Fuse: launch failed." << std::endl;

--- a/src/GuiOverlay.cpp
+++ b/src/GuiOverlay.cpp
@@ -297,8 +297,19 @@ void GuiOverlay::render(App* appInstance) {
         g_show_context_menu = false;
     }
     if (ImGui::BeginPopup("RIGHT_CLICK_MENU")) {
-        if (ImGui::MenuItem("Save frame as DNG")) { appInstance->saveCurrentFrameAsDng(); }
-        if (ImGui::MenuItem("Send to MotionCam Fuse")) { appInstance->sendCurrentFileToMotionCamFuse(); }
+        if (ImGui::MenuItem("Save Current Frame as DNG")) {
+            appInstance->saveCurrentFrameAsDng();
+        }
+        std::string deleteLabel = std::string("Soft Delete \"") + ui.currentFileName + "\"";
+        if (ImGui::MenuItem(deleteLabel.c_str())) {
+            appInstance->softDeleteCurrentFile();
+        }
+        if (ImGui::MenuItem("Send Current mcraw to MotionCam Fuse")) {
+            appInstance->sendCurrentFileToMotionCamFuse();
+        }
+        if (ImGui::MenuItem("Send All Playlist to MotionCam Fuse")) {
+            appInstance->sendPlaylistToMotionCamFuse();
+        }
         ImGui::EndPopup();
     }
 


### PR DESCRIPTION
## Summary
- disable context menu when no file is loaded
- expand right-click menu with file management options
- allow sending entire playlist to MotionCam Fuse

## Testing
- `cmake ..` *(fails: FATPREFIX environment variable not set)*

------
https://chatgpt.com/codex/tasks/task_e_6860e448c4848327bd73fd04f889471d