### PR TITLE
Fix linking of FFmpeg

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -37,6 +37,7 @@ message(STATUS "FFmpeg_FOUND=${FFmpeg_FOUND} FFMPEG_FOUND=${FFMPEG_FOUND}")
 if(FFMPEG_FOUND OR FFmpeg_FOUND)
     message(STATUS "FFmpeg found via vcpkg, enabling ProRes export")
     set(HAVE_FFMPEG TRUE)
+    set(PRORES_COMPILE_DEFS ENABLE_PRORES_EXPORT)
 else()
     message(STATUS "FFmpeg not found; ProRes export disabled")
     set(HAVE_FFMPEG FALSE)
@@ -180,6 +181,9 @@ add_dependencies(${PROJECT_NAME} CompileShaders glm motioncam_decoder imgui)
 
 target_compile_definitions(${PROJECT_NAME} PRIVATE SDL_MAIN_HANDLED)
 target_compile_definitions(${PROJECT_NAME} PRIVATE GLFW_INCLUDE_NONE)
+if(PRORES_COMPILE_DEFS)
+    target_compile_definitions(${PROJECT_NAME} PRIVATE ${PRORES_COMPILE_DEFS})
+endif()
 if(MSVC AND CMAKE_SYSTEM_NAME STREQUAL "Windows")
     set_target_properties(${PROJECT_NAME} PROPERTIES LINK_FLAGS "/ENTRY:mainCRTStartup")
     message(STATUS "MSVC: Setting LINK_FLAGS /ENTRY:mainCRTStartup for ${PROJECT_NAME}")
@@ -230,20 +234,18 @@ target_link_libraries(${PROJECT_NAME} PRIVATE
 )
 
 # ─── FFmpeg link block (uses imported targets) ────────────────────────
-find_package(FFMPEG REQUIRED
-  COMPONENTS avcodec avformat avutil swscale swresample
-)
-
-# headers
 target_include_directories(${PROJECT_NAME}
   PRIVATE
     ${FFMPEG_INCLUDE_DIRS}
 )
 
-# all the libs in one go
 target_link_libraries(${PROJECT_NAME}
   PRIVATE
-    ${FFMPEG_LIBRARIES}
+    FFMPEG::avcodec
+    FFMPEG::avformat
+    FFMPEG::avutil
+    FFMPEG::swscale
+    FFMPEG::swresample
 )
 # ───────────────────────────────────────────────────────────────────────
 

--- a/README.md
+++ b/README.md
@@ -22,9 +22,12 @@ This project builds a desktop player for MotionCam `.mcraw` files.
     cmake --build build --config Release
     ```
 
-FFmpeg is required for the "Export to ProRes" feature. The CMake configuration
-will fail if the libraries cannot be found via vcpkg. When running the
-application on Windows, ensure the FFmpeg runtime DLLs are available. A simple
+FFmpeg is required for the "Export to ProRes" feature. When detected, the build
+system defines the `ENABLE_PRORES_EXPORT` flag and links against the
+`FFMPEG::` imported targets provided by vcpkg so the relevant code is compiled
+automatically. The CMake configuration will fail if the libraries cannot be
+found via vcpkg. When running the application on Windows, ensure the FFmpeg
+runtime DLLs are available. A simple
 approach is to copy them from
 `C:/dev/vcpkg/installed/x64-windows/bin` (e.g. `avcodec-61.dll`,
 `avformat-61.dll`, `avutil-59.dll`, `swscale-8.dll`, `swresample-5.dll`,


### PR DESCRIPTION
## Summary
- link against imported `FFMPEG::` targets instead of the raw library list
- document the automatic linking in README

## Testing
- `cmake -S . -B build` *(fails: could not find FFMPEG package)*

------
https://chatgpt.com/codex/tasks/task_e_6867856a68b88327bec9af70fefcf3bd