### PR TITLE
Add tooltip for Export to ProRes

### DIFF
--- a/src/Gui/GuiRender.cpp
+++ b/src/Gui/GuiRender.cpp
@@ -239,8 +239,14 @@ namespace GuiOverlay {
             }
             ImGui::Separator();
 #ifdef ENABLE_PRORES_EXPORT
-            if (ImGui::MenuItem("Export to ProRes", nullptr, false, canOperateOnCurrentFile)) {
-                if (appInstance) appInstance->exportCurrentClipToProRes();
+            {
+                bool exportEnabled = canOperateOnCurrentFile;
+                if (ImGui::MenuItem("Export to ProRes", nullptr, false, exportEnabled)) {
+                    if (appInstance) appInstance->exportCurrentClipToProRes();
+                }
+                if (!exportEnabled && ImGui::IsItemHovered(ImGuiHoveredFlags_DelayNormal)) {
+                    ImGui::SetTooltip("Load a clip first");
+                }
             }
 #else
             ImGui::MenuItem("Export to ProRes", nullptr, false, false);


### PR DESCRIPTION
## Summary
- show tooltip when Export to ProRes is disabled due to no clip

## Testing
- `cmake -S . -B build` *(fails: could not find FFmpeg)*

------
https://chatgpt.com/codex/tasks/task_e_6866ba3071c4832797fab62499b82e06