### PR TITLE
Add ProRes conversion option

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -149,6 +149,7 @@ set(APP_SOURCES
 
   src/Utils/DebugLog.cpp
   src/Utils/OrientationUtils.cpp
+  src/Utils/ProResConverter.cpp
 
   src/main.cpp
 )

--- a/include/App/App.h
+++ b/include/App/App.h
@@ -111,6 +111,7 @@ public:
     void toggleHelpPage() { m_showHelpPage = !m_showHelpPage; }
     void saveCurrentFrameAsDng();
     void convertCurrentFileToDngs();
+    void convertCurrentFileToProRes();
     void performSeek(size_t new_frame_index);
     void triggerOpenFileViaDialog();
 	void setPlaybackMode(PlaybackController::PlaybackMode mode);

--- a/include/Utils/ProResConverter.h
+++ b/include/Utils/ProResConverter.h
@@ -1,0 +1,9 @@
+#ifndef PRORES_CONVERTER_H
+#define PRORES_CONVERTER_H
+#include <string>
+
+namespace ProResConverter {
+bool convertMcrawToProRes(const std::string& mcrawPath);
+}
+
+#endif // PRORES_CONVERTER_H

--- a/src/App/AppIO.cpp
+++ b/src/App/AppIO.cpp
@@ -17,6 +17,7 @@
 #endif
 #include <tinydng/tiny_dng_writer.h>
 
+#include "Utils/ProResConverter.h"
 
 #include <filesystem>
 #include <iostream>
@@ -1186,4 +1187,17 @@ void App::setPlaybackMode(PlaybackController::PlaybackMode mode) {
 
     LogToFile(std::string("[App::setPlaybackMode] Changed from ") + std::to_string(static_cast<int>(oldMode)) +
         " to " + std::to_string(static_cast<int>(mode)));
+}
+
+void App::convertCurrentFileToProRes() {
+    if (m_fileList.empty() || m_currentFileIndex < 0 || static_cast<size_t>(m_currentFileIndex) >= m_fileList.size()) {
+        LogToFile("[App::convertCurrentFileToProRes] No valid file to convert.");
+        return;
+    }
+
+    std::string currentMcrawPathStr = m_fileList[m_currentFileIndex];
+    bool result = ProResConverter::convertMcrawToProRes(currentMcrawPathStr);
+    if (!result) {
+        LogToFile("[App::convertCurrentFileToProRes] Conversion failed.");
+    }
 }

--- a/src/Utils/ProResConverter.cpp
+++ b/src/Utils/ProResConverter.cpp
@@ -1,0 +1,53 @@
+#include "Utils/ProResConverter.h"
+#include "Utils/DebugLog.h"
+#include <filesystem>
+#include <cstdlib>
+#ifdef _WIN32
+#include <windows.h>
+#endif
+
+namespace fs = std::filesystem;
+
+namespace ProResConverter {
+
+bool convertMcrawToProRes(const std::string& mcrawPath) {
+    fs::path inputPath(mcrawPath);
+    fs::path outputPath = inputPath;
+    outputPath.replace_extension(".mov");
+
+    std::string command = std::string("ffmpeg -y -i \"") + inputPath.string() +
+        "\" -c:v prores_ks -profile:v 3 \"" + outputPath.string() + "\"";
+    LogToFile(std::string("[convertMcrawToProRes] Command: ") + command);
+
+#ifdef _WIN32
+    int wlen = MultiByteToWideChar(CP_UTF8, 0, command.c_str(), -1, nullptr, 0);
+    if (wlen == 0) {
+        LogToFile("[convertMcrawToProRes] UTF-16 len fail.");
+        return false;
+    }
+    std::wstring wcmd(wlen, L'\0');
+    if (MultiByteToWideChar(CP_UTF8, 0, command.c_str(), -1, wcmd.data(), wlen) == 0) {
+        LogToFile("[convertMcrawToProRes] UTF-16 conv fail.");
+        return false;
+    }
+    STARTUPINFOW si{}; PROCESS_INFORMATION pi{};
+    si.cb = sizeof(si);
+    if (!CreateProcessW(nullptr, wcmd.data(), nullptr, nullptr, FALSE, CREATE_NO_WINDOW | CREATE_NEW_PROCESS_GROUP,
+                        nullptr, nullptr, &si, &pi)) {
+        LogToFile(std::string("[convertMcrawToProRes] CreateProcessW failed. ") + std::to_string(GetLastError()));
+        return false;
+    }
+    CloseHandle(pi.hProcess);
+    CloseHandle(pi.hThread);
+    return true;
+#else
+    int ret = system(command.c_str());
+    if (ret != 0) {
+        LogToFile("[convertMcrawToProRes] system() returned non-zero.");
+        return false;
+    }
+    return true;
+#endif
+}
+
+} // namespace ProResConverter

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -35,6 +35,7 @@
 
 #include "App/App.h"
 #include "Utils/DebugLog.h"
+#include "Utils/ProResConverter.h"
 #ifdef _WIN32
 #include "Utils/SingleInstanceGuard.h"
 #ifdef _WIN32
@@ -258,8 +259,19 @@ int main(int argc, char* argv[]) {
 
 
     std::string inPath;
-    if (argc >= 2 && argv[1] != nullptr) {
-        inPath = argv[1];
+    bool convertProRes = false;
+    for (int i = 1; i < argc; ++i) {
+        if (!argv[i]) continue;
+        std::string arg = argv[i];
+        if (arg == "--convert-prores") {
+            convertProRes = true;
+        } else if (arg.rfind("-", 0) == 0) {
+            // unknown flag - ignored
+        } else if (inPath.empty()) {
+            inPath = arg;
+        }
+    }
+    if (!inPath.empty()) {
         LogToFile(std::string("[main] Input file from command line: ") + inPath);
     } else {
         LogToFile("[main] No command line argument provided. Starting without file.");
@@ -282,6 +294,10 @@ int main(int argc, char* argv[]) {
 #endif
         std::cerr << errorMsg << std::endl;
         return 1;
+    }
+    if (convertProRes && !inPath.empty()) {
+        bool ok = ProResConverter::convertMcrawToProRes(inPath);
+        return ok ? 0 : 1;
     }
 
     LogToFile(std::string("[main] Initializing App with file: ") + inPath);


### PR DESCRIPTION
## Summary
- add small utility for converting `.mcraw` to ProRes via ffmpeg
- expose `convertCurrentFileToProRes` in App
- parse `--convert-prores` CLI option to convert instead of launch player
- hook up new function to AppIO

## Testing
- `cmake ..` *(fails: missing OpenGL)*

------
https://chatgpt.com/codex/tasks/task_e_68661e2acc288327a48ef0500c760408