### PR TITLE
Fix ProRes compile flag

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -180,6 +180,9 @@ add_dependencies(${PROJECT_NAME} CompileShaders glm motioncam_decoder imgui)
 
 target_compile_definitions(${PROJECT_NAME} PRIVATE SDL_MAIN_HANDLED)
 target_compile_definitions(${PROJECT_NAME} PRIVATE GLFW_INCLUDE_NONE)
+if(HAVE_FFMPEG)
+    target_compile_definitions(${PROJECT_NAME} PRIVATE ENABLE_PRORES_EXPORT)
+endif()
 if(MSVC AND CMAKE_SYSTEM_NAME STREQUAL "Windows")
     set_target_properties(${PROJECT_NAME} PROPERTIES LINK_FLAGS "/ENTRY:mainCRTStartup")
     message(STATUS "MSVC: Setting LINK_FLAGS /ENTRY:mainCRTStartup for ${PROJECT_NAME}")
@@ -230,21 +233,28 @@ target_link_libraries(${PROJECT_NAME} PRIVATE
 )
 
 # ─── FFmpeg link block (uses imported targets) ────────────────────────
-find_package(FFMPEG REQUIRED
-  COMPONENTS avcodec avformat avutil swscale swresample
-)
-
-# headers
 target_include_directories(${PROJECT_NAME}
   PRIVATE
     ${FFMPEG_INCLUDE_DIRS}
 )
 
-# all the libs in one go
-target_link_libraries(${PROJECT_NAME}
-  PRIVATE
-    ${FFMPEG_LIBRARIES}
-)
+# Prefer the imported targets provided by FindFFmpeg (vcpkg), but
+# fall back to the library list variables if the targets are not available.
+if(TARGET FFMPEG::avcodec)
+    target_link_libraries(${PROJECT_NAME}
+      PRIVATE
+        FFMPEG::avcodec
+        FFMPEG::avformat
+        FFMPEG::avutil
+        FFMPEG::swscale
+        FFMPEG::swresample
+    )
+else()
+    target_link_libraries(${PROJECT_NAME}
+      PRIVATE
+        ${FFMPEG_LIBRARIES}
+    )
+endif()
 # ───────────────────────────────────────────────────────────────────────
 
 if(WIN32)

--- a/README.md
+++ b/README.md
@@ -22,14 +22,23 @@ This project builds a desktop player for MotionCam `.mcraw` files.
     cmake --build build --config Release
     ```
 
-FFmpeg is required for the "Export to ProRes" feature. The CMake configuration
-will fail if the libraries cannot be found via vcpkg. When running the
-application on Windows, ensure the FFmpeg runtime DLLs are available. A simple
+FFmpeg is required for the "Export to ProRes" feature. When detected, the build
+system defines the `ENABLE_PRORES_EXPORT` flag. It will link using the
+`FFMPEG::` imported targets provided by vcpkg when they are available, falling
+back to the `${FFMPEG_LIBRARIES}` list otherwise. The CMake configuration will
+fail if the libraries cannot be found via vcpkg. When running the application on
+Windows, ensure the FFmpeg runtime DLLs are available. A simple
 approach is to copy them from
 `C:/dev/vcpkg/installed/x64-windows/bin` (e.g. `avcodec-61.dll`,
 `avformat-61.dll`, `avutil-59.dll`, `swscale-8.dll`, `swresample-5.dll`,
 `avfilter-10.dll`) to the output directory next to the executable. The
 `avfilter-10.pdb` file may also be copied for debugging symbols.
+
+If the **Export to ProRes** option is grayed out in the application, it means
+the binary was built without FFmpeg support. Re-run CMake and check that the
+configure step prints "FFmpeg found via vcpkg, enabling ProRes export". When
+this message appears, the `ENABLE_PRORES_EXPORT` definition is added and the
+runtime DLLs will be copied automatically.
 
 ## ProRes Export
 


### PR DESCRIPTION
## Summary
- define ENABLE_PRORES_EXPORT directly when FFmpeg is detected
- clarify troubleshooting steps when ProRes export is greyed out

## Testing
- `cmake -S . -B build` *(fails: could not find FFMPEG package)*

------
https://chatgpt.com/codex/tasks/task_e_6867856a68b88327bec9af70fefcf3bd