### PR TITLE
Fix missing vertex stage flag for UBO

### DIFF
--- a/src/Graphics/Descriptor.cpp
+++ b/src/Graphics/Descriptor.cpp
@@ -20,7 +20,9 @@ namespace Descriptor {
         uboLayoutBinding.binding = 1;
         uboLayoutBinding.descriptorType = VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER;
         uboLayoutBinding.descriptorCount = 1;
-        uboLayoutBinding.stageFlags = VK_SHADER_STAGE_FRAGMENT_BIT;
+        // The UBO is read in both the vertex and fragment shaders, so include
+        // both stages to avoid descriptor validation errors on some drivers.
+        uboLayoutBinding.stageFlags = VK_SHADER_STAGE_VERTEX_BIT | VK_SHADER_STAGE_FRAGMENT_BIT;
         uboLayoutBinding.pImmutableSamplers = nullptr;
 
         std::array<VkDescriptorSetLayoutBinding, 2> bindings = { samplerLayoutBinding, uboLayoutBinding };


### PR DESCRIPTION
## Summary
- expand UBO layout stage flags to include vertex stage

## Testing
- `cmake -S . -B build`
- `cmake --build build -j2` *(fails: GL/gl.h: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68654f4c88d48327815e41c8756fb500