### PR TITLE
Improve ProRes export logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,33 @@
+# MotionCam Player
+
+This project builds a desktop viewer for `.mcraw` files recorded by MotionCam Pro.
+
+## Building
+
+The project uses CMake and requires a Vulkan SDK, SDL2, GLFW, and FFmpeg installed.
+
+Example build steps:
+
+```bash
+mkdir build && cd build
+cmake ..
+cmake --build .
+```
+
+### FFmpeg
+
+`convertCurrentFileToProRes()` spawns the `ffmpeg` executable to encode ProRes videos. Ensure a recent FFmpeg is available in your `PATH`. On Windows the tool writes video and audio to named pipes which FFmpeg reads from. The command invoked is roughly:
+
+```
+ffmpeg -y -f rawvideo -pix_fmt rgba -s WxH -r <fps> -i - \
+       -f s16le -ar <sampleRate> -ac <channels> -i - \
+       -c:v prores_ks output.mov
+```
+
+FFmpeg 4.0 or newer is recommended.
+
+### Debugging
+
+Logs are written to `Logs/motioncam_player_log.txt` next to the application.
+ProRes exports also write detailed messages to `Logs/prores_export_log.txt` including pipe setup and frame progress.
+

--- a/include/App/App.h
+++ b/include/App/App.h
@@ -111,6 +111,7 @@ public:
     void toggleHelpPage() { m_showHelpPage = !m_showHelpPage; }
     void saveCurrentFrameAsDng();
     void convertCurrentFileToDngs();
+    void convertCurrentFileToProRes();
     void performSeek(size_t new_frame_index);
     void triggerOpenFileViaDialog();
 	void setPlaybackMode(PlaybackController::PlaybackMode mode);

--- a/include/Utils/DebugLog.h
+++ b/include/Utils/DebugLog.h
@@ -1,9 +1,10 @@
-#ifndef DEBUG_LOG_H
-#define DEBUG_LOG_H
+// FILE: include/Utils/DebugLog.h
+#pragma once
 
 #include <string>
 
 // Simple file logger declaration
 void LogToFile(const std::string& message);
 
-#endif // DEBUG_LOG_H
+// Separate logger for detailed ProRes export messages
+void LogToProResFile(const std::string& message);

--- a/src/App/AppIO.cpp
+++ b/src/App/AppIO.cpp
@@ -25,6 +25,13 @@
 #include <cmath>
 #include <cstdio>
 #include <sstream>
+#include <locale>
+#include <codecvt>
+#ifndef _WIN32
+#include <unistd.h>
+#include <sys/wait.h>
+#endif
+#include <thread>
 
 namespace fs = std::filesystem;
 
@@ -993,6 +1000,236 @@ void App::convertCurrentFileToDngs() {
 
     LogToFile(std::string("[App::convertCurrentFileToDngs] Conversion complete for ") + currentMcrawPathStr + ". Success: " + std::to_string(successCount) + ", Failed: " + std::to_string(failCount));
 
+    if (m_playbackController_ptr && m_playbackController_ptr->isPaused() && !wasPausedOriginalState) {
+        m_playbackController_ptr->togglePause();
+        if (m_audio) m_audio->setPaused(false);
+        anchorPlaybackTimeForResume();
+    }
+}
+
+void App::convertCurrentFileToProRes() {
+    if (!m_decoderWrapper_ptr || !m_decoderWrapper_ptr->getDecoder() ||
+        m_fileList.empty() || m_currentFileIndex < 0 ||
+        static_cast<size_t>(m_currentFileIndex) >= m_fileList.size()) {
+        LogToProResFile("[App::convertCurrentFileToProRes] Conditions not met for export.");
+        return;
+    }
+
+    std::string currentMcrawPathStr = m_fileList[m_currentFileIndex];
+    fs::path currentMcrawPath = currentMcrawPathStr;
+    fs::path outputMovPath = currentMcrawPath.parent_path() /
+        (currentMcrawPath.stem().string() + ".mov");
+
+    auto* decoder = m_decoderWrapper_ptr->getDecoder();
+    const auto& frameTimestamps = decoder->getFrames();
+    if (frameTimestamps.empty()) {
+        LogToProResFile("[App::convertCurrentFileToProRes] No frames to convert.");
+        return;
+    }
+
+    RawBytes tempFrame; nlohmann::json firstMeta;
+    decoder->loadFrame(frameTimestamps[0], tempFrame, firstMeta);
+    int width = firstMeta.value("width", 0);
+    int height = firstMeta.value("height", 0);
+    double fps = 30.0;
+    if (frameTimestamps.size() >= 2) {
+        int64_t diff = frameTimestamps[1] - frameTimestamps[0];
+        if (diff > 0) fps = 1e9 / static_cast<double>(diff);
+    }
+
+    int sampleRate = decoder->audioSampleRateHz();
+    int channels = decoder->numAudioChannels();
+
+
+    LogToProResFile(std::string("[App::convertCurrentFileToProRes] Starting conversion for ") +
+                    currentMcrawPathStr +
+                    " -> " + outputMovPath.string());
+    LogToProResFile(std::string("Width=") + std::to_string(width) +
+                    ", Height=" + std::to_string(height) +
+                    ", FPS=" + std::to_string(fps) +
+                    ", SampleRate=" + std::to_string(sampleRate) +
+                    ", Channels=" + std::to_string(channels));
+    bool wasPausedOriginalState = true;
+    if (m_playbackController_ptr) {
+        wasPausedOriginalState = m_playbackController_ptr->isPaused();
+        if (!wasPausedOriginalState) {
+            m_playbackController_ptr->togglePause();
+            if (m_audio) m_audio->setPaused(true);
+            recordPauseTime();
+        }
+    }
+
+#ifndef _WIN32
+    int videoPipe[2];
+    int audioPipe[2];
+    if (pipe(videoPipe) != 0 || pipe(audioPipe) != 0) {
+        LogToProResFile("[App::convertCurrentFileToProRes] Failed to create pipes.");
+        return;
+    }
+
+    std::string cmdStr = std::string("ffmpeg -y -f rawvideo -pix_fmt rgba -s ") +
+        std::to_string(width) + "x" + std::to_string(height) + " -r " +
+        std::to_string(fps) + " -i pipe:0 -f s16le -ar " + std::to_string(sampleRate) +
+        " -ac " + std::to_string(channels) + " -i pipe:3 -c:v prores_ks \"" +
+        outputMovPath.string() + "\"";
+    LogToProResFile(std::string("[App::convertCurrentFileToProRes] FFmpeg command: ") + cmdStr);
+
+    pid_t pid = fork();
+    if (pid == 0) {
+        dup2(videoPipe[0], 0);
+        dup2(audioPipe[0], 3);
+        close(videoPipe[0]); close(videoPipe[1]);
+        close(audioPipe[0]); close(audioPipe[1]);
+
+        char wh[64]; snprintf(wh, sizeof(wh), "%dx%d", width, height);
+        char fpsStr[32]; snprintf(fpsStr, sizeof(fpsStr), "%f", fps);
+        char srStr[32]; snprintf(srStr, sizeof(srStr), "%d", sampleRate);
+        char chStr[32]; snprintf(chStr, sizeof(chStr), "%d", channels);
+
+        execlp("ffmpeg", "ffmpeg", "-y",
+               "-f", "rawvideo", "-pix_fmt", "rgba", "-s", wh, "-r", fpsStr, "-i", "pipe:0",
+               "-f", "s16le", "-ar", srStr, "-ac", chStr, "-i", "pipe:3",
+               "-c:v", "prores_ks", outputMovPath.string().c_str(), (char*)nullptr);
+        _exit(1);
+    }
+
+    close(videoPipe[0]);
+    close(audioPipe[0]);
+    FILE* videoFp = fdopen(videoPipe[1], "wb");
+    FILE* audioFp = fdopen(audioPipe[1], "wb");
+
+    auto audioWriter = std::thread([&]() {
+        motioncam::AudioChunkLoader& loader = decoder->loadAudio();
+        motioncam::AudioChunk chunk;
+        while (loader.next(chunk)) {
+            if (!chunk.second.empty()) {
+                fwrite(chunk.second.data(), sizeof(int16_t), chunk.second.size(), audioFp);
+            }
+        }
+        fclose(audioFp);
+    });
+
+    std::vector<uint8_t> rgba(width * height * 4);
+    for (size_t i = 0; i < frameTimestamps.size(); ++i) {
+        if (m_window && glfwWindowShouldClose(m_window)) {
+            LogToProResFile("[App::convertCurrentFileToProRes] Export interrupted by window close request.");
+            break;
+        }
+        glfwPollEvents();
+
+        RawBytes raw; nlohmann::json meta;
+        decoder->loadFrame(frameTimestamps[i], raw, meta);
+        const uint16_t* src = asU16(raw);
+        for (size_t p = 0; p < static_cast<size_t>(width) * height; ++p) {
+            uint8_t v = static_cast<uint8_t>(src[p] >> 8);
+            rgba[p * 4 + 0] = v;
+            rgba[p * 4 + 1] = v;
+            rgba[p * 4 + 2] = v;
+            rgba[p * 4 + 3] = 255;
+        }
+        fwrite(rgba.data(), 1, rgba.size(), videoFp);
+        if ((i + 1) % 50 == 0 || i == frameTimestamps.size() - 1) {
+            LogToProResFile(std::string("[App::convertCurrentFileToProRes] Written ") +
+                      std::to_string(i + 1) + "/" + std::to_string(frameTimestamps.size()) + " frames");
+        }
+    }
+    fclose(videoFp);
+    audioWriter.join();
+    int status = 0; waitpid(pid, &status, 0);
+#else
+    std::wstring videoPipeName = L"\\.\pipe\mcraw_video_" + std::to_wstring(GetCurrentProcessId()) +
+                                 L"_" + std::to_wstring(GetTickCount64());
+    std::wstring audioPipeName = L"\\.\pipe\mcraw_audio_" + std::to_wstring(GetCurrentProcessId()) +
+                                 L"_" + std::to_wstring(GetTickCount64());
+
+    constexpr DWORD PIPE_BUF_SIZE = 4096;
+    HANDLE videoPipe = CreateNamedPipeW(videoPipeName.c_str(),
+        PIPE_ACCESS_OUTBOUND | FILE_FLAG_FIRST_PIPE_INSTANCE,
+        PIPE_TYPE_BYTE | PIPE_WAIT, 1, PIPE_BUF_SIZE, PIPE_BUF_SIZE, 0, nullptr);
+    HANDLE audioPipe = CreateNamedPipeW(audioPipeName.c_str(),
+        PIPE_ACCESS_OUTBOUND | FILE_FLAG_FIRST_PIPE_INSTANCE,
+        PIPE_TYPE_BYTE | PIPE_WAIT, 1, PIPE_BUF_SIZE, PIPE_BUF_SIZE, 0, nullptr);
+    if (videoPipe == INVALID_HANDLE_VALUE || audioPipe == INVALID_HANDLE_VALUE) {
+        DWORD err = GetLastError();
+        LogToProResFile(std::string("[App::convertCurrentFileToProRes] Failed to create named pipes. Err: ") + std::to_string(err));
+        if (videoPipe != INVALID_HANDLE_VALUE) CloseHandle(videoPipe);
+        if (audioPipe != INVALID_HANDLE_VALUE) CloseHandle(audioPipe);
+        return;
+    }
+
+    char wh[64]; snprintf(wh, sizeof(wh), "%dx%d", width, height);
+    char fpsStr[32]; snprintf(fpsStr, sizeof(fpsStr), "%f", fps);
+    char srStr[32]; snprintf(srStr, sizeof(srStr), "%d", sampleRate);
+    char chStr[32]; snprintf(chStr, sizeof(chStr), "%d", channels);
+
+    std::wstring cmd = L"ffmpeg -y -f rawvideo -pix_fmt rgba -s " +
+        std::wstring_convert<std::codecvt_utf8<wchar_t>>().from_bytes(wh) + L" -r " +
+        std::wstring_convert<std::codecvt_utf8<wchar_t>>().from_bytes(fpsStr) + L" -i " + videoPipeName +
+        L" -f s16le -ar " + std::wstring_convert<std::codecvt_utf8<wchar_t>>().from_bytes(srStr) +
+        L" -ac " + std::wstring_convert<std::codecvt_utf8<wchar_t>>().from_bytes(chStr) +
+        L" -i " + audioPipeName + L" -c:v prores_ks \"" +
+        std::wstring_convert<std::codecvt_utf8<wchar_t>>().from_bytes(outputMovPath.string()) + L"\"";
+    LogToProResFile(std::string("[App::convertCurrentFileToProRes] FFmpeg command: ") +
+        std::wstring_convert<std::codecvt_utf8<wchar_t>>().to_bytes(cmd));
+
+    STARTUPINFOW si{}; PROCESS_INFORMATION pi{}; si.cb = sizeof(si);
+    if (!CreateProcessW(nullptr, cmd.data(), nullptr, nullptr, FALSE,
+        CREATE_NO_WINDOW | CREATE_NEW_PROCESS_GROUP, nullptr, nullptr, &si, &pi)) {
+        LogToProResFile(std::string("[App::convertCurrentFileToProRes] CreateProcessW failed. Err: ") +
+                        std::to_string(GetLastError()));
+        CloseHandle(videoPipe); CloseHandle(audioPipe);
+        return;
+    }
+
+    ConnectNamedPipe(videoPipe, nullptr);
+    ConnectNamedPipe(audioPipe, nullptr);
+
+    auto audioWriter = std::thread([&]() {
+        motioncam::AudioChunkLoader* loader = m_decoderWrapper_ptr->makeFreshAudioLoader();
+        motioncam::AudioChunk chunk;
+        while (loader && loader->next(chunk)) {
+            if (!chunk.second.empty()) {
+                DWORD written = 0;
+                WriteFile(audioPipe, chunk.second.data(),
+                          static_cast<DWORD>(chunk.second.size() * sizeof(int16_t)), &written, nullptr);
+            }
+        }
+        FlushFileBuffers(audioPipe);
+        CloseHandle(audioPipe);
+    });
+
+    std::vector<uint8_t> rgba(width * height * 4);
+    for (size_t i = 0; i < frameTimestamps.size(); ++i) {
+        if (m_window && glfwWindowShouldClose(m_window)) {
+            LogToProResFile("[App::convertCurrentFileToProRes] Export interrupted by window close request.");
+            break;
+        }
+        glfwPollEvents();
+
+        RawBytes raw; nlohmann::json meta;
+        decoder->loadFrame(frameTimestamps[i], raw, meta);
+        const uint16_t* src = asU16(raw);
+        for (size_t p = 0; p < static_cast<size_t>(width) * height; ++p) {
+            uint8_t v = static_cast<uint8_t>(src[p] >> 8);
+            rgba[p * 4 + 0] = v;
+            rgba[p * 4 + 1] = v;
+            rgba[p * 4 + 2] = v;
+            rgba[p * 4 + 3] = 255;
+        }
+        DWORD written = 0;
+        WriteFile(videoPipe, rgba.data(), static_cast<DWORD>(rgba.size()), &written, nullptr);
+        if ((i + 1) % 50 == 0 || i == frameTimestamps.size() - 1) {
+            LogToProResFile(std::string("[App::convertCurrentFileToProRes] Written ") +
+                      std::to_string(i + 1) + "/" + std::to_string(frameTimestamps.size()) + " frames");
+        }
+    }
+    FlushFileBuffers(videoPipe);
+    CloseHandle(videoPipe);
+    audioWriter.join();
+    WaitForSingleObject(pi.hProcess, INFINITE);
+    CloseHandle(pi.hProcess); CloseHandle(pi.hThread);
+#endif
+    LogToProResFile("[App::convertCurrentFileToProRes] Conversion finished.");
     if (m_playbackController_ptr && m_playbackController_ptr->isPaused() && !wasPausedOriginalState) {
         m_playbackController_ptr->togglePause();
         if (m_audio) m_audio->setPaused(false);

--- a/src/Gui/GuiRender.cpp
+++ b/src/Gui/GuiRender.cpp
@@ -224,6 +224,9 @@ namespace GuiOverlay {
             if (ImGui::MenuItem("Save Current Frame as DNG", nullptr, false, canOperateOnCurrentFile)) {
                 if (appInstance) appInstance->saveCurrentFrameAsDng();
             }
+            if (ImGui::MenuItem("Convert Current File to ProRes", nullptr, false, canOperateOnCurrentFile)) {
+                if (appInstance) appInstance->convertCurrentFileToProRes();
+            }
             ImGui::Separator();
             if (ImGui::MenuItem("Soft Delete MCRAW", nullptr, false, canOperateOnCurrentFile)) {
                 if (appInstance) appInstance->softDeleteCurrentFile();

--- a/src/Utils/DebugLog.cpp
+++ b/src/Utils/DebugLog.cpp
@@ -29,6 +29,21 @@ static std::ofstream& get_log_file() {
     return log_file;
 }
 
+// Helper for dedicated ProRes export logging
+static std::ofstream& get_prores_log_file() {
+    static std::ofstream log_file;
+    static bool initialized = false;
+    if (!initialized) {
+        std::filesystem::path logDir = std::filesystem::path(g_AppBasePath) / "Logs";
+        std::error_code ec;
+        std::filesystem::create_directories(logDir, ec);
+        std::filesystem::path logPath = logDir / "prores_export_log.txt";
+        log_file.open(logPath, std::ios_base::app | std::ios_base::out);
+        initialized = true;
+    }
+    return log_file;
+}
+
 void LogToFile(const std::string& message) {
     std::lock_guard<std::mutex> lock(g_log_mutex); // Lock for thread safety
 
@@ -52,5 +67,25 @@ void LogToFile(const std::string& message) {
 
         log_file << "[" << oss.str() << "] " << message << std::endl;
         // log_file.flush(); // Optional: flush immediately, impacts performance
+    }
+}
+
+void LogToProResFile(const std::string& message) {
+    std::lock_guard<std::mutex> lock(g_log_mutex);
+    std::ofstream& log_file = get_prores_log_file();
+    if (log_file.is_open()) {
+        auto now = std::chrono::system_clock::now();
+        auto ms = std::chrono::duration_cast<std::chrono::milliseconds>(now.time_since_epoch()) % 1000;
+        std::time_t time_now = std::chrono::system_clock::to_time_t(now);
+        std::tm timeinfo{};
+#ifdef _WIN32
+        localtime_s(&timeinfo, &time_now);
+#else
+        localtime_r(&time_now, &timeinfo);
+#endif
+        std::ostringstream oss;
+        oss << std::put_time(&timeinfo, "%Y-%m-%d %H:%M:%S");
+        oss << '.' << std::setfill('0') << std::setw(3) << ms.count();
+        log_file << "[" << oss.str() << "] " << message << std::endl;
     }
 }


### PR DESCRIPTION
## Summary
- add dedicated `prores_export_log.txt` logging
- document the new log in the README
- log FFmpeg command and export parameters for debugging
- fix DebugLog header guard

## Testing
- `cmake ..`
- `cmake --build .` *(fails: GL/gl.h missing)*

------
https://chatgpt.com/codex/tasks/task_e_686588b3b9288327b44f262af0369d8a