### PR TITLE
Add ffmpeg-based ProRes export skeleton

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -32,6 +32,8 @@ if(NOT Vulkan_FOUND)
     message(FATAL_ERROR "Vulkan SDK not found. Please ensure it is installed and discoverable.")
 endif()
 find_package(Threads REQUIRED)
+find_package(PkgConfig REQUIRED)
+pkg_check_modules(FFMPEG REQUIRED IMPORTED_TARGET libavcodec libavformat libavutil libswscale libswresample)
 message(STATUS "Found Vulkan SDK:")
 message(STATUS "  Libraries:    ${Vulkan_LIBRARIES}")
 message(STATUS "  Include Dirs: ${Vulkan_INCLUDE_DIRS}")
@@ -217,6 +219,7 @@ target_link_libraries(${PROJECT_NAME} PRIVATE
     "${GLFW_LIB_PATH_VC_SPECIFIC}"
     "${SDL2_LIBRARY_DIR}/SDL2.lib"
     ${Vulkan_LIBRARIES}
+    PkgConfig::FFMPEG
 )
 
 if(WIN32)

--- a/include/App/App.h
+++ b/include/App/App.h
@@ -111,6 +111,7 @@ public:
     void toggleHelpPage() { m_showHelpPage = !m_showHelpPage; }
     void saveCurrentFrameAsDng();
     void convertCurrentFileToDngs();
+    void exportCurrentClipToProRes();
     void performSeek(size_t new_frame_index);
     void triggerOpenFileViaDialog();
 	void setPlaybackMode(PlaybackController::PlaybackMode mode);
@@ -217,6 +218,15 @@ private:
     double m_uiAutoHideDelaySec = 3.0;
     float m_uiFadeSpeed = 3.0f;
 
+    struct ProResExportStatus {
+        std::atomic<bool> active{ false };
+        std::atomic<int> currentFrame{ 0 };
+        int totalFrames{ 0 };
+        std::string errorMsg;
+    } m_proResStatus;
+    std::atomic<bool> m_showExportProgressPopup{ false };
+    std::thread m_proResThread;
+
 
 #ifdef _WIN32
     HWND _ipcWnd = nullptr;
@@ -257,6 +267,7 @@ private:
     void handleCursorPos(double xpos, double ypos);
     void framebufferSizeCallback(int width, int height);
     std::string openMcrawDialog();
+    std::string openSaveMovDialog();
 
     struct SwapChainSupportDetails {
         VkSurfaceCapabilitiesKHR capabilities;

--- a/src/App/AppCleanup.cpp
+++ b/src/App/AppCleanup.cpp
@@ -52,6 +52,11 @@ App::~App() {
         m_decodeThread.join();
         LogToFile("[App::~App] Decode thread joined.");
     }
+    if (m_proResThread.joinable()) {
+        LogToFile("[App::~App] Joining ProRes export thread...");
+        m_proResThread.join();
+        LogToFile("[App::~App] ProRes export thread joined.");
+    }
 
     destroyPersistentStagingBuffers();
 

--- a/src/App/AppIO.cpp
+++ b/src/App/AppIO.cpp
@@ -20,11 +20,17 @@
 
 #include <filesystem>
 #include <iostream>
+#include <fstream>
 #include <numeric>
 #include <algorithm>
 #include <cmath>
 #include <cstdio>
 #include <sstream>
+#include <libavformat/avformat.h>
+#include <libavcodec/avcodec.h>
+#include <libavutil/opt.h>
+#include <libavutil/imgutils.h>
+#include <libswscale/swscale.h>
 
 namespace fs = std::filesystem;
 
@@ -1163,6 +1169,196 @@ void App::sendAllPlaylistFilesToMotionCamFS()
 
     LogToFile(std::string("[App::sendAllToMotionCamFS] Done. Success: ")
         + std::to_string(ok) + ", Fail: " + std::to_string(fail));
+}
+
+void App::exportCurrentClipToProRes() {
+    if (m_proResStatus.active.load()) {
+        showActionMessage("Export already running");
+        return;
+    }
+
+    std::string outputPath = openSaveMovDialog();
+    if (outputPath.empty()) return;
+    if (outputPath.size() < 4 || outputPath.substr(outputPath.size() - 4) != ".mov") {
+        outputPath += ".mov";
+    }
+
+    if (!m_decoderWrapper_ptr || !m_decoderWrapper_ptr->getDecoder()) {
+        showActionMessage("No clip loaded");
+        return;
+    }
+
+    m_proResStatus.totalFrames = static_cast<int>(m_decoderWrapper_ptr->getDecoder()->getFrames().size());
+    m_proResStatus.currentFrame.store(0);
+    m_proResStatus.active.store(true);
+    m_proResStatus.errorMsg.clear();
+    m_showExportProgressPopup.store(true);
+    showActionMessage("Export Started");
+
+    if (m_proResThread.joinable()) {
+        m_proResThread.join();
+    }
+
+    m_proResThread = std::thread([this, outputPath]() {
+        av_log_set_level(AV_LOG_ERROR);
+
+        auto* dec = m_decoderWrapper_ptr->getDecoder();
+        const auto& frames = dec->getFrames();
+        if (frames.empty()) {
+            m_proResStatus.errorMsg = "No frames to export";
+            m_proResStatus.active.store(false);
+            return;
+        }
+
+        RawBytes rawBuf;
+        nlohmann::json meta;
+        try {
+            dec->loadFrame(frames[0], rawBuf, meta);
+        } catch (const std::exception& e) {
+            LogToFile(std::string("[ProResExport] Failed to load first frame: ") + e.what());
+            m_proResStatus.errorMsg = "Failed to load first frame";
+            m_proResStatus.active.store(false);
+            return;
+        }
+        int width = meta.value("width", 0);
+        int height = meta.value("height", 0);
+        if (width <= 0 || height <= 0) {
+            m_proResStatus.errorMsg = "Invalid frame dimensions";
+            m_proResStatus.active.store(false);
+            return;
+        }
+
+        int64_t frameDurationNs = 0;
+        if (frames.size() >= 2) {
+            frameDurationNs = frames[1] - frames[0];
+        } else {
+            frameDurationNs = 41708333; // ~24fps fallback
+        }
+        AVRational timeBase{ static_cast<int>(frameDurationNs / 1000), 1000000 };
+
+        AVFormatContext* fmt = nullptr;
+        if (avformat_alloc_output_context2(&fmt, nullptr, nullptr, outputPath.c_str()) < 0 || !fmt) {
+            m_proResStatus.errorMsg = "avformat_alloc_output_context2 failed";
+            m_proResStatus.active.store(false);
+            return;
+        }
+
+        const AVCodec* vcodec = avcodec_find_encoder_by_name("prores_ks");
+        if (!vcodec) {
+            m_proResStatus.errorMsg = "ProRes encoder not found";
+            m_proResStatus.active.store(false);
+            avformat_free_context(fmt);
+            return;
+        }
+
+        AVStream* vstream = avformat_new_stream(fmt, nullptr);
+        AVCodecContext* vctx = avcodec_alloc_context3(vcodec);
+        vctx->codec_id = vcodec->id;
+        vctx->codec_type = AVMEDIA_TYPE_VIDEO;
+        vctx->pix_fmt = AV_PIX_FMT_YUV422P10LE;
+        vctx->width = width;
+        vctx->height = height;
+        vctx->time_base = timeBase;
+        vctx->framerate = av_inv_q(timeBase);
+        if (fmt->oformat->flags & AVFMT_GLOBALHEADER)
+            vctx->flags |= AV_CODEC_FLAG_GLOBAL_HEADER;
+        if (avcodec_open2(vctx, vcodec, nullptr) < 0) {
+            m_proResStatus.errorMsg = "avcodec_open2 failed";
+            m_proResStatus.active.store(false);
+            avcodec_free_context(&vctx);
+            avformat_free_context(fmt);
+            return;
+        }
+        avcodec_parameters_from_context(vstream->codecpar, vctx);
+        vstream->time_base = timeBase;
+
+        if (!(fmt->oformat->flags & AVFMT_NOFILE)) {
+            if (avio_open(&fmt->pb, outputPath.c_str(), AVIO_FLAG_WRITE) < 0) {
+                m_proResStatus.errorMsg = "avio_open failed";
+                m_proResStatus.active.store(false);
+                avcodec_free_context(&vctx);
+                avformat_free_context(fmt);
+                return;
+            }
+        }
+
+        if (avformat_write_header(fmt, nullptr) < 0) {
+            m_proResStatus.errorMsg = "avformat_write_header failed";
+            m_proResStatus.active.store(false);
+            if (!(fmt->oformat->flags & AVFMT_NOFILE)) avio_closep(&fmt->pb);
+            avcodec_free_context(&vctx);
+            avformat_free_context(fmt);
+            return;
+        }
+
+        AVFrame* frame = av_frame_alloc();
+        frame->format = vctx->pix_fmt;
+        frame->width = width;
+        frame->height = height;
+        av_frame_get_buffer(frame, 32);
+
+        AVPacket pkt;
+        av_init_packet(&pkt);
+
+        int64_t pts = 0;
+        for (size_t idx = 0; idx < frames.size(); ++idx) {
+            RawBytes raw;
+            nlohmann::json metaTmp;
+            try { dec->loadFrame(frames[idx], raw, metaTmp); }
+            catch (...) { m_proResStatus.errorMsg = "Frame read error"; break; }
+
+            if (av_frame_make_writable(frame) < 0) { m_proResStatus.errorMsg = "frame not writable"; break; }
+            // naive grayscale export from Bayer
+            const uint16_t* src = asU16(raw);
+            for (int y = 0; y < height; ++y) {
+                uint16_t* ydst = reinterpret_cast<uint16_t*>(frame->data[0] + y * frame->linesize[0]);
+                uint16_t* udst = reinterpret_cast<uint16_t*>(frame->data[1] + (y/1) * frame->linesize[1]);
+                uint16_t* vdst = reinterpret_cast<uint16_t*>(frame->data[2] + (y/1) * frame->linesize[2]);
+                for (int x = 0; x < width; ++x) {
+                    uint16_t val16 = src[y*width + x];
+                    uint16_t val10 = val16 >> 6;
+                    ydst[x] = val10 << 6;
+                    if ((x & 1) == 0) {
+                        udst[x/2] = 512 << 6;
+                        vdst[x/2] = 512 << 6;
+                    }
+                }
+            }
+
+            frame->pts = pts;
+            pts++;
+
+            if (avcodec_send_frame(vctx, frame) < 0) { m_proResStatus.errorMsg = "send_frame failed"; break; }
+            while (avcodec_receive_packet(vctx, &pkt) == 0) {
+                pkt.stream_index = vstream->index;
+                pkt.duration = 1;
+                pkt.pts = av_rescale_q(pkt.pts, vctx->time_base, vstream->time_base);
+                pkt.dts = pkt.pts;
+                if (av_interleaved_write_frame(fmt, &pkt) < 0) { m_proResStatus.errorMsg = "write_frame failed"; av_packet_unref(&pkt); break; }
+                av_packet_unref(&pkt);
+            }
+            m_proResStatus.currentFrame.store(static_cast<int>(idx + 1));
+        }
+
+        avcodec_send_frame(vctx, nullptr);
+        while (avcodec_receive_packet(vctx, &pkt) == 0) {
+            pkt.stream_index = vstream->index;
+            pkt.duration = 1;
+            pkt.pts = av_rescale_q(pkt.pts, vctx->time_base, vstream->time_base);
+            pkt.dts = pkt.pts;
+            av_interleaved_write_frame(fmt, &pkt);
+            av_packet_unref(&pkt);
+        }
+
+        av_write_trailer(fmt);
+        if (!(fmt->oformat->flags & AVFMT_NOFILE)) avio_closep(&fmt->pb);
+        avcodec_free_context(&vctx);
+        avformat_free_context(fmt);
+
+        if (m_proResStatus.errorMsg.empty()) showActionMessage("Export Finished");
+        else LogToFile(std::string("[ProResExport] Error: ") + m_proResStatus.errorMsg);
+        m_proResStatus.active.store(false);
+    });
 }
 
 void App::setPlaybackMode(PlaybackController::PlaybackMode mode) {

--- a/src/App/AppInit.cpp
+++ b/src/App/AppInit.cpp
@@ -145,7 +145,9 @@ App::App(const std::string& filePath) :
     m_uiAutoHidden(false),
     m_uiOpacity(1.0f),
     m_uiAutoHideDelaySec(3.0),
-    m_uiFadeSpeed(3.0f)
+    m_uiFadeSpeed(3.0f),
+    m_showExportProgressPopup(false),
+    m_proResStatus()
 {
     LogToFile(std::string("App::App Constructor called for file: ") + this->m_filePath);
 #ifndef NDEBUG

--- a/src/App/AppInput.cpp
+++ b/src/App/AppInput.cpp
@@ -488,6 +488,39 @@ std::string App::openMcrawDialog() {
     return {};
 }
 
+std::string App::openSaveMovDialog() {
+#ifdef _WIN32
+    OPENFILENAMEW ofn{};
+    wchar_t szFile[MAX_PATH] = { 0 };
+    ofn.lStructSize = sizeof(ofn);
+
+    HWND ownerHwnd = NULL;
+    if (m_window) {
+        ownerHwnd = glfwGetWin32Window(m_window);
+    }
+
+    ofn.hwndOwner = ownerHwnd;
+    ofn.lpstrFilter = L"MOV files\0*.mov\0All Files\0*.*\0";
+    ofn.lpstrFile = szFile;
+    ofn.nMaxFile = MAX_PATH;
+    ofn.Flags = OFN_OVERWRITEPROMPT | OFN_PATHMUSTEXIST | OFN_NOCHANGEDIR;
+    ofn.lpstrDefExt = L"mov";
+
+    if (GetSaveFileNameW(&ofn)) {
+        std::string utf8Path = DebugLogHelper::wstring_to_utf8(szFile);
+        if (utf8Path.empty() && szFile[0] != L'\0') {
+            LogToFile("[App::openSaveMovDialog] UTF-8 conversion failed for selected path.");
+            return {};
+        }
+        return utf8Path;
+    }
+#else
+    LogToFile("[App::openSaveMovDialog] Save dialog not implemented for this platform.");
+    std::cerr << "Save dialog not implemented for this platform." << std::endl;
+#endif
+    return {};
+}
+
 void App::triggerOpenFileViaDialog() {
     std::string newPath = openMcrawDialog();
     if (!newPath.empty()) {

--- a/src/Gui/GuiRender.cpp
+++ b/src/Gui/GuiRender.cpp
@@ -55,7 +55,7 @@ namespace GuiOverlay {
         ImGui::NewFrame();
     }
 
-    GuiOverlay::UIData GuiOverlay::gatherData(App* appInstance) {
+    UIData gatherData(App* appInstance) {
         UIData data = {};
         if (!appInstance) return data;
 
@@ -236,6 +236,10 @@ namespace GuiOverlay {
             }
             if (ImGui::MenuItem("Send All in Playlist to MotionCam Fuse", nullptr, false, playlistNotEmpty)) {
                 if (appInstance) appInstance->sendAllPlaylistFilesToMotionCamFS();
+            }
+            ImGui::Separator();
+            if (ImGui::MenuItem("Export to ProRes", nullptr, false, canOperateOnCurrentFile)) {
+                if (appInstance) appInstance->exportCurrentClipToProRes();
             }
             ImGui::EndPopup();
         }
@@ -656,6 +660,27 @@ namespace GuiOverlay {
             } else {
                 appInstance->m_actionMessage.clear();
             }
+        }
+
+        if (appInstance->m_showExportProgressPopup.load()) {
+            ImGui::OpenPopup("EXPORT_PROGRESS");
+        }
+        if (ImGui::BeginPopupModal("EXPORT_PROGRESS", nullptr, ImGuiWindowFlags_AlwaysAutoResize)) {
+            int cur = appInstance->m_proResStatus.currentFrame.load();
+            int total = appInstance->m_proResStatus.totalFrames;
+            float progress = total > 0 ? static_cast<float>(cur) / static_cast<float>(total) : 0.0f;
+            ImGui::Text("Exporting to ProRes %d / %d", cur, total);
+            ImGui::ProgressBar(progress, ImVec2(200, 0));
+            if (!appInstance->m_proResStatus.errorMsg.empty()) {
+                ImGui::TextColored(ImVec4(1,0,0,1), "%s", appInstance->m_proResStatus.errorMsg.c_str());
+            }
+            if (!appInstance->m_proResStatus.active.load()) {
+                if (ImGui::Button("Close")) {
+                    ImGui::CloseCurrentPopup();
+                    appInstance->m_showExportProgressPopup.store(false);
+                }
+            }
+            ImGui::EndPopup();
         }
         ImGui::PopStyleVar();
     }


### PR DESCRIPTION
## Summary
- link against FFmpeg via pkg-config
- prototype `exportCurrentClipToProRes` using libavformat/avcodec
- update GUI gatherData declaration

## Testing
- `cmake -S . -B build`
- `cmake --build build -j2` *(fails: linker error with prebuilt GLFW/SDL libs)*

------
https://chatgpt.com/codex/tasks/task_e_68664522e6508327b9646f2f51c24775