### PR TITLE
Fix GPU buffer sync on non-coherent memory

### DIFF
--- a/src/App/AppDecode.cpp
+++ b/src/App/AppDecode.cpp
@@ -111,6 +111,9 @@ void App::decodeWorkerLoop() {
                         decodeSuccess = false;
                     }
                 }
+
+                // Flush writes to the staging buffer in case the memory is not HOST_COHERENT
+                vmaFlushAllocation(m_vmaAllocator, m_persistentStagingBuffers[stagingIdx].allocation, 0, VK_WHOLE_SIZE);
             }
         }
         catch (const std::exception& e) {


### PR DESCRIPTION
## Summary
- flush persistent staging buffers after decoding

## Testing
- `cmake ..`
- `cmake --build . -j $(nproc)` *(fails: `GL/gl.h` missing)*

------
https://chatgpt.com/codex/tasks/task_e_686528f532248327b789492bc3cb742c