### PR TITLE
Add detailed FFmpeg startup checks

### DIFF
--- a/include/Utils/DebugLog.h
+++ b/include/Utils/DebugLog.h
@@ -5,6 +5,9 @@
 
 // Simple file logger declaration
 void LogToFile(const std::string& message);
+void LogProRes(const std::string& message);
+// Logs whether FFmpeg/ProRes support is available at runtime
+void LogFFmpegStatus();
 
 // Returns path to directory where log files should be stored.
 // On Windows this uses the user's roaming AppData directory.

--- a/src/App/AppIO.cpp
+++ b/src/App/AppIO.cpp
@@ -1193,7 +1193,10 @@ void App::exportCurrentClipToProRes() {
         return;
     }
 
+    LogProRes(std::string("[ProResExport] Starting export to ") + outputPath);
+
     m_proResStatus.totalFrames = static_cast<int>(m_decoderWrapper_ptr->getDecoder()->getFrames().size());
+    LogProRes(std::string("[ProResExport] Total frames: ") + std::to_string(m_proResStatus.totalFrames));
     m_proResStatus.currentFrame.store(0);
     m_proResStatus.active.store(true);
     m_proResStatus.errorMsg.clear();
@@ -1206,9 +1209,11 @@ void App::exportCurrentClipToProRes() {
 
     m_proResThread = std::thread([this, outputPath]() {
         av_log_set_level(AV_LOG_ERROR);
+        LogProRes("[ProResExport] Thread started");
 
         auto* dec = m_decoderWrapper_ptr->getDecoder();
         const auto& frames = dec->getFrames();
+        LogProRes(std::string("[ProResExport] Frames to export: ") + std::to_string(frames.size()));
         if (frames.empty()) {
             m_proResStatus.errorMsg = "No frames to export";
             m_proResStatus.active.store(false);
@@ -1227,6 +1232,7 @@ void App::exportCurrentClipToProRes() {
         }
         int width = meta.value("width", 0);
         int height = meta.value("height", 0);
+        LogProRes(std::string("[ProResExport] Frame dimensions: ") + std::to_string(width) + "x" + std::to_string(height));
         if (width <= 0 || height <= 0) {
             m_proResStatus.errorMsg = "Invalid frame dimensions";
             m_proResStatus.active.store(false);
@@ -1240,13 +1246,16 @@ void App::exportCurrentClipToProRes() {
             frameDurationNs = 41708333; // ~24fps fallback
         }
         AVRational timeBase{ static_cast<int>(frameDurationNs / 1000), 1000000 };
+        LogProRes(std::string("[ProResExport] Time base: ") + std::to_string(timeBase.num) + "/" + std::to_string(timeBase.den));
 
+        LogProRes("[ProResExport] Allocating output context");
         AVFormatContext* fmt = nullptr;
         if (avformat_alloc_output_context2(&fmt, nullptr, nullptr, outputPath.c_str()) < 0 || !fmt) {
             m_proResStatus.errorMsg = "avformat_alloc_output_context2 failed";
             m_proResStatus.active.store(false);
             return;
         }
+        LogProRes("[ProResExport] Output context created");
 
         const AVCodec* vcodec = avcodec_find_encoder_by_name("prores_ks");
         if (!vcodec) {
@@ -1255,6 +1264,7 @@ void App::exportCurrentClipToProRes() {
             avformat_free_context(fmt);
             return;
         }
+        LogProRes("[ProResExport] ProRes encoder found");
 
         AVStream* vstream = avformat_new_stream(fmt, nullptr);
         AVCodecContext* vctx = avcodec_alloc_context3(vcodec);
@@ -1294,13 +1304,16 @@ void App::exportCurrentClipToProRes() {
             if (avcodec_open2(actx, acodec, nullptr) >= 0) {
                 avcodec_parameters_from_context(astream->codecpar, actx);
                 astream->time_base = actx->time_base;
+                LogProRes("[ProResExport] Audio encoder initialized");
             } else {
                 avcodec_free_context(&actx);
                 actx = nullptr;
+                LogProRes("[ProResExport] Failed to initialize audio encoder");
             }
         }
 
         if (!(fmt->oformat->flags & AVFMT_NOFILE)) {
+            LogProRes("[ProResExport] Opening output file");
             if (avio_open(&fmt->pb, outputPath.c_str(), AVIO_FLAG_WRITE) < 0) {
                 m_proResStatus.errorMsg = "avio_open failed";
                 m_proResStatus.active.store(false);
@@ -1308,8 +1321,10 @@ void App::exportCurrentClipToProRes() {
                 avformat_free_context(fmt);
                 return;
             }
+            LogProRes("[ProResExport] Output file opened");
         }
 
+        LogProRes("[ProResExport] Writing header");
         if (avformat_write_header(fmt, nullptr) < 0) {
             m_proResStatus.errorMsg = "avformat_write_header failed";
             m_proResStatus.active.store(false);
@@ -1318,6 +1333,7 @@ void App::exportCurrentClipToProRes() {
             avformat_free_context(fmt);
             return;
         }
+        LogProRes("[ProResExport] Header written");
 
         AVFrame* frame = av_frame_alloc();
         frame->format = vctx->pix_fmt;
@@ -1377,10 +1393,14 @@ void App::exportCurrentClipToProRes() {
                 av_packet_unref(&pkt);
             }
             m_proResStatus.currentFrame.store(static_cast<int>(idx + 1));
+            if ((idx + 1) % 50 == 0) {
+                LogProRes(std::string("[ProResExport] Encoded frame ") + std::to_string(idx + 1) + "/" + std::to_string(frames.size()));
+            }
         }
 
         // Encode audio
         if (actx && astream) {
+            LogProRes("[ProResExport] Starting audio encode");
             motioncam::AudioChunkLoader* loader = m_decoderWrapper_ptr->makeFreshAudioLoader();
             motioncam::AudioChunk chunk;
             int64_t audioPts = 0;
@@ -1418,6 +1438,7 @@ void App::exportCurrentClipToProRes() {
                 av_interleaved_write_frame(fmt, &apkt);
                 av_packet_unref(&apkt);
             }
+            LogProRes("[ProResExport] Audio encode finished");
         }
 
         avcodec_send_frame(vctx, nullptr);
@@ -1437,8 +1458,14 @@ void App::exportCurrentClipToProRes() {
         avcodec_free_context(&vctx);
         avformat_free_context(fmt);
 
-        if (m_proResStatus.errorMsg.empty()) showActionMessage("Export Finished");
-        else LogToFile(std::string("[ProResExport] Error: ") + m_proResStatus.errorMsg);
+        if (m_proResStatus.errorMsg.empty()) {
+            showActionMessage("Export Finished");
+            LogProRes("[ProResExport] Export finished successfully");
+        }
+        else {
+            LogToFile(std::string("[ProResExport] Error: ") + m_proResStatus.errorMsg);
+            LogProRes(std::string("[ProResExport] Error: ") + m_proResStatus.errorMsg);
+        }
         m_proResStatus.active.store(false);
     });
 }

--- a/src/Utils/DebugLog.cpp
+++ b/src/Utils/DebugLog.cpp
@@ -12,8 +12,30 @@
 #   include <windows.h>
 #   include <shlobj.h>
 #endif
+#ifdef ENABLE_PRORES_EXPORT
+#include <libavcodec/avcodec.h>
+#include <libavformat/avformat.h>
+#endif
 
 static std::mutex g_log_mutex; // Mutex to protect file access
+
+// helper to format timestamp for log entries
+static std::string make_timestamp()
+{
+    auto now = std::chrono::system_clock::now();
+    auto ms = std::chrono::duration_cast<std::chrono::milliseconds>(now.time_since_epoch()) % 1000;
+    std::time_t time_now = std::chrono::system_clock::to_time_t(now);
+    std::tm timeinfo{};
+#ifdef _WIN32
+    localtime_s(&timeinfo, &time_now);
+#else
+    localtime_r(&time_now, &timeinfo);
+#endif
+    std::ostringstream oss;
+    oss << std::put_time(&timeinfo, "%Y-%m-%d %H:%M:%S");
+    oss << '.' << std::setfill('0') << std::setw(3) << ms.count();
+    return oss.str();
+}
 
 // Application base path defined in main.cpp
 extern std::string g_AppBasePath;
@@ -52,6 +74,21 @@ static std::ofstream& get_log_file() {
     return log_file;
 }
 
+// Separate log file specifically for ProRes export diagnostics
+static std::ofstream& get_prores_log_file() {
+    static std::ofstream log_file;
+    static bool initialized = false;
+    if (!initialized) {
+        std::filesystem::path logDir = getLogDirectory();
+        std::error_code ec;
+        std::filesystem::create_directories(logDir, ec);
+        std::filesystem::path logPath = logDir / "prores_export_log.txt";
+        log_file.open(logPath, std::ios_base::app | std::ios_base::out);
+        initialized = true;
+    }
+    return log_file;
+}
+
 void LogToFile(const std::string& message) {
     std::lock_guard<std::mutex> lock(g_log_mutex); // Lock for thread safety
 
@@ -76,4 +113,61 @@ void LogToFile(const std::string& message) {
         log_file << "[" << oss.str() << "] " << message << std::endl;
         // log_file.flush(); // Optional: flush immediately, impacts performance
     }
+}
+
+void LogProRes(const std::string& message) {
+    std::lock_guard<std::mutex> lock(g_log_mutex);
+
+    std::ofstream& log_file = get_prores_log_file();
+    if (log_file.is_open()) {
+        log_file << "[" << make_timestamp() << "] " << message << std::endl;
+    }
+}
+
+void LogFFmpegStatus() {
+#ifdef ENABLE_PRORES_EXPORT
+    LogToFile("[FFmpeg] ProRes export support compiled in.");
+    LogProRes("[FFmpeg] ProRes export support compiled in.");
+#   ifdef _WIN32
+    const char* dlls[] = {
+        "avcodec-61.dll", "avformat-61.dll", "avutil-59.dll",
+        "swscale-8.dll", "swresample-5.dll", "avfilter-10.dll" };
+    std::filesystem::path exeDir = g_AppBasePath.empty() ? std::filesystem::current_path() : std::filesystem::path(g_AppBasePath);
+    bool allLoaded = true;
+    for (const char* dll : dlls) {
+        std::filesystem::path p = exeDir / dll;
+        if (std::filesystem::exists(p)) {
+            HMODULE h = LoadLibraryA(p.string().c_str());
+            if (h) {
+                LogToFile(std::string("[FFmpeg] Loaded ") + dll);
+                LogProRes(std::string("[FFmpeg] Loaded ") + dll);
+                FreeLibrary(h);
+            } else {
+                LogToFile(std::string("[FFmpeg] Failed to load ") + dll + " error " + std::to_string(GetLastError()));
+                LogProRes(std::string("[FFmpeg] Failed to load ") + dll + " error " + std::to_string(GetLastError()));
+                allLoaded = false;
+            }
+        } else {
+            LogToFile(std::string("[FFmpeg] Missing ") + dll);
+            LogProRes(std::string("[FFmpeg] Missing ") + dll);
+            allLoaded = false;
+        }
+    }
+    if (allLoaded) {
+        LogToFile("[FFmpeg] All DLLs loaded; ProRes export enabled.");
+        LogProRes("[FFmpeg] All DLLs loaded; ProRes export enabled.");
+    } else {
+        LogToFile("[FFmpeg] Some FFmpeg DLLs could not be loaded; export may fail.");
+        LogProRes("[FFmpeg] Some FFmpeg DLLs could not be loaded; export may fail.");
+    }
+#   else
+    av_register_all();
+    int version = avcodec_version();
+    LogToFile(std::string("[FFmpeg] avcodec version ") + std::to_string(version));
+    LogProRes(std::string("[FFmpeg] avcodec version ") + std::to_string(version));
+#   endif
+#else
+    LogToFile("[FFmpeg] FFmpeg support not built; ProRes export unavailable.");
+    LogProRes("[FFmpeg] FFmpeg support not built; ProRes export unavailable.");
+#endif
 }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -200,6 +200,12 @@ int main(int argc, char* argv[]) {
     // Determine and set the application base path.
     determineAppBasePath(argc > 0 ? argv[0] : "");
 
+    // Force creation of ProRes log at startup
+    LogProRes("[Startup] ProRes log initialized");
+
+    // Record whether FFmpeg support is available
+    LogFFmpegStatus();
+
 
 #ifdef _WIN32
     static const wchar_t* kMutexName = L"MCRAW_PLAYER_SINGLE_INSTANCE_MUTEX_V2_UNIQUE";


### PR DESCRIPTION
## Summary
- expand `LogFFmpegStatus` to attempt loading each FFmpeg DLL
- log `avcodec_version` on non-Windows systems
- create the ProRes log on startup

## Testing
- `cmake -S . -B build -DCMAKE_BUILD_TYPE=Release` *(fails: could not find FFmpeg)*
- `cmake --build build` *(fails: No rule to make target `Makefile`)*

------
https://chatgpt.com/codex/tasks/task_e_68676ba206cc8327b246597210e7a992