### PR TITLE
Add experimental HEVC hardware export option

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -32,6 +32,7 @@ if(NOT Vulkan_FOUND)
     message(FATAL_ERROR "Vulkan SDK not found. Please ensure it is installed and discoverable.")
 endif()
 find_package(Threads REQUIRED)
+find_package(OpenMP)
 find_package(FFMPEG REQUIRED COMPONENTS avcodec avformat avutil swscale swresample)
 message(STATUS "FFmpeg_FOUND=${FFmpeg_FOUND} FFMPEG_FOUND=${FFMPEG_FOUND}")
 if(FFMPEG_FOUND OR FFmpeg_FOUND)
@@ -182,6 +183,7 @@ target_compile_definitions(${PROJECT_NAME} PRIVATE SDL_MAIN_HANDLED)
 target_compile_definitions(${PROJECT_NAME} PRIVATE GLFW_INCLUDE_NONE)
 if(HAVE_FFMPEG)
     target_compile_definitions(${PROJECT_NAME} PRIVATE ENABLE_PRORES_EXPORT)
+    target_compile_definitions(${PROJECT_NAME} PRIVATE ENABLE_HEVC_EXPORT)
 endif()
 if(MSVC AND CMAKE_SYSTEM_NAME STREQUAL "Windows")
     set_target_properties(${PROJECT_NAME} PROPERTIES LINK_FLAGS "/ENTRY:mainCRTStartup")
@@ -231,6 +233,11 @@ target_link_libraries(${PROJECT_NAME} PRIVATE
     "${SDL2_LIBRARY_DIR}/SDL2.lib"
     ${Vulkan_LIBRARIES}
 )
+if(OpenMP_CXX_FOUND)
+    target_link_libraries(${PROJECT_NAME} PRIVATE OpenMP::OpenMP_CXX)
+    target_compile_definitions(${PROJECT_NAME} PRIVATE USE_OPENMP)
+    message(STATUS "OpenMP enabled for ${PROJECT_NAME}")
+endif()
 
 # ─── FFmpeg link block (uses imported targets) ────────────────────────
 target_include_directories(${PROJECT_NAME}

--- a/include/App/App.h
+++ b/include/App/App.h
@@ -112,6 +112,7 @@ public:
     void saveCurrentFrameAsDng();
     void convertCurrentFileToDngs();
     void exportCurrentClipToProRes();
+    void exportCurrentClipToHevc();
     void performSeek(size_t new_frame_index);
     void triggerOpenFileViaDialog();
 	void setPlaybackMode(PlaybackController::PlaybackMode mode);
@@ -229,6 +230,17 @@ private:
     std::thread m_proResThread;
 #endif
 
+#ifdef ENABLE_HEVC_EXPORT
+    struct HevcExportStatus {
+        std::atomic<bool> active{ false };
+        std::atomic<int> currentFrame{ 0 };
+        int totalFrames{ 0 };
+        std::string errorMsg;
+    } m_hevcStatus;
+    std::atomic<bool> m_showHevcProgressPopup{ false };
+    std::thread m_hevcThread;
+#endif
+
 
 #ifdef _WIN32
     HWND _ipcWnd = nullptr;
@@ -270,6 +282,7 @@ private:
     void framebufferSizeCallback(int width, int height);
     std::string openMcrawDialog();
     std::string openSaveMovDialog();
+    std::string openSaveMp4Dialog();
 
     struct SwapChainSupportDetails {
         VkSurfaceCapabilitiesKHR capabilities;

--- a/include/Utils/DebugLog.h
+++ b/include/Utils/DebugLog.h
@@ -6,6 +6,7 @@
 // Simple file logger declaration
 void LogToFile(const std::string& message);
 void LogProRes(const std::string& message);
+void LogHevc(const std::string& message);
 // Logs whether FFmpeg/ProRes support is available at runtime
 void LogFFmpegStatus();
 

--- a/src/App/AppCleanup.cpp
+++ b/src/App/AppCleanup.cpp
@@ -59,6 +59,13 @@ App::~App() {
         LogToFile("[App::~App] ProRes export thread joined.");
     }
 #endif
+#ifdef ENABLE_HEVC_EXPORT
+    if (m_hevcThread.joinable()) {
+        LogToFile("[App::~App] Joining HEVC export thread...");
+        m_hevcThread.join();
+        LogToFile("[App::~App] HEVC export thread joined.");
+    }
+#endif
 
     destroyPersistentStagingBuffers();
 

--- a/src/App/AppIO.cpp
+++ b/src/App/AppIO.cpp
@@ -26,7 +26,7 @@
 #include <cmath>
 #include <cstdio>
 #include <sstream>
-#ifdef ENABLE_PRORES_EXPORT
+#if defined(ENABLE_PRORES_EXPORT) || defined(ENABLE_HEVC_EXPORT)
 #include "ffmpeg_headers.hpp"
 #endif
 #include "Utils/ColorPipelineCPU.h"
@@ -1205,6 +1205,7 @@ void App::exportCurrentClipToProRes() {
     m_proResThread = std::thread([this, outputPath]() {
         av_log_set_level(AV_LOG_ERROR);
         LogProRes("[ProResExport] Thread started");
+        auto exportStartTime = std::chrono::high_resolution_clock::now();
 
         auto* dec = m_decoderWrapper_ptr->getDecoder();
         const auto& frames = dec->getFrames();
@@ -1417,11 +1418,17 @@ void App::exportCurrentClipToProRes() {
         for (size_t idx = 0; idx < frames.size(); ++idx) {
             RawBytes raw;
             nlohmann::json metaTmp;
+
+            auto t0 = std::chrono::high_resolution_clock::now();
             try { dec->loadFrame(frames[idx], raw, metaTmp); }
             catch (...) { m_proResStatus.errorMsg = "Frame read error"; break; }
+            auto t1 = std::chrono::high_resolution_clock::now();
 
+            auto t2 = std::chrono::high_resolution_clock::now();
             convertRawToRGB24(asU16(raw), cpParams, rgbBuf);
+            auto t3 = std::chrono::high_resolution_clock::now();
 
+            auto t4 = std::chrono::high_resolution_clock::now();
             if (av_frame_make_writable(frame) < 0) { m_proResStatus.errorMsg = "frame not writable"; break; }
             const uint8_t* srcSlices[1] = { rgbBuf.data() };
             int srcStride[1] = { width*3 };
@@ -1440,7 +1447,21 @@ void App::exportCurrentClipToProRes() {
                 av_packet_unref(&pkt);
                 ++framesEncoded;
             }
+            auto t5 = std::chrono::high_resolution_clock::now();
+
             m_proResStatus.currentFrame.store(static_cast<int>(idx + 1));
+
+            double loadMs    = std::chrono::duration<double, std::milli>(t1 - t0).count();
+            double convertMs = std::chrono::duration<double, std::milli>(t3 - t2).count();
+            double encodeMs  = std::chrono::duration<double, std::milli>(t5 - t4).count();
+
+            std::ostringstream stageLog;
+            stageLog << "[ProResExport] Frame " << (idx + 1)
+                     << " loadFrame=" << loadMs << "ms"
+                     << " convert=" << convertMs << "ms"
+                     << " encode=" << encodeMs << "ms";
+            LogProRes(stageLog.str());
+
             if ((idx + 1) % 50 == 0) {
                 LogProRes(std::string("[ProResExport] Encoded frame ") + std::to_string(idx + 1) + "/" + std::to_string(frames.size()));
             }
@@ -1504,6 +1525,15 @@ void App::exportCurrentClipToProRes() {
             m_proResStatus.errorMsg = "No video frames encoded";
         }
 
+        auto exportEndTime = std::chrono::high_resolution_clock::now();
+        double totalMs = std::chrono::duration<double, std::milli>(exportEndTime - exportStartTime).count();
+        double avgMs = framesEncoded > 0 ? totalMs / framesEncoded : 0.0;
+        {
+            std::ostringstream oss;
+            oss << "[ProResExport] Export duration " << totalMs << " ms (avg " << avgMs << " ms/frame)";
+            LogProRes(oss.str());
+        }
+
         av_write_trailer(fmt);
         sws_freeContext(sws);
         if (actx) avcodec_free_context(&actx);
@@ -1524,6 +1554,247 @@ void App::exportCurrentClipToProRes() {
 }
 #else
 void App::exportCurrentClipToProRes() {
+    showActionMessage("FFmpeg support not built");
+}
+#endif
+
+#ifdef ENABLE_HEVC_EXPORT
+void App::exportCurrentClipToHevc() {
+    if (m_hevcStatus.active.load()) {
+        showActionMessage("Export already running");
+        return;
+    }
+
+    std::string outputPath = openSaveMp4Dialog();
+    if (outputPath.empty()) return;
+    if (outputPath.size() < 4 || outputPath.substr(outputPath.size() - 4) != ".mp4") {
+        outputPath += ".mp4";
+    }
+
+    if (!m_decoderWrapper_ptr || !m_decoderWrapper_ptr->getDecoder()) {
+        showActionMessage("No clip loaded");
+        return;
+    }
+
+    LogHevc(std::string("[HevcExport] Starting export to ") + outputPath);
+
+    m_hevcStatus.totalFrames = static_cast<int>(m_decoderWrapper_ptr->getDecoder()->getFrames().size());
+    LogHevc(std::string("[HevcExport] Total frames: ") + std::to_string(m_hevcStatus.totalFrames));
+    m_hevcStatus.currentFrame.store(0);
+    m_hevcStatus.active.store(true);
+    m_hevcStatus.errorMsg.clear();
+    m_showHevcProgressPopup.store(true);
+    showActionMessage("Export Started");
+
+    if (m_hevcThread.joinable()) {
+        m_hevcThread.join();
+    }
+
+    m_hevcThread = std::thread([this, outputPath]() {
+        av_log_set_level(AV_LOG_ERROR);
+        LogHevc("[HevcExport] Thread started");
+        auto exportStartTime = std::chrono::high_resolution_clock::now();
+
+        auto* dec = m_decoderWrapper_ptr->getDecoder();
+        const auto& frames = dec->getFrames();
+        if (frames.empty()) {
+            m_hevcStatus.errorMsg = "No frames to export";
+            m_hevcStatus.active.store(false);
+            return;
+        }
+
+        RawBytes rawBuf;
+        nlohmann::json meta;
+        try {
+            dec->loadFrame(frames[0], rawBuf, meta);
+        } catch (const std::exception& e) {
+            LogToFile(std::string("[HevcExport] Failed to load first frame: ") + e.what());
+            m_hevcStatus.errorMsg = "Failed to load first frame";
+            m_hevcStatus.active.store(false);
+            return;
+        }
+        int width = meta.value("width", 0);
+        int height = meta.value("height", 0);
+        if (width <= 0 || height <= 0) {
+            m_hevcStatus.errorMsg = "Invalid frame dimensions";
+            m_hevcStatus.active.store(false);
+            return;
+        }
+
+        int64_t frameDurationNs = 0;
+        if (frames.size() >= 2) {
+            frameDurationNs = frames[1] - frames[0];
+        } else {
+            frameDurationNs = 41708333;
+        }
+        AVRational timeBase{ static_cast<int>(frameDurationNs / 1000), 1000000 };
+
+        AVFormatContext* fmt = nullptr;
+        if (avformat_alloc_output_context2(&fmt, nullptr, nullptr, outputPath.c_str()) < 0 || !fmt) {
+            m_hevcStatus.errorMsg = "avformat_alloc_output_context2 failed";
+            m_hevcStatus.active.store(false);
+            return;
+        }
+
+        const AVCodec* vcodec = avcodec_find_encoder_by_name("hevc_amf");
+        if (!vcodec) vcodec = avcodec_find_encoder(AV_CODEC_ID_HEVC);
+        if (!vcodec) {
+            m_hevcStatus.errorMsg = "HEVC encoder not found";
+            m_hevcStatus.active.store(false);
+            avformat_free_context(fmt);
+            return;
+        }
+
+        AVStream* vstream = avformat_new_stream(fmt, nullptr);
+        if (!vstream) {
+            m_hevcStatus.errorMsg = "avformat_new_stream failed";
+            m_hevcStatus.active.store(false);
+            avformat_free_context(fmt);
+            return;
+        }
+        AVCodecContext* vctx = avcodec_alloc_context3(vcodec);
+        vctx->codec_id = vcodec->id;
+        vctx->codec_type = AVMEDIA_TYPE_VIDEO;
+        vctx->pix_fmt = AV_PIX_FMT_P010LE;
+        vctx->width = width;
+        vctx->height = height;
+        vctx->time_base = timeBase;
+        vctx->framerate = av_inv_q(timeBase);
+        if (fmt->oformat->flags & AVFMT_GLOBALHEADER)
+            vctx->flags |= AV_CODEC_FLAG_GLOBAL_HEADER;
+
+        av_opt_set(vctx->priv_data, "preset", "quality", 0);
+
+        if (avcodec_open2(vctx, vcodec, nullptr) < 0) {
+            m_hevcStatus.errorMsg = "avcodec_open2 failed";
+            m_hevcStatus.active.store(false);
+            avcodec_free_context(&vctx);
+            avformat_free_context(fmt);
+            return;
+        }
+
+        avcodec_parameters_from_context(vstream->codecpar, vctx);
+        vstream->time_base = timeBase;
+
+        if (!(fmt->oformat->flags & AVFMT_NOFILE)) {
+            if (avio_open(&fmt->pb, outputPath.c_str(), AVIO_FLAG_WRITE) < 0) {
+                m_hevcStatus.errorMsg = "Failed to open output file";
+                m_hevcStatus.active.store(false);
+                avcodec_free_context(&vctx);
+                avformat_free_context(fmt);
+                return;
+            }
+        }
+        if (avformat_write_header(fmt, nullptr) < 0) {
+            m_hevcStatus.errorMsg = "avformat_write_header failed";
+            m_hevcStatus.active.store(false);
+            if (!(fmt->oformat->flags & AVFMT_NOFILE)) avio_closep(&fmt->pb);
+            avcodec_free_context(&vctx);
+            avformat_free_context(fmt);
+            return;
+        }
+
+        SwsContext* sws = sws_getContext(width, height, AV_PIX_FMT_RGB24,
+                                         width, height, AV_PIX_FMT_P010LE,
+                                         SWS_BILINEAR, nullptr, nullptr, nullptr);
+        CPUColorParams cpParams;
+        cpParams.width = width;
+        cpParams.height = height;
+        cpParams.blackLevel = meta.value("blackLevel", 0.0);
+        cpParams.whiteLevel = meta.value("whiteLevel", 1023.0);
+        cpParams.asShotNeutral = meta.value("asShotNeutral", std::vector<float>{1.0f,1.0f,1.0f});
+        cpParams.ccm = meta.value("ColorMatrix", std::vector<float>(9,0.0f));
+        cpParams.cfaType = meta.value("cfaPattern", 0);
+        cpParams.saturation = 1.0f;
+
+        std::vector<uint8_t> rgbBuf;
+        RawBytes raw;
+        nlohmann::json metaTmp;
+        AVFrame* frame = av_frame_alloc();
+        frame->format = vctx->pix_fmt;
+        frame->width = width;
+        frame->height = height;
+        av_frame_get_buffer(frame, 0);
+
+        int64_t pts = 0;
+        size_t framesEncoded = 0;
+
+        for (size_t idx = 0; idx < frames.size(); ++idx) {
+            auto t0 = std::chrono::high_resolution_clock::now();
+            try { dec->loadFrame(frames[idx], raw, metaTmp); }
+            catch (...) { m_hevcStatus.errorMsg = "Frame read error"; break; }
+            auto t1 = std::chrono::high_resolution_clock::now();
+            convertRawToRGB24(asU16(raw), cpParams, rgbBuf);
+            auto t2 = std::chrono::high_resolution_clock::now();
+            if (av_frame_make_writable(frame) < 0) { m_hevcStatus.errorMsg = "frame not writable"; break; }
+            const uint8_t* srcSlices[1] = { rgbBuf.data() };
+            int srcStride[1] = { width * 3 };
+            sws_scale(sws, srcSlices, srcStride, 0, height, frame->data, frame->linesize);
+            frame->pts = pts++;
+            if (avcodec_send_frame(vctx, frame) < 0) { m_hevcStatus.errorMsg = "send_frame failed"; break; }
+            AVPacket pkt{};
+            while (avcodec_receive_packet(vctx, &pkt) == 0) {
+                pkt.stream_index = vstream->index;
+                pkt.duration = 1;
+                pkt.pts = av_rescale_q(pkt.pts, vctx->time_base, vstream->time_base);
+                pkt.dts = pkt.pts;
+                if (av_interleaved_write_frame(fmt, &pkt) < 0) { m_hevcStatus.errorMsg = "write_frame failed"; av_packet_unref(&pkt); break; }
+                av_packet_unref(&pkt);
+                ++framesEncoded;
+            }
+            auto t3 = std::chrono::high_resolution_clock::now();
+            m_hevcStatus.currentFrame.store(static_cast<int>(idx + 1));
+
+            double loadMs = std::chrono::duration<double, std::milli>(t1 - t0).count();
+            double convertMs = std::chrono::duration<double, std::milli>(t2 - t1).count();
+            double encodeMs = std::chrono::duration<double, std::milli>(t3 - t2).count();
+            std::ostringstream stageLog;
+            stageLog << "[HevcExport] Frame " << (idx + 1)
+                     << " loadFrame=" << loadMs << "ms"
+                     << " convert=" << convertMs << "ms"
+                     << " encode=" << encodeMs << "ms";
+            LogHevc(stageLog.str());
+        }
+
+        avcodec_send_frame(vctx, nullptr);
+        AVPacket pkt{};
+        while (avcodec_receive_packet(vctx, &pkt) == 0) {
+            pkt.stream_index = vstream->index;
+            pkt.duration = 1;
+            pkt.pts = av_rescale_q(pkt.pts, vctx->time_base, vstream->time_base);
+            pkt.dts = pkt.pts;
+            av_interleaved_write_frame(fmt, &pkt);
+            av_packet_unref(&pkt);
+            ++framesEncoded;
+        }
+
+        auto exportEndTime = std::chrono::high_resolution_clock::now();
+        double totalMs = std::chrono::duration<double, std::milli>(exportEndTime - exportStartTime).count();
+        double avgMs = framesEncoded > 0 ? totalMs / framesEncoded : 0.0;
+        {
+            std::ostringstream oss;
+            oss << "[HevcExport] Export duration " << totalMs << " ms (avg " << avgMs << " ms/frame)";
+            LogHevc(oss.str());
+        }
+
+        av_write_trailer(fmt);
+        sws_freeContext(sws);
+        if (!(fmt->oformat->flags & AVFMT_NOFILE)) avio_closep(&fmt->pb);
+        avcodec_free_context(&vctx);
+        avformat_free_context(fmt);
+
+        if (m_hevcStatus.errorMsg.empty()) {
+            showActionMessage("Export Finished");
+            LogHevc(std::string("[HevcExport] Export finished successfully, frames encoded: ") + std::to_string(framesEncoded));
+        } else {
+            LogToFile(std::string("[HevcExport] Error: ") + m_hevcStatus.errorMsg);
+            LogHevc(std::string("[HevcExport] Error: ") + m_hevcStatus.errorMsg);
+        }
+        m_hevcStatus.active.store(false);
+    });
+}
+#else
+void App::exportCurrentClipToHevc() {
     showActionMessage("FFmpeg support not built");
 }
 #endif

--- a/src/App/AppInit.cpp
+++ b/src/App/AppInit.cpp
@@ -150,6 +150,10 @@ App::App(const std::string& filePath) :
     , m_showExportProgressPopup(false)
     , m_proResStatus()
 #endif
+#ifdef ENABLE_HEVC_EXPORT
+    , m_showHevcProgressPopup(false)
+    , m_hevcStatus()
+#endif
 {
     LogToFile(std::string("App::App Constructor called for file: ") + this->m_filePath);
 #ifndef NDEBUG

--- a/src/App/AppInput.cpp
+++ b/src/App/AppInput.cpp
@@ -524,6 +524,42 @@ std::string App::openSaveMovDialog() {
     return {};
 }
 
+std::string App::openSaveMp4Dialog() {
+#ifdef _WIN32
+    OPENFILENAMEW ofn{};
+    wchar_t szFile[MAX_PATH] = { 0 };
+    ofn.lStructSize = sizeof(ofn);
+
+    HWND ownerHwnd = NULL;
+    if (m_window) {
+        ownerHwnd = glfwGetWin32Window(m_window);
+    }
+
+    ofn.hwndOwner = ownerHwnd;
+    ofn.lpstrFilter = L"MP4 files\0*.mp4\0All Files\0*.*\0";
+    ofn.lpstrFile = szFile;
+    ofn.nMaxFile = MAX_PATH;
+    ofn.Flags = OFN_OVERWRITEPROMPT | OFN_PATHMUSTEXIST | OFN_NOCHANGEDIR;
+    ofn.lpstrDefExt = L"mp4";
+
+    if (GetSaveFileNameW(&ofn)) {
+        std::string utf8Path = DebugLogHelper::wstring_to_utf8(szFile);
+        if (utf8Path.empty() && szFile[0] != L'\0') {
+            LogToFile("[App::openSaveMp4Dialog] UTF-8 conversion failed for selected path.");
+            return {};
+        }
+        return utf8Path;
+    }
+#else
+    LogToFile("[App::openSaveMp4Dialog] Save dialog not implemented for this platform. Using console fallback.");
+    std::string path;
+    std::cout << "Enter output .mp4 path: " << std::flush;
+    std::getline(std::cin, path);
+    return path;
+#endif
+    return {};
+}
+
 void App::triggerOpenFileViaDialog() {
     std::string newPath = openMcrawDialog();
     if (!newPath.empty()) {

--- a/src/Gui/GuiRender.cpp
+++ b/src/Gui/GuiRender.cpp
@@ -245,6 +245,13 @@ namespace GuiOverlay {
 #else
             ImGui::MenuItem("Export to ProRes", nullptr, false, false);
 #endif
+#ifdef ENABLE_HEVC_EXPORT
+            if (ImGui::MenuItem("Export to HEVC", nullptr, false, canOperateOnCurrentFile)) {
+                if (appInstance) appInstance->exportCurrentClipToHevc();
+            }
+#else
+            ImGui::MenuItem("Export to HEVC", nullptr, false, false);
+#endif
             ImGui::EndPopup();
         }
 
@@ -683,6 +690,28 @@ namespace GuiOverlay {
                 if (ImGui::Button("Close")) {
                     ImGui::CloseCurrentPopup();
                     appInstance->m_showExportProgressPopup.store(false);
+                }
+            }
+            ImGui::EndPopup();
+        }
+#endif
+#ifdef ENABLE_HEVC_EXPORT
+        if (appInstance->m_showHevcProgressPopup.load()) {
+            ImGui::OpenPopup("HEVC_EXPORT_PROGRESS");
+        }
+        if (ImGui::BeginPopupModal("HEVC_EXPORT_PROGRESS", nullptr, ImGuiWindowFlags_AlwaysAutoResize)) {
+            int cur = appInstance->m_hevcStatus.currentFrame.load();
+            int total = appInstance->m_hevcStatus.totalFrames;
+            float progress = total > 0 ? static_cast<float>(cur) / static_cast<float>(total) : 0.0f;
+            ImGui::Text("Exporting to HEVC %d / %d", cur, total);
+            ImGui::ProgressBar(progress, ImVec2(200, 0));
+            if (!appInstance->m_hevcStatus.errorMsg.empty()) {
+                ImGui::TextColored(ImVec4(1,0,0,1), "%s", appInstance->m_hevcStatus.errorMsg.c_str());
+            }
+            if (!appInstance->m_hevcStatus.active.load()) {
+                if (ImGui::Button("Close")) {
+                    ImGui::CloseCurrentPopup();
+                    appInstance->m_showHevcProgressPopup.store(false);
                 }
             }
             ImGui::EndPopup();

--- a/src/Utils/ColorPipelineCPU.cpp
+++ b/src/Utils/ColorPipelineCPU.cpp
@@ -1,6 +1,9 @@
 #include "Utils/ColorPipelineCPU.h"
 #include <algorithm>
 #include <cmath>
+#ifdef USE_OPENMP
+#include <omp.h>
+#endif
 
 static inline float srgb_eotf(float v) {
     v = std::clamp(v, 0.0f, 1.0f);
@@ -35,6 +38,9 @@ void convertRawToRGB24(const uint16_t* raw, const CPUColorParams& p, std::vector
 
     const float* ccm = p.ccm.data();
 
+    #ifdef USE_OPENMP
+    #pragma omp parallel for schedule(static)
+    #endif
     for(int y=0;y<p.height;++y){
         for(int x=0;x<p.width;++x){
             bool ye = (y%2)==0;

--- a/src/Utils/DebugLog.cpp
+++ b/src/Utils/DebugLog.cpp
@@ -12,7 +12,7 @@
 #   include <windows.h>
 #   include <shlobj.h>
 #endif
-#ifdef ENABLE_PRORES_EXPORT
+#if defined(ENABLE_PRORES_EXPORT) || defined(ENABLE_HEVC_EXPORT)
 #include "ffmpeg_headers.hpp"
 #endif
 
@@ -88,6 +88,21 @@ static std::ofstream& get_prores_log_file() {
     return log_file;
 }
 
+// Separate log file for HEVC export diagnostics
+static std::ofstream& get_hevc_log_file() {
+    static std::ofstream log_file;
+    static bool initialized = false;
+    if (!initialized) {
+        std::filesystem::path logDir = getLogDirectory();
+        std::error_code ec;
+        std::filesystem::create_directories(logDir, ec);
+        std::filesystem::path logPath = logDir / "hevc_export_log.txt";
+        log_file.open(logPath, std::ios_base::app | std::ios_base::out);
+        initialized = true;
+    }
+    return log_file;
+}
+
 void LogToFile(const std::string& message) {
     std::lock_guard<std::mutex> lock(g_log_mutex); // Lock for thread safety
 
@@ -123,10 +138,24 @@ void LogProRes(const std::string& message) {
     }
 }
 
+void LogHevc(const std::string& message) {
+    std::lock_guard<std::mutex> lock(g_log_mutex);
+
+    std::ofstream& log_file = get_hevc_log_file();
+    if (log_file.is_open()) {
+        log_file << "[" << make_timestamp() << "] " << message << std::endl;
+    }
+}
+
 void LogFFmpegStatus() {
+#if defined(ENABLE_PRORES_EXPORT) || defined(ENABLE_HEVC_EXPORT)
 #ifdef ENABLE_PRORES_EXPORT
     LogToFile("[FFmpeg] ProRes export support compiled in.");
     LogProRes("[FFmpeg] ProRes export support compiled in.");
+#endif
+#ifdef ENABLE_HEVC_EXPORT
+    LogToFile("[FFmpeg] HEVC export support compiled in.");
+    LogHevc("[FFmpeg] HEVC export support compiled in.");
 #   ifdef _WIN32
     const char* dlls[] = {
         "avcodec-61.dll", "avformat-61.dll", "avutil-59.dll",


### PR DESCRIPTION
## Summary
- enable `ENABLE_HEVC_EXPORT` when FFmpeg is found
- add `LogHevc` helper and HEVC export logging
- create `openSaveMp4Dialog` and GUI option to export HEVC
- implement new `exportCurrentClipToHevc` workflow using FFmpeg's HEVC encoder
- track HEVC export progress in the UI

## Testing
- `cmake -S . -B build -DCMAKE_BUILD_TYPE=Release` *(fails: FFmpeg package not found)*

------
https://chatgpt.com/codex/tasks/task_e_68679bf781048327aaea51a4ea515e83