### PR TITLE
Add ProRes GUI option

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -149,6 +149,7 @@ set(APP_SOURCES
 
   src/Utils/DebugLog.cpp
   src/Utils/OrientationUtils.cpp
+  src/Utils/ProResConverter.cpp
 
   src/main.cpp
 )

--- a/include/App/App.h
+++ b/include/App/App.h
@@ -111,6 +111,7 @@ public:
     void toggleHelpPage() { m_showHelpPage = !m_showHelpPage; }
     void saveCurrentFrameAsDng();
     void convertCurrentFileToDngs();
+    void convertCurrentFileToProRes();
     void performSeek(size_t new_frame_index);
     void triggerOpenFileViaDialog();
 	void setPlaybackMode(PlaybackController::PlaybackMode mode);

--- a/include/Utils/DebugLog.h
+++ b/include/Utils/DebugLog.h
@@ -5,6 +5,8 @@
 
 // Simple file logger declaration
 void LogToFile(const std::string& message);
+// Dedicated log for ProRes conversion operations
+void LogProRes(const std::string& message);
 
 // Returns path to directory where log files should be stored.
 // On Windows this uses the user's roaming AppData directory.

--- a/include/Utils/ProResConverter.h
+++ b/include/Utils/ProResConverter.h
@@ -1,0 +1,10 @@
+#ifndef PRORES_CONVERTER_H
+#define PRORES_CONVERTER_H
+#include <string>
+#include "Utils/OrientationUtils.h"
+
+namespace ProResConverter {
+bool convertMcrawToProRes(const std::string& mcrawPath, OrientationTag orientTag);
+}
+
+#endif // PRORES_CONVERTER_H

--- a/src/App/AppIO.cpp
+++ b/src/App/AppIO.cpp
@@ -17,6 +17,7 @@
 #endif
 #include <tinydng/tiny_dng_writer.h>
 
+#include "Utils/ProResConverter.h"
 
 #include <filesystem>
 #include <iostream>
@@ -1186,4 +1187,22 @@ void App::setPlaybackMode(PlaybackController::PlaybackMode mode) {
 
     LogToFile(std::string("[App::setPlaybackMode] Changed from ") + std::to_string(static_cast<int>(oldMode)) +
         " to " + std::to_string(static_cast<int>(mode)));
+}
+
+void App::convertCurrentFileToProRes() {
+    if (m_fileList.empty() || m_currentFileIndex < 0 || static_cast<size_t>(m_currentFileIndex) >= m_fileList.size()) {
+        LogToFile("[App::convertCurrentFileToProRes] No valid file to convert.");
+        LogProRes("No valid file to convert");
+        return;
+    }
+
+    std::string currentMcrawPathStr = m_fileList[m_currentFileIndex];
+    LogProRes(std::string("Starting conversion of ") + currentMcrawPathStr);
+    bool result = ProResConverter::convertMcrawToProRes(currentMcrawPathStr, m_containerOrientationTag);
+    if (!result) {
+        LogToFile("[App::convertCurrentFileToProRes] Conversion failed.");
+        LogProRes("Conversion failed");
+    } else {
+        LogProRes("Conversion command finished");
+    }
 }

--- a/src/Gui/GuiRender.cpp
+++ b/src/Gui/GuiRender.cpp
@@ -226,6 +226,9 @@ namespace GuiOverlay {
             if (ImGui::MenuItem("Save Current Frame as DNG", nullptr, false, canOperateOnCurrentFile)) {
                 if (appInstance) appInstance->saveCurrentFrameAsDng();
             }
+            if (ImGui::MenuItem("Convert Current File to ProRes", nullptr, false, canOperateOnCurrentFile)) {
+                if (appInstance) appInstance->convertCurrentFileToProRes();
+            }
             ImGui::Separator();
             if (ImGui::MenuItem("Soft Delete MCRAW", nullptr, false, canOperateOnCurrentFile)) {
                 if (appInstance) appInstance->softDeleteCurrentFile();

--- a/src/Utils/DebugLog.cpp
+++ b/src/Utils/DebugLog.cpp
@@ -14,6 +14,7 @@
 #endif
 
 static std::mutex g_log_mutex; // Mutex to protect file access
+static std::mutex g_prores_log_mutex;
 
 // Application base path defined in main.cpp
 extern std::string g_AppBasePath;
@@ -52,6 +53,20 @@ static std::ofstream& get_log_file() {
     return log_file;
 }
 
+static std::ofstream& get_prores_log_file() {
+    static std::ofstream prores_log_file;
+    static bool initialized = false;
+    if (!initialized) {
+        std::filesystem::path logDir = getLogDirectory();
+        std::error_code ec;
+        std::filesystem::create_directories(logDir, ec);
+        std::filesystem::path logPath = logDir / "prores_conversion_log.txt";
+        prores_log_file.open(logPath, std::ios_base::app | std::ios_base::out);
+        initialized = true;
+    }
+    return prores_log_file;
+}
+
 void LogToFile(const std::string& message) {
     std::lock_guard<std::mutex> lock(g_log_mutex); // Lock for thread safety
 
@@ -75,5 +90,25 @@ void LogToFile(const std::string& message) {
 
         log_file << "[" << oss.str() << "] " << message << std::endl;
         // log_file.flush(); // Optional: flush immediately, impacts performance
+    }
+}
+
+void LogProRes(const std::string& message) {
+    std::lock_guard<std::mutex> lock(g_prores_log_mutex);
+    std::ofstream& log_file = get_prores_log_file();
+    if (log_file.is_open()) {
+        auto now = std::chrono::system_clock::now();
+        auto ms = std::chrono::duration_cast<std::chrono::milliseconds>(now.time_since_epoch()) % 1000;
+        std::time_t time_now = std::chrono::system_clock::to_time_t(now);
+        std::tm timeinfo{};
+#ifdef _WIN32
+        localtime_s(&timeinfo, &time_now);
+#else
+        localtime_r(&time_now, &timeinfo);
+#endif
+        std::ostringstream oss;
+        oss << std::put_time(&timeinfo, "%Y-%m-%d %H:%M:%S");
+        oss << '.' << std::setfill('0') << std::setw(3) << ms.count();
+        log_file << "[" << oss.str() << "] " << message << std::endl;
     }
 }

--- a/src/Utils/ProResConverter.cpp
+++ b/src/Utils/ProResConverter.cpp
@@ -1,0 +1,82 @@
+#include "Utils/ProResConverter.h"
+#include "Utils/DebugLog.h"
+#include <filesystem>
+#include <cstdlib>
+#ifdef _WIN32
+#include <windows.h>
+#endif
+
+namespace fs = std::filesystem;
+
+namespace ProResConverter {
+
+static bool isMirrorTag(OrientationTag tag) {
+    return tag == OrientationTag::kMirror || tag == OrientationTag::kMirror180 ||
+           tag == OrientationTag::kMirror90CW || tag == OrientationTag::kMirror90CCW;
+}
+
+static std::string buildFilter(OrientationTag tag) {
+    int deg = orientationDegreesFromTag(tag);
+    bool mirror = isMirrorTag(tag);
+    std::string filter;
+    switch (deg) {
+        case 90:  filter = "transpose=1"; break;
+        case 180: filter = "transpose=2,transpose=2"; break;
+        case 270: filter = "transpose=2"; break;
+        default: break;
+    }
+    if (mirror) {
+        if (!filter.empty()) filter += ",";
+        filter += "hflip";
+    }
+    return filter;
+}
+
+bool convertMcrawToProRes(const std::string& mcrawPath, OrientationTag orientTag) {
+    fs::path inputPath(mcrawPath);
+    fs::path outputPath = inputPath;
+    outputPath.replace_extension(".mov");
+
+    std::string filter = buildFilter(orientTag);
+    std::string command = std::string("ffmpeg -y -i \"") + inputPath.string() +
+        "\" -c:v prores_ks -profile:v 3";
+    if (!filter.empty()) {
+        command += " -vf \"" + filter + "\"";
+    }
+    command += " \"" + outputPath.string() + "\"";
+    LogProRes(std::string("Command: ") + command);
+
+#ifdef _WIN32
+    int wlen = MultiByteToWideChar(CP_UTF8, 0, command.c_str(), -1, nullptr, 0);
+    if (wlen == 0) {
+        LogProRes("UTF-16 len fail.");
+        return false;
+    }
+    std::wstring wcmd(wlen, L'\0');
+    if (MultiByteToWideChar(CP_UTF8, 0, command.c_str(), -1, wcmd.data(), wlen) == 0) {
+        LogProRes("UTF-16 conv fail.");
+        return false;
+    }
+    STARTUPINFOW si{}; PROCESS_INFORMATION pi{};
+    si.cb = sizeof(si);
+    if (!CreateProcessW(nullptr, wcmd.data(), nullptr, nullptr, FALSE, CREATE_NO_WINDOW | CREATE_NEW_PROCESS_GROUP,
+                        nullptr, nullptr, &si, &pi)) {
+        LogProRes(std::string("CreateProcessW failed. ") + std::to_string(GetLastError()));
+        return false;
+    }
+    CloseHandle(pi.hProcess);
+    CloseHandle(pi.hThread);
+    LogProRes("Conversion finished successfully.");
+    return true;
+#else
+    int ret = system(command.c_str());
+    if (ret != 0) {
+        LogProRes("system() returned non-zero.");
+        return false;
+    }
+    LogProRes("Conversion finished successfully.");
+    return true;
+#endif
+}
+
+} // namespace ProResConverter

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -35,6 +35,9 @@
 
 #include "App/App.h"
 #include "Utils/DebugLog.h"
+#include "Utils/ProResConverter.h"
+#include "Decoder/DecoderWrapper.h"
+#include "Utils/OrientationUtils.h"
 #ifdef _WIN32
 #include "Utils/SingleInstanceGuard.h"
 #ifdef _WIN32
@@ -258,8 +261,19 @@ int main(int argc, char* argv[]) {
 
 
     std::string inPath;
-    if (argc >= 2 && argv[1] != nullptr) {
-        inPath = argv[1];
+    bool convertProRes = false;
+    for (int i = 1; i < argc; ++i) {
+        if (!argv[i]) continue;
+        std::string arg = argv[i];
+        if (arg == "--convert-prores") {
+            convertProRes = true;
+        } else if (arg.rfind("-", 0) == 0) {
+            // unknown flag - ignored
+        } else if (inPath.empty()) {
+            inPath = arg;
+        }
+    }
+    if (!inPath.empty()) {
         LogToFile(std::string("[main] Input file from command line: ") + inPath);
     } else {
         LogToFile("[main] No command line argument provided. Starting without file.");
@@ -282,6 +296,21 @@ int main(int argc, char* argv[]) {
 #endif
         std::cerr << errorMsg << std::endl;
         return 1;
+    }
+    if (convertProRes && !inPath.empty()) {
+        LogProRes(std::string("CLI conversion requested for ") + inPath);
+        OrientationTag tag = OrientationTag::kNormal;
+        try {
+            DecoderWrapper decoder(inPath);
+            const nlohmann::json& meta = decoder.getContainerMetadata();
+            nlohmann::json val = findOrientationValue(meta);
+            bool flipped = meta.value("flipped", false);
+            tag = computeOrientationTag(val, flipped, OrientationTag::kNormal);
+        } catch (const std::exception& e) {
+            LogProRes(std::string("Failed to load orientation metadata: ") + e.what());
+        }
+        bool ok = ProResConverter::convertMcrawToProRes(inPath, tag);
+        return ok ? 0 : 1;
     }
 
     LogToFile(std::string("[main] Initializing App with file: ") + inPath);


### PR DESCRIPTION
## Summary
- add dedicated prores log in DebugLog
- hook log into ProRes conversion
- expose `Convert Current File to ProRes` from context menu
- call prores log from CLI and App
- improve ProRes conversion to respect orientation metadata

## Testing
- `cmake ..`
- `cmake --build . -j4` *(fails: missing GL headers)*

------
https://chatgpt.com/codex/tasks/task_e_68661e2acc288327a48ef0500c760408