### PR TITLE
Fix FFmpeg include paths

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -32,6 +32,32 @@ if(NOT Vulkan_FOUND)
     message(FATAL_ERROR "Vulkan SDK not found. Please ensure it is installed and discoverable.")
 endif()
 find_package(Threads REQUIRED)
+find_package(PkgConfig QUIET)
+find_package(FFmpeg QUIET COMPONENTS avcodec avformat avutil swscale swresample)
+if(NOT FFmpeg_FOUND AND PkgConfig_FOUND)
+    pkg_check_modules(PC_FFMPEG QUIET libavcodec libavformat libavutil libswscale libswresample)
+endif()
+
+message(STATUS "FFmpeg_FOUND=${FFmpeg_FOUND} FFMPEG_FOUND=${FFMPEG_FOUND} PC_FFMPEG_FOUND=${PC_FFMPEG_FOUND}")
+if(FFmpeg_FOUND OR FFMPEG_FOUND OR PC_FFMPEG_FOUND)
+    message(STATUS "FFmpeg found; enabling ProRes export")
+    set(HAVE_FFMPEG TRUE)
+
+    # Collect possible include directories and libraries from different find modules
+    set(_ffmpeg_inc_dirs "${FFmpeg_INCLUDE_DIRS};${FFmpeg_INCLUDE_DIR};${FFMPEG_INCLUDE_DIRS};${FFMPEG_INCLUDE_DIR};${PC_FFMPEG_INCLUDE_DIRS};${PC_FFMPEG_INCLUDE_DIR}")
+    set(_ffmpeg_libs "${FFmpeg_LIBRARIES};${FFMPEG_LIBRARIES};${PC_FFMPEG_LIBRARIES}")
+    string(REPLACE ";;" ";" _ffmpeg_inc_dirs "${_ffmpeg_inc_dirs}")
+    string(REPLACE ";;" ";" _ffmpeg_libs "${_ffmpeg_libs}")
+    separate_arguments(_ffmpeg_inc_dirs)
+    separate_arguments(_ffmpeg_libs)
+    list(REMOVE_DUPLICATES _ffmpeg_inc_dirs)
+    list(REMOVE_DUPLICATES _ffmpeg_libs)
+    set(FFMPEG_INCLUDE_DIRS_COMBINED ${_ffmpeg_inc_dirs})
+    set(FFMPEG_LIBRARIES_COMBINED ${_ffmpeg_libs})
+else()
+    message(STATUS "FFmpeg not found; ProRes export disabled")
+    set(HAVE_FFMPEG FALSE)
+endif()
 message(STATUS "Found Vulkan SDK:")
 message(STATUS "  Libraries:    ${Vulkan_LIBRARIES}")
 message(STATUS "  Include Dirs: ${Vulkan_INCLUDE_DIRS}")
@@ -149,6 +175,7 @@ set(APP_SOURCES
 
   src/Utils/DebugLog.cpp
   src/Utils/OrientationUtils.cpp
+  src/Utils/ColorPipelineCPU.cpp
 
   src/main.cpp
 )
@@ -169,7 +196,7 @@ endif()
 add_dependencies(${PROJECT_NAME} CompileShaders glm motioncam_decoder imgui)
 
 target_compile_definitions(${PROJECT_NAME} PRIVATE SDL_MAIN_HANDLED)
-
+target_compile_definitions(${PROJECT_NAME} PRIVATE GLFW_INCLUDE_NONE)
 if(MSVC AND CMAKE_SYSTEM_NAME STREQUAL "Windows")
     set_target_properties(${PROJECT_NAME} PROPERTIES LINK_FLAGS "/ENTRY:mainCRTStartup")
     message(STATUS "MSVC: Setting LINK_FLAGS /ENTRY:mainCRTStartup for ${PROJECT_NAME}")
@@ -219,8 +246,60 @@ target_link_libraries(${PROJECT_NAME} PRIVATE
     ${Vulkan_LIBRARIES}
 )
 
+if(HAVE_FFMPEG)
+    # Prefer modern imported targets if provided
+    if(TARGET FFmpeg::avcodec)
+        set(FFMPEG_NS "FFmpeg")
+    elseif(TARGET FFMPEG::avcodec)
+        set(FFMPEG_NS "FFMPEG")
+    endif()
+
+    if(DEFINED FFMPEG_NS)
+        target_link_libraries(${PROJECT_NAME} PRIVATE
+            ${FFMPEG_NS}::avcodec
+            ${FFMPEG_NS}::avformat
+            ${FFMPEG_NS}::avutil
+            ${FFMPEG_NS}::swscale
+            ${FFMPEG_NS}::swresample
+        )
+        target_include_directories(${PROJECT_NAME} PRIVATE ${FFMPEG_INCLUDE_DIRS_COMBINED})
+    elseif(PC_FFMPEG_FOUND)
+        target_link_libraries(${PROJECT_NAME} PRIVATE PkgConfig::PC_FFMPEG)
+        target_include_directories(${PROJECT_NAME} PRIVATE ${FFMPEG_INCLUDE_DIRS_COMBINED})
+    elseif(FFMPEG_LIBRARIES_COMBINED)
+        # Fallback for find modules that only expose variables
+        target_include_directories(${PROJECT_NAME} PRIVATE ${FFMPEG_INCLUDE_DIRS_COMBINED})
+        target_link_libraries(${PROJECT_NAME} PRIVATE ${FFMPEG_LIBRARIES_COMBINED})
+    else()
+        message(WARNING "FFmpeg libraries not found; ProRes export disabled")
+        set(HAVE_FFMPEG FALSE)
+    endif()
+
+    if(HAVE_FFMPEG)
+        target_compile_definitions(${PROJECT_NAME} PRIVATE ENABLE_PRORES_EXPORT)
+    endif()
+endif()
+
 if(WIN32)
     target_link_libraries(${PROJECT_NAME} PRIVATE Shlwapi.lib Comdlg32.lib dwmapi.lib Shell32.lib)
+    if(HAVE_FFMPEG)
+        # Copy required FFmpeg runtime DLLs next to the executable
+        set(FFMPEG_RUNTIME_DIR "C:/dev/vcpkg/installed/x64-windows/bin")
+        foreach(dll IN ITEMS avcodec-61.dll avformat-61.dll avutil-59.dll swscale-8.dll swresample-5.dll avfilter-10.dll)
+            add_custom_command(TARGET ${PROJECT_NAME} POST_BUILD
+                COMMAND ${CMAKE_COMMAND} -E copy_if_different
+                    "${FFMPEG_RUNTIME_DIR}/${dll}"
+                    "$<TARGET_FILE_DIR:${PROJECT_NAME}>/${dll}"
+                COMMENT "Copying ${dll}"
+            )
+        endforeach()
+        add_custom_command(TARGET ${PROJECT_NAME} POST_BUILD
+            COMMAND ${CMAKE_COMMAND} -E copy_if_different
+                "${FFMPEG_RUNTIME_DIR}/avfilter-10.pdb"
+                "$<TARGET_FILE_DIR:${PROJECT_NAME}>/avfilter-10.pdb"
+            COMMENT "Copying avfilter-10.pdb"
+        )
+    endif()
 endif()
 
 if(CMAKE_CXX_COMPILER_ID MATCHES "GNU|Clang|AppleClang")

--- a/README.md
+++ b/README.md
@@ -1,0 +1,39 @@
+# MotionCam Player
+
+This project builds a desktop player for MotionCam `.mcraw` files.
+
+## Building
+
+1. Install the **Vulkan SDK** and ensure `glslangValidator` is in `PATH`.
+2. Install [**vcpkg**](https://github.com/microsoft/vcpkg) and bootstrap it.
+    Make sure it resides at `C:/dev/vcpkg` (or adjust the toolchain path).
+    Install dependencies using:
+    ```cmd
+    vcpkg install pkgconf "ffmpeg[avcodec,avformat,avutil,swscale,swresample]" glfw3 sdl2
+    ```
+    Ensure `pkgconf` is in your `PATH` so CMake can locate `pkg-config`.
+3. Generate the Visual Studio project using the vcpkg toolchain file:
+    ```cmd
+    cmake -S . -B build -G "Visual Studio 17 2022" -A x64 ^
+          -DCMAKE_TOOLCHAIN_FILE=C:/dev/vcpkg/scripts/buildsystems/vcpkg.cmake
+    ```
+4. Build:
+    ```cmd
+    cmake --build build --config Release
+    ```
+
+FFmpeg is required for the "Export to ProRes" feature. The CMake configuration
+will fail if the libraries cannot be found via vcpkg. When running the
+application on Windows, ensure the FFmpeg runtime DLLs are available. A simple
+approach is to copy them from
+`C:/dev/vcpkg/installed/x64-windows/bin` (e.g. `avcodec-61.dll`,
+`avformat-61.dll`, `avutil-59.dll`, `swscale-8.dll`, `swresample-5.dll`,
+`avfilter-10.dll`) to the output directory next to the executable. The
+`avfilter-10.pdb` file may also be copied for debugging symbols.
+
+## ProRes Export
+
+- Right-click anywhere in the player window to open the context menu.
+- Choose **Export to ProRes** and select a `.mov` file path.
+- Encoding uses FFmpeg linked via vcpkg. Make sure the libraries are installed in your vcpkg instance.
+- Progress is shown in a modal popup while the encoding thread runs.

--- a/external/imgui/CMakeLists.txt
+++ b/external/imgui/CMakeLists.txt
@@ -6,15 +6,9 @@ file(GLOB IMGUI_SRC
     ${CMAKE_CURRENT_SOURCE_DIR}/*.cpp
 )
 
-# Collect the GLFW+OpenGL3 backend sources
-set(IMGUI_BACKENDS
-    ${CMAKE_CURRENT_SOURCE_DIR}/backends/imgui_impl_glfw.cpp
-    ${CMAKE_CURRENT_SOURCE_DIR}/backends/imgui_impl_opengl3.cpp
-)
-
+# Build core ImGui sources only. Backends are compiled by the parent project.
 add_library(imgui STATIC
     ${IMGUI_SRC}
-    ${IMGUI_BACKENDS}
 )
 
 # Public include dirs so users only need to do `target_link_libraries(imgui)` 
@@ -24,18 +18,7 @@ target_include_directories(imgui
         ${CMAKE_CURRENT_SOURCE_DIR}/backends
 )
 
-# Link to GLFW (and OpenGL if needed)
-find_package(glfw3 REQUIRED)        # you already have this
-target_link_libraries(imgui
-    PUBLIC
-        glfw
-)
-
-# On some platforms you may need to link OpenGL
-find_package(OpenGL)
-if(OpenGL_FOUND)
-    target_link_libraries(imgui PUBLIC OpenGL::GL)
-endif()
+# The parent project links GLFW and any renderer backends as needed
 
 # Optional: set C++ standard (should match your main project)
 target_compile_features(imgui PUBLIC cxx_std_17)

--- a/include/App/App.h
+++ b/include/App/App.h
@@ -111,6 +111,7 @@ public:
     void toggleHelpPage() { m_showHelpPage = !m_showHelpPage; }
     void saveCurrentFrameAsDng();
     void convertCurrentFileToDngs();
+    void exportCurrentClipToProRes();
     void performSeek(size_t new_frame_index);
     void triggerOpenFileViaDialog();
 	void setPlaybackMode(PlaybackController::PlaybackMode mode);
@@ -217,6 +218,17 @@ private:
     double m_uiAutoHideDelaySec = 3.0;
     float m_uiFadeSpeed = 3.0f;
 
+#ifdef ENABLE_PRORES_EXPORT
+    struct ProResExportStatus {
+        std::atomic<bool> active{ false };
+        std::atomic<int> currentFrame{ 0 };
+        int totalFrames{ 0 };
+        std::string errorMsg;
+    } m_proResStatus;
+    std::atomic<bool> m_showExportProgressPopup{ false };
+    std::thread m_proResThread;
+#endif
+
 
 #ifdef _WIN32
     HWND _ipcWnd = nullptr;
@@ -257,6 +269,7 @@ private:
     void handleCursorPos(double xpos, double ypos);
     void framebufferSizeCallback(int width, int height);
     std::string openMcrawDialog();
+    std::string openSaveMovDialog();
 
     struct SwapChainSupportDetails {
         VkSurfaceCapabilitiesKHR capabilities;

--- a/include/Utils/ColorPipelineCPU.h
+++ b/include/Utils/ColorPipelineCPU.h
@@ -1,0 +1,19 @@
+#pragma once
+#include <vector>
+#include <cstdint>
+#include <array>
+
+struct CPUColorParams {
+    int width{0};
+    int height{0};
+    int cfaType{0}; // 0 BGGR,1 RGGB,2 GBRG,3 GRBG
+    double blackLevel{0.0};
+    double whiteLevel{65535.0};
+    float gainR{1.0f};
+    float gainG{1.0f};
+    float gainB{1.0f};
+    std::array<float,9> ccm{1,0,0,0,1,0,0,0,1};
+    float saturation{1.0f};
+};
+
+void convertRawToRGB24(const uint16_t* raw, const CPUColorParams& params, std::vector<uint8_t>& outRGB);

--- a/src/App/AppCleanup.cpp
+++ b/src/App/AppCleanup.cpp
@@ -52,6 +52,13 @@ App::~App() {
         m_decodeThread.join();
         LogToFile("[App::~App] Decode thread joined.");
     }
+#ifdef ENABLE_PRORES_EXPORT
+    if (m_proResThread.joinable()) {
+        LogToFile("[App::~App] Joining ProRes export thread...");
+        m_proResThread.join();
+        LogToFile("[App::~App] ProRes export thread joined.");
+    }
+#endif
 
     destroyPersistentStagingBuffers();
 

--- a/src/App/AppIO.cpp
+++ b/src/App/AppIO.cpp
@@ -20,11 +20,21 @@
 
 #include <filesystem>
 #include <iostream>
+#include <fstream>
 #include <numeric>
 #include <algorithm>
 #include <cmath>
 #include <cstdio>
 #include <sstream>
+#ifdef ENABLE_PRORES_EXPORT
+#include <libavformat/avformat.h>
+#include <libavcodec/avcodec.h>
+#include <libavutil/opt.h>
+#include <libavutil/imgutils.h>
+#include <libavutil/channel_layout.h>
+#include <libswscale/swscale.h>
+#endif
+#include "Utils/ColorPipelineCPU.h"
 
 namespace fs = std::filesystem;
 
@@ -1164,6 +1174,279 @@ void App::sendAllPlaylistFilesToMotionCamFS()
     LogToFile(std::string("[App::sendAllToMotionCamFS] Done. Success: ")
         + std::to_string(ok) + ", Fail: " + std::to_string(fail));
 }
+
+#ifdef ENABLE_PRORES_EXPORT
+void App::exportCurrentClipToProRes() {
+    if (m_proResStatus.active.load()) {
+        showActionMessage("Export already running");
+        return;
+    }
+
+    std::string outputPath = openSaveMovDialog();
+    if (outputPath.empty()) return;
+    if (outputPath.size() < 4 || outputPath.substr(outputPath.size() - 4) != ".mov") {
+        outputPath += ".mov";
+    }
+
+    if (!m_decoderWrapper_ptr || !m_decoderWrapper_ptr->getDecoder()) {
+        showActionMessage("No clip loaded");
+        return;
+    }
+
+    m_proResStatus.totalFrames = static_cast<int>(m_decoderWrapper_ptr->getDecoder()->getFrames().size());
+    m_proResStatus.currentFrame.store(0);
+    m_proResStatus.active.store(true);
+    m_proResStatus.errorMsg.clear();
+    m_showExportProgressPopup.store(true);
+    showActionMessage("Export Started");
+
+    if (m_proResThread.joinable()) {
+        m_proResThread.join();
+    }
+
+    m_proResThread = std::thread([this, outputPath]() {
+        av_log_set_level(AV_LOG_ERROR);
+
+        auto* dec = m_decoderWrapper_ptr->getDecoder();
+        const auto& frames = dec->getFrames();
+        if (frames.empty()) {
+            m_proResStatus.errorMsg = "No frames to export";
+            m_proResStatus.active.store(false);
+            return;
+        }
+
+        RawBytes rawBuf;
+        nlohmann::json meta;
+        try {
+            dec->loadFrame(frames[0], rawBuf, meta);
+        } catch (const std::exception& e) {
+            LogToFile(std::string("[ProResExport] Failed to load first frame: ") + e.what());
+            m_proResStatus.errorMsg = "Failed to load first frame";
+            m_proResStatus.active.store(false);
+            return;
+        }
+        int width = meta.value("width", 0);
+        int height = meta.value("height", 0);
+        if (width <= 0 || height <= 0) {
+            m_proResStatus.errorMsg = "Invalid frame dimensions";
+            m_proResStatus.active.store(false);
+            return;
+        }
+
+        int64_t frameDurationNs = 0;
+        if (frames.size() >= 2) {
+            frameDurationNs = frames[1] - frames[0];
+        } else {
+            frameDurationNs = 41708333; // ~24fps fallback
+        }
+        AVRational timeBase{ static_cast<int>(frameDurationNs / 1000), 1000000 };
+
+        AVFormatContext* fmt = nullptr;
+        if (avformat_alloc_output_context2(&fmt, nullptr, nullptr, outputPath.c_str()) < 0 || !fmt) {
+            m_proResStatus.errorMsg = "avformat_alloc_output_context2 failed";
+            m_proResStatus.active.store(false);
+            return;
+        }
+
+        const AVCodec* vcodec = avcodec_find_encoder_by_name("prores_ks");
+        if (!vcodec) {
+            m_proResStatus.errorMsg = "ProRes encoder not found";
+            m_proResStatus.active.store(false);
+            avformat_free_context(fmt);
+            return;
+        }
+
+        AVStream* vstream = avformat_new_stream(fmt, nullptr);
+        AVCodecContext* vctx = avcodec_alloc_context3(vcodec);
+        vctx->codec_id = vcodec->id;
+        vctx->codec_type = AVMEDIA_TYPE_VIDEO;
+        vctx->pix_fmt = AV_PIX_FMT_YUV422P10LE;
+        vctx->width = width;
+        vctx->height = height;
+        vctx->time_base = timeBase;
+        vctx->framerate = av_inv_q(timeBase);
+        if (fmt->oformat->flags & AVFMT_GLOBALHEADER)
+            vctx->flags |= AV_CODEC_FLAG_GLOBAL_HEADER;
+        if (avcodec_open2(vctx, vcodec, nullptr) < 0) {
+            m_proResStatus.errorMsg = "avcodec_open2 failed";
+            m_proResStatus.active.store(false);
+            avcodec_free_context(&vctx);
+            avformat_free_context(fmt);
+            return;
+        }
+        avcodec_parameters_from_context(vstream->codecpar, vctx);
+        vstream->time_base = timeBase;
+
+        // Audio stream (PCM s16le)
+        const AVCodec* acodec = avcodec_find_encoder(AV_CODEC_ID_PCM_S16LE);
+        AVStream* astream = nullptr;
+        AVCodecContext* actx = nullptr;
+        if (acodec) {
+            astream = avformat_new_stream(fmt, nullptr);
+            actx = avcodec_alloc_context3(acodec);
+            actx->codec_id = AV_CODEC_ID_PCM_S16LE;
+            actx->sample_rate = 48000;
+            av_channel_layout_default(&actx->ch_layout, 2);
+            actx->sample_fmt = AV_SAMPLE_FMT_S16;
+            actx->time_base = {1, actx->sample_rate};
+            if (fmt->oformat->flags & AVFMT_GLOBALHEADER)
+                actx->flags |= AV_CODEC_FLAG_GLOBAL_HEADER;
+            if (avcodec_open2(actx, acodec, nullptr) >= 0) {
+                avcodec_parameters_from_context(astream->codecpar, actx);
+                astream->time_base = actx->time_base;
+            } else {
+                avcodec_free_context(&actx);
+                actx = nullptr;
+            }
+        }
+
+        if (!(fmt->oformat->flags & AVFMT_NOFILE)) {
+            if (avio_open(&fmt->pb, outputPath.c_str(), AVIO_FLAG_WRITE) < 0) {
+                m_proResStatus.errorMsg = "avio_open failed";
+                m_proResStatus.active.store(false);
+                avcodec_free_context(&vctx);
+                avformat_free_context(fmt);
+                return;
+            }
+        }
+
+        if (avformat_write_header(fmt, nullptr) < 0) {
+            m_proResStatus.errorMsg = "avformat_write_header failed";
+            m_proResStatus.active.store(false);
+            if (!(fmt->oformat->flags & AVFMT_NOFILE)) avio_closep(&fmt->pb);
+            avcodec_free_context(&vctx);
+            avformat_free_context(fmt);
+            return;
+        }
+
+        AVFrame* frame = av_frame_alloc();
+        frame->format = vctx->pix_fmt;
+        frame->width = width;
+        frame->height = height;
+        av_frame_get_buffer(frame, 32);
+
+        SwsContext* sws = sws_getContext(width, height, AV_PIX_FMT_RGB24,
+                                         width, height, AV_PIX_FMT_YUV422P10LE,
+                                         SWS_BILINEAR, nullptr,nullptr,nullptr);
+
+        CPUColorParams cpParams{};
+        cpParams.width = width;
+        cpParams.height = height;
+        cpParams.cfaType = m_cfaTypeFromMetadata;
+        cpParams.blackLevel = m_staticBlack;
+        cpParams.whiteLevel = m_staticWhite;
+        auto asn_json = meta.value("asShotNeutral", std::vector<double>{1.0,1.0,1.0});
+        if (asn_json.size() >= 3) {
+            cpParams.gainR = (asn_json[1] > 1e-6 && asn_json[0] > 1e-6) ? (float)(asn_json[1]/asn_json[0]) : 1.0f;
+            cpParams.gainB = (asn_json[1] > 1e-6 && asn_json[2] > 1e-6) ? (float)(asn_json[1]/asn_json[2]) : 1.0f;
+        }
+        auto ccm_json = meta.value("ColorMatrix2", meta.value("ColorMatrix", std::vector<float>{1,0,0,0,1,0,0,0,1}));
+        if (ccm_json.size() == 9) {
+            for(int i=0;i<9;++i) cpParams.ccm[i] = ccm_json[i];
+        }
+        cpParams.saturation = 1.0f;
+
+        AVPacket pkt;
+        av_init_packet(&pkt);
+
+        std::vector<uint8_t> rgbBuf;
+        int64_t pts = 0;
+        for (size_t idx = 0; idx < frames.size(); ++idx) {
+            RawBytes raw;
+            nlohmann::json metaTmp;
+            try { dec->loadFrame(frames[idx], raw, metaTmp); }
+            catch (...) { m_proResStatus.errorMsg = "Frame read error"; break; }
+
+            convertRawToRGB24(asU16(raw), cpParams, rgbBuf);
+
+            if (av_frame_make_writable(frame) < 0) { m_proResStatus.errorMsg = "frame not writable"; break; }
+            const uint8_t* srcSlices[1] = { rgbBuf.data() };
+            int srcStride[1] = { width*3 };
+            sws_scale(sws, srcSlices, srcStride, 0, height, frame->data, frame->linesize);
+
+            frame->pts = pts;
+            pts++;
+
+            if (avcodec_send_frame(vctx, frame) < 0) { m_proResStatus.errorMsg = "send_frame failed"; break; }
+            while (avcodec_receive_packet(vctx, &pkt) == 0) {
+                pkt.stream_index = vstream->index;
+                pkt.duration = 1;
+                pkt.pts = av_rescale_q(pkt.pts, vctx->time_base, vstream->time_base);
+                pkt.dts = pkt.pts;
+                if (av_interleaved_write_frame(fmt, &pkt) < 0) { m_proResStatus.errorMsg = "write_frame failed"; av_packet_unref(&pkt); break; }
+                av_packet_unref(&pkt);
+            }
+            m_proResStatus.currentFrame.store(static_cast<int>(idx + 1));
+        }
+
+        // Encode audio
+        if (actx && astream) {
+            motioncam::AudioChunkLoader* loader = m_decoderWrapper_ptr->makeFreshAudioLoader();
+            motioncam::AudioChunk chunk;
+            int64_t audioPts = 0;
+            while (loader && loader->next(chunk)) {
+                if (chunk.second.empty()) break;
+                AVFrame* af = av_frame_alloc();
+                af->format = actx->sample_fmt;
+                av_channel_layout_copy(&af->ch_layout, &actx->ch_layout);
+                af->sample_rate = actx->sample_rate;
+                int nb = chunk.second.size() / actx->ch_layout.nb_channels;
+                af->nb_samples = nb;
+                av_frame_get_buffer(af, 0);
+                memcpy(af->data[0], chunk.second.data(), chunk.second.size()*sizeof(int16_t));
+                af->pts = audioPts;
+                audioPts += nb;
+                if (avcodec_send_frame(actx, af) >= 0) {
+                    AVPacket apkt; av_init_packet(&apkt);
+                    while (avcodec_receive_packet(actx, &apkt) == 0) {
+                        apkt.stream_index = astream->index;
+                        apkt.pts = av_rescale_q(apkt.pts, actx->time_base, astream->time_base);
+                        apkt.dts = apkt.pts;
+                        apkt.duration = apkt.size ? nb : 0;
+                        av_interleaved_write_frame(fmt, &apkt);
+                        av_packet_unref(&apkt);
+                    }
+                }
+                av_frame_free(&af);
+            }
+            avcodec_send_frame(actx, nullptr);
+            AVPacket apkt; av_init_packet(&apkt);
+            while (avcodec_receive_packet(actx, &apkt) == 0) {
+                apkt.stream_index = astream->index;
+                apkt.pts = av_rescale_q(apkt.pts, actx->time_base, astream->time_base);
+                apkt.dts = apkt.pts;
+                av_interleaved_write_frame(fmt, &apkt);
+                av_packet_unref(&apkt);
+            }
+        }
+
+        avcodec_send_frame(vctx, nullptr);
+        while (avcodec_receive_packet(vctx, &pkt) == 0) {
+            pkt.stream_index = vstream->index;
+            pkt.duration = 1;
+            pkt.pts = av_rescale_q(pkt.pts, vctx->time_base, vstream->time_base);
+            pkt.dts = pkt.pts;
+            av_interleaved_write_frame(fmt, &pkt);
+            av_packet_unref(&pkt);
+        }
+
+        av_write_trailer(fmt);
+        sws_freeContext(sws);
+        if (actx) avcodec_free_context(&actx);
+        if (!(fmt->oformat->flags & AVFMT_NOFILE)) avio_closep(&fmt->pb);
+        avcodec_free_context(&vctx);
+        avformat_free_context(fmt);
+
+        if (m_proResStatus.errorMsg.empty()) showActionMessage("Export Finished");
+        else LogToFile(std::string("[ProResExport] Error: ") + m_proResStatus.errorMsg);
+        m_proResStatus.active.store(false);
+    });
+}
+#else
+void App::exportCurrentClipToProRes() {
+    showActionMessage("FFmpeg support not built");
+}
+#endif
 
 void App::setPlaybackMode(PlaybackController::PlaybackMode mode) {
     if (!m_playbackController_ptr) return;

--- a/src/App/AppInit.cpp
+++ b/src/App/AppInit.cpp
@@ -146,6 +146,10 @@ App::App(const std::string& filePath) :
     m_uiOpacity(1.0f),
     m_uiAutoHideDelaySec(3.0),
     m_uiFadeSpeed(3.0f)
+#ifdef ENABLE_PRORES_EXPORT
+    , m_showExportProgressPopup(false)
+    , m_proResStatus()
+#endif
 {
     LogToFile(std::string("App::App Constructor called for file: ") + this->m_filePath);
 #ifndef NDEBUG

--- a/src/App/AppInput.cpp
+++ b/src/App/AppInput.cpp
@@ -488,6 +488,42 @@ std::string App::openMcrawDialog() {
     return {};
 }
 
+std::string App::openSaveMovDialog() {
+#ifdef _WIN32
+    OPENFILENAMEW ofn{};
+    wchar_t szFile[MAX_PATH] = { 0 };
+    ofn.lStructSize = sizeof(ofn);
+
+    HWND ownerHwnd = NULL;
+    if (m_window) {
+        ownerHwnd = glfwGetWin32Window(m_window);
+    }
+
+    ofn.hwndOwner = ownerHwnd;
+    ofn.lpstrFilter = L"MOV files\0*.mov\0All Files\0*.*\0";
+    ofn.lpstrFile = szFile;
+    ofn.nMaxFile = MAX_PATH;
+    ofn.Flags = OFN_OVERWRITEPROMPT | OFN_PATHMUSTEXIST | OFN_NOCHANGEDIR;
+    ofn.lpstrDefExt = L"mov";
+
+    if (GetSaveFileNameW(&ofn)) {
+        std::string utf8Path = DebugLogHelper::wstring_to_utf8(szFile);
+        if (utf8Path.empty() && szFile[0] != L'\0') {
+            LogToFile("[App::openSaveMovDialog] UTF-8 conversion failed for selected path.");
+            return {};
+        }
+        return utf8Path;
+    }
+#else
+    LogToFile("[App::openSaveMovDialog] Save dialog not implemented for this platform. Using console fallback.");
+    std::string path;
+    std::cout << "Enter output .mov path: " << std::flush;
+    std::getline(std::cin, path);
+    return path;
+#endif
+    return {};
+}
+
 void App::triggerOpenFileViaDialog() {
     std::string newPath = openMcrawDialog();
     if (!newPath.empty()) {

--- a/src/Gui/GuiRender.cpp
+++ b/src/Gui/GuiRender.cpp
@@ -55,7 +55,7 @@ namespace GuiOverlay {
         ImGui::NewFrame();
     }
 
-    GuiOverlay::UIData GuiOverlay::gatherData(App* appInstance) {
+    UIData gatherData(App* appInstance) {
         UIData data = {};
         if (!appInstance) return data;
 
@@ -237,6 +237,14 @@ namespace GuiOverlay {
             if (ImGui::MenuItem("Send All in Playlist to MotionCam Fuse", nullptr, false, playlistNotEmpty)) {
                 if (appInstance) appInstance->sendAllPlaylistFilesToMotionCamFS();
             }
+            ImGui::Separator();
+#ifdef ENABLE_PRORES_EXPORT
+            if (ImGui::MenuItem("Export to ProRes", nullptr, false, canOperateOnCurrentFile)) {
+                if (appInstance) appInstance->exportCurrentClipToProRes();
+            }
+#else
+            ImGui::MenuItem("Export to ProRes", nullptr, false, false);
+#endif
             ImGui::EndPopup();
         }
 
@@ -657,6 +665,29 @@ namespace GuiOverlay {
                 appInstance->m_actionMessage.clear();
             }
         }
+
+#ifdef ENABLE_PRORES_EXPORT
+        if (appInstance->m_showExportProgressPopup.load()) {
+            ImGui::OpenPopup("EXPORT_PROGRESS");
+        }
+        if (ImGui::BeginPopupModal("EXPORT_PROGRESS", nullptr, ImGuiWindowFlags_AlwaysAutoResize)) {
+            int cur = appInstance->m_proResStatus.currentFrame.load();
+            int total = appInstance->m_proResStatus.totalFrames;
+            float progress = total > 0 ? static_cast<float>(cur) / static_cast<float>(total) : 0.0f;
+            ImGui::Text("Exporting to ProRes %d / %d", cur, total);
+            ImGui::ProgressBar(progress, ImVec2(200, 0));
+            if (!appInstance->m_proResStatus.errorMsg.empty()) {
+                ImGui::TextColored(ImVec4(1,0,0,1), "%s", appInstance->m_proResStatus.errorMsg.c_str());
+            }
+            if (!appInstance->m_proResStatus.active.load()) {
+                if (ImGui::Button("Close")) {
+                    ImGui::CloseCurrentPopup();
+                    appInstance->m_showExportProgressPopup.store(false);
+                }
+            }
+            ImGui::EndPopup();
+        }
+#endif
         ImGui::PopStyleVar();
     }
 

--- a/src/Utils/ColorPipelineCPU.cpp
+++ b/src/Utils/ColorPipelineCPU.cpp
@@ -1,0 +1,101 @@
+#include "Utils/ColorPipelineCPU.h"
+#include <algorithm>
+#include <cmath>
+
+static inline float srgb_eotf(float v) {
+    v = std::clamp(v, 0.0f, 1.0f);
+    return (v <= 0.0031308f) ? v * 12.92f : 1.055f * std::pow(v, 1.0f/2.4f) - 0.055f;
+}
+
+static inline uint16_t readU16(const uint16_t* src, int x, int y, int w, int h) {
+    x = std::clamp(x,0,w-1);
+    y = std::clamp(y,0,h-1);
+    return src[y*w + x];
+}
+
+static inline float linFromRaw(uint16_t v, double black, double invRange) {
+    double t = (static_cast<double>(v) - black) * invRange;
+    t = std::clamp(t, 0.0, 1.0);
+    return static_cast<float>(t);
+}
+
+void convertRawToRGB24(const uint16_t* raw, const CPUColorParams& p, std::vector<uint8_t>& outRGB)
+{
+    outRGB.resize(p.width * p.height * 3);
+    double range = p.whiteLevel - p.blackLevel;
+    double invRange = (std::abs(range) < 1e-6) ? 1.0 : 1.0 / range;
+
+    auto lin = [&](int x, int y) -> float {
+        return linFromRaw(readU16(raw,x,y,p.width,p.height), p.blackLevel, invRange);
+    };
+    auto interpG = [&](int x, int y)->float{ return 0.25f*(lin(x+1,y)+lin(x-1,y)+lin(x,y+1)+lin(x,y-1));};
+    auto interpH = [&](int x, int y)->float{ return 0.5f*(lin(x+1,y)+lin(x-1,y));};
+    auto interpV = [&](int x, int y)->float{ return 0.5f*(lin(x,y+1)+lin(x,y-1));};
+    auto interpD = [&](int x, int y)->float{ return 0.25f*(lin(x+1,y+1)+lin(x-1,y+1)+lin(x+1,y-1)+lin(x-1,y-1));};
+
+    const float* ccm = p.ccm.data();
+
+    for(int y=0;y<p.height;++y){
+        for(int x=0;x<p.width;++x){
+            bool ye = (y%2)==0;
+            bool xe = (x%2)==0;
+            float r=0,g=0,b=0;
+            switch(p.cfaType){
+                case 0: // BGGR
+                    if(ye){
+                        if(xe){ b=lin(x,y); g=interpG(x,y); r=interpD(x,y); }
+                        else { g=lin(x,y); r=interpV(x,y); b=interpH(x,y); }
+                    }else{
+                        if(xe){ g=lin(x,y); r=interpH(x,y); b=interpV(x,y); }
+                        else { r=lin(x,y); g=interpG(x,y); b=interpD(x,y); }
+                    }
+                    break;
+                case 1: // RGGB
+                    if(ye){
+                        if(xe){ r=lin(x,y); g=interpG(x,y); b=interpD(x,y); }
+                        else { g=lin(x,y); r=interpH(x,y); b=interpV(x,y); }
+                    }else{
+                        if(xe){ g=lin(x,y); r=interpV(x,y); b=interpH(x,y); }
+                        else { b=lin(x,y); g=interpG(x,y); r=interpD(x,y); }
+                    }
+                    break;
+                case 2: // GBRG
+                    if(ye){
+                        if(xe){ g=lin(x,y); r=interpV(x,y); b=interpH(x,y); }
+                        else { b=lin(x,y); g=interpG(x,y); r=interpD(x,y); }
+                    }else{
+                        if(xe){ r=lin(x,y); g=interpG(x,y); b=interpD(x,y); }
+                        else { g=lin(x,y); r=interpH(x,y); b=interpV(x,y); }
+                    }
+                    break;
+                default: // GRBG
+                    if(ye){
+                        if(xe){ g=lin(x,y); r=interpH(x,y); b=interpV(x,y); }
+                        else { r=lin(x,y); g=interpG(x,y); b=interpD(x,y); }
+                    }else{
+                        if(xe){ b=lin(x,y); g=interpG(x,y); r=interpD(x,y); }
+                        else { g=lin(x,y); r=interpV(x,y); b=interpH(x,y); }
+                    }
+                    break;
+            }
+            float r_wb = std::clamp(r * p.gainR, 0.0f, 1.0f);
+            float g_wb = std::clamp(g * p.gainG, 0.0f, 1.0f);
+            float b_wb = std::clamp(b * p.gainB, 0.0f, 1.0f);
+            float r_cc = ccm[0]*r_wb + ccm[3]*g_wb + ccm[6]*b_wb;
+            float g_cc = ccm[1]*r_wb + ccm[4]*g_wb + ccm[7]*b_wb;
+            float b_cc = ccm[2]*r_wb + ccm[5]*g_wb + ccm[8]*b_wb;
+            r_cc = std::clamp(r_cc,0.0f,1.0f);
+            g_cc = std::clamp(g_cc,0.0f,1.0f);
+            b_cc = std::clamp(b_cc,0.0f,1.0f);
+            float lum = 0.2126f*r_cc + 0.7152f*g_cc + 0.0722f*b_cc;
+            float sat = p.saturation;
+            r_cc = lum*(1-sat) + r_cc*sat;
+            g_cc = lum*(1-sat) + g_cc*sat;
+            b_cc = lum*(1-sat) + b_cc*sat;
+            uint8_t* dst = &outRGB[(y*p.width + x)*3];
+            dst[0] = (uint8_t)std::clamp(int(srgb_eotf(r_cc)*255.0f + 0.5f),0,255);
+            dst[1] = (uint8_t)std::clamp(int(srgb_eotf(g_cc)*255.0f + 0.5f),0,255);
+            dst[2] = (uint8_t)std::clamp(int(srgb_eotf(b_cc)*255.0f + 0.5f),0,255);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- gather FFmpeg include dirs and libs from all find-module variants
- apply combined paths when linking so headers are found

## Testing
- `cmake -S . -B build -DCMAKE_BUILD_TYPE=Release`
- `cmake --build build -j$(nproc)` *(fails: dangerous relocation errors with Windows libs)*

------
https://chatgpt.com/codex/tasks/task_e_68664522e6508327b9646f2f51c24775