### PR TITLE
Add logs for ProRes availability

### DIFF
--- a/src/App/AppInit.cpp
+++ b/src/App/AppInit.cpp
@@ -152,6 +152,11 @@ App::App(const std::string& filePath) :
 #endif
 {
     LogToFile(std::string("App::App Constructor called for file: ") + this->m_filePath);
+#ifdef ENABLE_PRORES_EXPORT
+    LogToFile("[App] ProRes export feature ENABLED (FFmpeg detected at build time)");
+#else
+    LogToFile("[App] ProRes export feature DISABLED (no FFmpeg support)");
+#endif
 #ifndef NDEBUG
     std::cout << "App::App Constructor called for file: " << this->m_filePath << std::endl;
 #endif

--- a/src/Gui/GuiRender.cpp
+++ b/src/Gui/GuiRender.cpp
@@ -239,11 +239,33 @@ namespace GuiOverlay {
             }
             ImGui::Separator();
 #ifdef ENABLE_PRORES_EXPORT
-            if (ImGui::MenuItem("Export to ProRes", nullptr, false, canOperateOnCurrentFile)) {
-                if (appInstance) appInstance->exportCurrentClipToProRes();
+            {
+                bool exportEnabled = canOperateOnCurrentFile;
+                if (ImGui::MenuItem("Export to ProRes", nullptr, false, exportEnabled)) {
+                    if (appInstance) appInstance->exportCurrentClipToProRes();
+                }
+                static bool loggedDisabled = false;
+                if (!exportEnabled) {
+                    if (!loggedDisabled) {
+                        LogToFile("[GUI] Export to ProRes disabled: no clip loaded");
+                        loggedDisabled = true;
+                    }
+                    if (ImGui::IsItemHovered(ImGuiHoveredFlags_DelayNormal)) {
+                        ImGui::SetTooltip("Load a clip first");
+                    }
+                } else {
+                    loggedDisabled = false;
+                }
             }
 #else
-            ImGui::MenuItem("Export to ProRes", nullptr, false, false);
+            {
+                ImGui::MenuItem("Export to ProRes", nullptr, false, false);
+                static bool loggedNoSupport = false;
+                if (!loggedNoSupport) {
+                    LogToFile("[GUI] Export to ProRes unavailable: built without FFmpeg support");
+                    loggedNoSupport = true;
+                }
+            }
 #endif
             ImGui::EndPopup();
         }


### PR DESCRIPTION
## Summary
- log whether ProRes support is built
- record reason for disabling Export to ProRes

## Testing
- `cmake -S . -B build` *(fails: could not find FFmpeg)*
- `cmake --build build` *(fails: no build files)*

------
https://chatgpt.com/codex/tasks/task_e_6866ba3071c4832797fab62499b82e06