### PR TITLE
Place debug log in Logs folder

### DIFF
--- a/src/Utils/DebugLog.cpp
+++ b/src/Utils/DebugLog.cpp
@@ -5,14 +5,34 @@
 #include <fstream>
 #include <iomanip>
 #include <sstream>
-#include <mutex> // For thread-safe logging
+#include <mutex>   // For thread-safe logging
+#include <string>
+#include <filesystem>
 
 static std::mutex g_log_mutex; // Mutex to protect file access
+
+// Application base path defined in main.cpp
+extern std::string g_AppBasePath;
+
+// Helper function to lazily open the log file in a Logs directory
+static std::ofstream& get_log_file() {
+    static std::ofstream log_file;
+    static bool initialized = false;
+    if (!initialized) {
+        std::filesystem::path logDir = std::filesystem::path(g_AppBasePath) / "Logs";
+        std::error_code ec;
+        std::filesystem::create_directories(logDir, ec); // Ignore errors, file open will fail if directory can't be created
+        std::filesystem::path logPath = logDir / "motioncam_player_log.txt";
+        log_file.open(logPath, std::ios_base::app | std::ios_base::out);
+        initialized = true;
+    }
+    return log_file;
+}
 
 void LogToFile(const std::string& message) {
     std::lock_guard<std::mutex> lock(g_log_mutex); // Lock for thread safety
 
-    static std::ofstream log_file("motioncam_player_log.txt", std::ios_base::app | std::ios_base::out);
+    std::ofstream& log_file = get_log_file();
 
     if (log_file.is_open()) {
         auto now = std::chrono::system_clock::now();


### PR DESCRIPTION
## Summary
- write debug log to a `Logs` folder beside the executable

## Testing
- `cmake --build build` *(fails: `GL/gl.h` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68657e673f5883279f1b8c34a05b2e3a