### PR TITLE
Update fuse path and tidy logs

### DIFF
--- a/src/App/AppIO.cpp
+++ b/src/App/AppIO.cpp
@@ -1021,18 +1021,18 @@ void App::sendCurrentFileToMotionCamFS()
     GetModuleFileNameA(nullptr, modulePathChars, MAX_PATH);
     fs::path currentExePath(modulePathChars);
     motionCamFsExePath =
-        (currentExePath.parent_path() / "MotionCam Fuse.exe").string();
+        (currentExePath.parent_path() / ".." / "Fuse" / "MotionCamFuse.exe").string();
 #else
     char result[PATH_MAX];
     ssize_t count = readlink("/proc/self/exe", result, PATH_MAX);
     fs::path currentExePath = (count > 0) ? fs::path(std::string(result, count)) : fs::path("");
 
-    fs::path nearby_exe = currentExePath.parent_path() / "MotionCam Fuse";
+    fs::path nearby_exe = currentExePath.parent_path() / ".." / "Fuse" / "MotionCamFuse";
     if (fs::exists(nearby_exe)) {
         motionCamFsExePath = nearby_exe.string();
     }
     else {
-        motionCamFsExePath = "MotionCam Fuse"; // Try PATH
+        motionCamFsExePath = "MotionCamFuse"; // Try PATH
     }
 #endif
 
@@ -1092,18 +1092,18 @@ void App::sendAllPlaylistFilesToMotionCamFS()
     GetModuleFileNameA(nullptr, modulePathChars, MAX_PATH);
     fs::path exeDir(modulePathChars);
     motionCamFsExePath =
-        (exeDir.parent_path() / "MotionCam Fuse.exe").string();
+        (exeDir.parent_path() / ".." / "Fuse" / "MotionCamFuse.exe").string();
 #else
     char result[PATH_MAX];
     ssize_t count = readlink("/proc/self/exe", result, PATH_MAX);
     fs::path currentExePath = (count > 0) ? fs::path(std::string(result, count)) : fs::path("");
 
-    fs::path nearby_exe = currentExePath.parent_path() / "MotionCam Fuse";
+    fs::path nearby_exe = currentExePath.parent_path() / ".." / "Fuse" / "MotionCamFuse";
     if (fs::exists(nearby_exe)) {
         motionCamFsExePath = nearby_exe.string();
     }
     else {
-        motionCamFsExePath = "MotionCam Fuse"; // Try PATH
+        motionCamFsExePath = "MotionCamFuse"; // Try PATH
     }
 #endif
 

--- a/src/Graphics/Renderer_VK.cpp
+++ b/src/Graphics/Renderer_VK.cpp
@@ -254,11 +254,8 @@ void Renderer_VK::prepareAndUploadFrameData(
         frameOrientVal,
         frameMetadata.value("flipped", containerFlipped),
         defaultOrientation);
-    LogToFile(std::string("[Renderer_VK::prepareAndUploadFrameData] Raw frame orientation value: ") +
-        (frameOrientVal.is_null() ? "null" : frameOrientVal.dump()));
     ubo.orientationDegrees = orientationDegreesFromTag(tag);
     m_currentOrientationDegrees = ubo.orientationDegrees;
-    LogToFile(std::string("[Renderer_VK::prepareAndUploadFrameData] Orientation degrees: ") + std::to_string(ubo.orientationDegrees));
 
     updateUniformBuffer(uboBindingIndex, ubo);
 }

--- a/src/Gui/GuiSetup.cpp
+++ b/src/Gui/GuiSetup.cpp
@@ -13,8 +13,9 @@
 #include <imgui_impl_glfw.h>
 #include <imgui_impl_vulkan.h>
 
-#include <GLFW/glfw3.h> 
-#include <vulkan/vulkan.h>  
+#include <GLFW/glfw3.h>
+#include <vulkan/vulkan.h>
+#include <filesystem>
 #include <cstdio> // For fprintf, abort
 
 // For App::QueueFamilyIndices, if not fully defined in App.h
@@ -22,11 +23,21 @@
 
 namespace GuiOverlay {
 
+    // Hold persistent path for ImGui ini file
+    static std::string g_ImGuiIniPath;
+
+    // Access application's base path from main.cpp
+    extern std::string g_AppBasePath;
+
     void setup(GLFWwindow* window, App* appInstance) {
         IMGUI_CHECKVERSION();
         ImGui::CreateContext();
         ImGuiIO& io = ImGui::GetIO(); (void)io;
         io.ConfigFlags |= ImGuiConfigFlags_NavEnableKeyboard; // Enable Keyboard Controls
+
+        // Explicitly set ini file location so it stays in the application folder
+        g_ImGuiIniPath = (std::filesystem::path(g_AppBasePath) / "imgui.ini").string();
+        io.IniFilename = g_ImGuiIniPath.c_str();
 
         // Load fonts and apply custom style
         GuiStyles::LoadFonts(io); // This will populate GuiStyles::G_TextFont etc.


### PR DESCRIPTION
## Summary
- locate `MotionCamFuse.exe` in `../Fuse/`
- keep `imgui.ini` in the application directory
- drop verbose orientation logging

## Testing
- `cmake ..`
- `cmake --build .` *(fails: GL/gl.h not found)*

------
https://chatgpt.com/codex/tasks/task_e_6865205531108327b242c2d9b625bb56