### PR TITLE
Add cross-platform ProRes export

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,28 @@
+# MotionCam Player
+
+This project builds a desktop viewer for `.mcraw` files recorded by MotionCam Pro.
+
+## Building
+
+The project uses CMake and requires a Vulkan SDK, SDL2, GLFW, and FFmpeg installed.
+
+Example build steps:
+
+```bash
+mkdir build && cd build
+cmake ..
+cmake --build .
+```
+
+### FFmpeg
+
+`convertCurrentFileToProRes()` spawns the `ffmpeg` executable to encode ProRes videos. Ensure a recent FFmpeg is available in your `PATH`. On Windows the tool writes video and audio to named pipes which FFmpeg reads from. The command invoked is roughly:
+
+```
+ffmpeg -y -f rawvideo -pix_fmt rgba -s WxH -r <fps> -i - \
+       -f s16le -ar <sampleRate> -ac <channels> -i - \
+       -c:v prores_ks output.mov
+```
+
+FFmpeg 4.0 or newer is recommended.
+

--- a/include/App/App.h
+++ b/include/App/App.h
@@ -111,6 +111,7 @@ public:
     void toggleHelpPage() { m_showHelpPage = !m_showHelpPage; }
     void saveCurrentFrameAsDng();
     void convertCurrentFileToDngs();
+    void convertCurrentFileToProRes();
     void performSeek(size_t new_frame_index);
     void triggerOpenFileViaDialog();
 	void setPlaybackMode(PlaybackController::PlaybackMode mode);

--- a/src/App/AppIO.cpp
+++ b/src/App/AppIO.cpp
@@ -25,6 +25,13 @@
 #include <cmath>
 #include <cstdio>
 #include <sstream>
+#include <locale>
+#include <codecvt>
+#ifndef _WIN32
+#include <unistd.h>
+#include <sys/wait.h>
+#endif
+#include <thread>
 
 namespace fs = std::filesystem;
 
@@ -993,6 +1000,216 @@ void App::convertCurrentFileToDngs() {
 
     LogToFile(std::string("[App::convertCurrentFileToDngs] Conversion complete for ") + currentMcrawPathStr + ". Success: " + std::to_string(successCount) + ", Failed: " + std::to_string(failCount));
 
+    if (m_playbackController_ptr && m_playbackController_ptr->isPaused() && !wasPausedOriginalState) {
+        m_playbackController_ptr->togglePause();
+        if (m_audio) m_audio->setPaused(false);
+        anchorPlaybackTimeForResume();
+    }
+}
+
+void App::convertCurrentFileToProRes() {
+    if (!m_decoderWrapper_ptr || !m_decoderWrapper_ptr->getDecoder() ||
+        m_fileList.empty() || m_currentFileIndex < 0 ||
+        static_cast<size_t>(m_currentFileIndex) >= m_fileList.size()) {
+        LogToFile("[App::convertCurrentFileToProRes] Conditions not met for export.");
+        return;
+    }
+
+    std::string currentMcrawPathStr = m_fileList[m_currentFileIndex];
+    fs::path currentMcrawPath = currentMcrawPathStr;
+    fs::path outputMovPath = currentMcrawPath.parent_path() /
+        (currentMcrawPath.stem().string() + ".mov");
+
+    auto* decoder = m_decoderWrapper_ptr->getDecoder();
+    const auto& frameTimestamps = decoder->getFrames();
+    if (frameTimestamps.empty()) {
+        LogToFile("[App::convertCurrentFileToProRes] No frames to convert.");
+        return;
+    }
+
+    RawBytes tempFrame; nlohmann::json firstMeta;
+    decoder->loadFrame(frameTimestamps[0], tempFrame, firstMeta);
+    int width = firstMeta.value("width", 0);
+    int height = firstMeta.value("height", 0);
+    double fps = 30.0;
+    if (frameTimestamps.size() >= 2) {
+        int64_t diff = frameTimestamps[1] - frameTimestamps[0];
+        if (diff > 0) fps = 1e9 / static_cast<double>(diff);
+    }
+
+    int sampleRate = decoder->audioSampleRateHz();
+    int channels = decoder->numAudioChannels();
+
+    LogToFile(std::string("[App::convertCurrentFileToProRes] Starting conversion for ") +
+              currentMcrawPathStr);
+    bool wasPausedOriginalState = true;
+    if (m_playbackController_ptr) {
+        wasPausedOriginalState = m_playbackController_ptr->isPaused();
+        if (!wasPausedOriginalState) {
+            m_playbackController_ptr->togglePause();
+            if (m_audio) m_audio->setPaused(true);
+            recordPauseTime();
+        }
+    }
+
+#ifndef _WIN32
+    int videoPipe[2];
+    int audioPipe[2];
+    if (pipe(videoPipe) != 0 || pipe(audioPipe) != 0) {
+        LogToFile("[App::convertCurrentFileToProRes] Failed to create pipes.");
+        return;
+    }
+
+    pid_t pid = fork();
+    if (pid == 0) {
+        dup2(videoPipe[0], 0);
+        dup2(audioPipe[0], 3);
+        close(videoPipe[0]); close(videoPipe[1]);
+        close(audioPipe[0]); close(audioPipe[1]);
+
+        char wh[64]; snprintf(wh, sizeof(wh), "%dx%d", width, height);
+        char fpsStr[32]; snprintf(fpsStr, sizeof(fpsStr), "%f", fps);
+        char srStr[32]; snprintf(srStr, sizeof(srStr), "%d", sampleRate);
+        char chStr[32]; snprintf(chStr, sizeof(chStr), "%d", channels);
+
+        execlp("ffmpeg", "ffmpeg", "-y",
+               "-f", "rawvideo", "-pix_fmt", "rgba", "-s", wh, "-r", fpsStr, "-i", "pipe:0",
+               "-f", "s16le", "-ar", srStr, "-ac", chStr, "-i", "pipe:3",
+               "-c:v", "prores_ks", outputMovPath.string().c_str(), (char*)nullptr);
+        _exit(1);
+    }
+
+    close(videoPipe[0]);
+    close(audioPipe[0]);
+    FILE* videoFp = fdopen(videoPipe[1], "wb");
+    FILE* audioFp = fdopen(audioPipe[1], "wb");
+
+    auto audioWriter = std::thread([&]() {
+        motioncam::AudioChunkLoader& loader = decoder->loadAudio();
+        motioncam::AudioChunk chunk;
+        while (loader.next(chunk)) {
+            if (!chunk.second.empty()) {
+                fwrite(chunk.second.data(), sizeof(int16_t), chunk.second.size(), audioFp);
+            }
+        }
+        fclose(audioFp);
+    });
+
+    std::vector<uint8_t> rgba(width * height * 4);
+    for (size_t i = 0; i < frameTimestamps.size(); ++i) {
+        if (m_window && glfwWindowShouldClose(m_window)) {
+            LogToFile("[App::convertCurrentFileToProRes] Export interrupted by window close request.");
+            break;
+        }
+        glfwPollEvents();
+
+        RawBytes raw; nlohmann::json meta;
+        decoder->loadFrame(frameTimestamps[i], raw, meta);
+        const uint16_t* src = asU16(raw);
+        for (size_t p = 0; p < static_cast<size_t>(width) * height; ++p) {
+            uint8_t v = static_cast<uint8_t>(src[p] >> 8);
+            rgba[p * 4 + 0] = v;
+            rgba[p * 4 + 1] = v;
+            rgba[p * 4 + 2] = v;
+            rgba[p * 4 + 3] = 255;
+        }
+        fwrite(rgba.data(), 1, rgba.size(), videoFp);
+        if ((i + 1) % 50 == 0 || i == frameTimestamps.size() - 1) {
+            LogToFile(std::string("[App::convertCurrentFileToProRes] Written ") +
+                      std::to_string(i + 1) + "/" + std::to_string(frameTimestamps.size()) + " frames");
+        }
+    }
+    fclose(videoFp);
+    audioWriter.join();
+    int status = 0; waitpid(pid, &status, 0);
+#else
+    std::wstring videoPipeName = L"\\.\pipe\mcraw_video_" + std::to_wstring(GetCurrentProcessId()) +
+                                 L"_" + std::to_wstring(GetTickCount64());
+    std::wstring audioPipeName = L"\\.\pipe\mcraw_audio_" + std::to_wstring(GetCurrentProcessId()) +
+                                 L"_" + std::to_wstring(GetTickCount64());
+
+    HANDLE videoPipe = CreateNamedPipeW(videoPipeName.c_str(), PIPE_ACCESS_OUTBOUND,
+        PIPE_TYPE_BYTE | PIPE_WAIT, 1, 0, 0, 0, nullptr);
+    HANDLE audioPipe = CreateNamedPipeW(audioPipeName.c_str(), PIPE_ACCESS_OUTBOUND,
+        PIPE_TYPE_BYTE | PIPE_WAIT, 1, 0, 0, 0, nullptr);
+    if (videoPipe == INVALID_HANDLE_VALUE || audioPipe == INVALID_HANDLE_VALUE) {
+        LogToFile("[App::convertCurrentFileToProRes] Failed to create named pipes.");
+        if (videoPipe != INVALID_HANDLE_VALUE) CloseHandle(videoPipe);
+        if (audioPipe != INVALID_HANDLE_VALUE) CloseHandle(audioPipe);
+        return;
+    }
+
+    char wh[64]; snprintf(wh, sizeof(wh), "%dx%d", width, height);
+    char fpsStr[32]; snprintf(fpsStr, sizeof(fpsStr), "%f", fps);
+    char srStr[32]; snprintf(srStr, sizeof(srStr), "%d", sampleRate);
+    char chStr[32]; snprintf(chStr, sizeof(chStr), "%d", channels);
+
+    std::wstring cmd = L"ffmpeg -y -f rawvideo -pix_fmt rgba -s " +
+        std::wstring_convert<std::codecvt_utf8<wchar_t>>().from_bytes(wh) + L" -r " +
+        std::wstring_convert<std::codecvt_utf8<wchar_t>>().from_bytes(fpsStr) + L" -i " + videoPipeName +
+        L" -f s16le -ar " + std::wstring_convert<std::codecvt_utf8<wchar_t>>().from_bytes(srStr) +
+        L" -ac " + std::wstring_convert<std::codecvt_utf8<wchar_t>>().from_bytes(chStr) +
+        L" -i " + audioPipeName + L" -c:v prores_ks \"" +
+        std::wstring_convert<std::codecvt_utf8<wchar_t>>().from_bytes(outputMovPath.string()) + L"\"";
+
+    STARTUPINFOW si{}; PROCESS_INFORMATION pi{}; si.cb = sizeof(si);
+    if (!CreateProcessW(nullptr, cmd.data(), nullptr, nullptr, FALSE,
+        CREATE_NO_WINDOW | CREATE_NEW_PROCESS_GROUP, nullptr, nullptr, &si, &pi)) {
+        LogToFile(std::string("[App::convertCurrentFileToProRes] CreateProcessW failed. Err: ") +
+                  std::to_string(GetLastError()));
+        CloseHandle(videoPipe); CloseHandle(audioPipe);
+        return;
+    }
+
+    ConnectNamedPipe(videoPipe, nullptr);
+    ConnectNamedPipe(audioPipe, nullptr);
+
+    auto audioWriter = std::thread([&]() {
+        motioncam::AudioChunkLoader* loader = m_decoderWrapper_ptr->makeFreshAudioLoader();
+        motioncam::AudioChunk chunk;
+        while (loader && loader->next(chunk)) {
+            if (!chunk.second.empty()) {
+                DWORD written = 0;
+                WriteFile(audioPipe, chunk.second.data(),
+                          static_cast<DWORD>(chunk.second.size() * sizeof(int16_t)), &written, nullptr);
+            }
+        }
+        FlushFileBuffers(audioPipe);
+        CloseHandle(audioPipe);
+    });
+
+    std::vector<uint8_t> rgba(width * height * 4);
+    for (size_t i = 0; i < frameTimestamps.size(); ++i) {
+        if (m_window && glfwWindowShouldClose(m_window)) {
+            LogToFile("[App::convertCurrentFileToProRes] Export interrupted by window close request.");
+            break;
+        }
+        glfwPollEvents();
+
+        RawBytes raw; nlohmann::json meta;
+        decoder->loadFrame(frameTimestamps[i], raw, meta);
+        const uint16_t* src = asU16(raw);
+        for (size_t p = 0; p < static_cast<size_t>(width) * height; ++p) {
+            uint8_t v = static_cast<uint8_t>(src[p] >> 8);
+            rgba[p * 4 + 0] = v;
+            rgba[p * 4 + 1] = v;
+            rgba[p * 4 + 2] = v;
+            rgba[p * 4 + 3] = 255;
+        }
+        DWORD written = 0;
+        WriteFile(videoPipe, rgba.data(), static_cast<DWORD>(rgba.size()), &written, nullptr);
+        if ((i + 1) % 50 == 0 || i == frameTimestamps.size() - 1) {
+            LogToFile(std::string("[App::convertCurrentFileToProRes] Written ") +
+                      std::to_string(i + 1) + "/" + std::to_string(frameTimestamps.size()) + " frames");
+        }
+    }
+    FlushFileBuffers(videoPipe);
+    CloseHandle(videoPipe);
+    audioWriter.join();
+    WaitForSingleObject(pi.hProcess, INFINITE);
+    CloseHandle(pi.hProcess); CloseHandle(pi.hThread);
+#endif
+    LogToFile("[App::convertCurrentFileToProRes] Conversion finished.");
     if (m_playbackController_ptr && m_playbackController_ptr->isPaused() && !wasPausedOriginalState) {
         m_playbackController_ptr->togglePause();
         if (m_audio) m_audio->setPaused(false);

--- a/src/Gui/GuiRender.cpp
+++ b/src/Gui/GuiRender.cpp
@@ -224,6 +224,9 @@ namespace GuiOverlay {
             if (ImGui::MenuItem("Save Current Frame as DNG", nullptr, false, canOperateOnCurrentFile)) {
                 if (appInstance) appInstance->saveCurrentFrameAsDng();
             }
+            if (ImGui::MenuItem("Convert Current File to ProRes", nullptr, false, canOperateOnCurrentFile)) {
+                if (appInstance) appInstance->convertCurrentFileToProRes();
+            }
             ImGui::Separator();
             if (ImGui::MenuItem("Soft Delete MCRAW", nullptr, false, canOperateOnCurrentFile)) {
                 if (appInstance) appInstance->softDeleteCurrentFile();


### PR DESCRIPTION
## Summary
- implement `convertCurrentFileToProRes` using DecoderWrapper
- stream frames/audio to ffmpeg via pipes or named pipes on Windows
- pause playback while exporting and log progress
- document named-pipe use in README

## Testing
- `cmake ..`
- `cmake --build .` *(fails: GL/gl.h missing)*

------
https://chatgpt.com/codex/tasks/task_e_686588b3b9288327b44f262af0369d8a