### PR TITLE
Use all CPU cores for ProRes export

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,8 +45,10 @@ runtime DLLs will be copied automatically.
 - Right-click anywhere in the player window to open the context menu.
 - Choose **Export to ProRes** and select a `.mov` file path.
 - Encoding uses FFmpeg linked via vcpkg. Make sure the libraries are installed in your vcpkg instance.
-- Progress is shown in a modal popup while the encoding thread runs.
-- The export uses the `prores_ks` encoder to create a 10-bit 4:2:2 file.
+ - Progress is shown in a modal popup while the encoding thread runs.
+ - The export uses the `prores_ks` encoder to create a 10-bit 4:2:2 file.
+   All available CPU cores are used for encoding, and the chosen thread count
+   is logged to `prores_export_log.txt`.
 - Frame rate is derived from the clip's timestamps so the output is constant frame rate.
 - If the clip contains audio, 16‑bit PCM is muxed into the `.mov` container.
 - A `prores_export_log.txt` file is written inside the `Logs` folder for troubleshooting.

--- a/src/App/AppIO.cpp
+++ b/src/App/AppIO.cpp
@@ -19,6 +19,7 @@
 
 
 #include <filesystem>
+#include <thread>
 #include <iostream>
 #include <fstream>
 #include <numeric>
@@ -1259,7 +1260,7 @@ void App::exportCurrentClipToProRes() {
             avformat_free_context(fmt);
             return;
         }
-        LogProRes("[ProResExport] ProRes encoder found");
+        LogProRes(std::string("[ProResExport] ProRes encoder: ") + avcodec_get_name(vcodec->id));
 
         AVStream* vstream = avformat_new_stream(fmt, nullptr);
         if (!vstream) {
@@ -1276,6 +1277,11 @@ void App::exportCurrentClipToProRes() {
         vctx->height = height;
         vctx->time_base = timeBase;
         vctx->framerate = av_inv_q(timeBase);
+        unsigned threads = std::thread::hardware_concurrency();
+        vctx->thread_count = threads ? threads : 1; // use all CPU cores
+        vctx->thread_type = FF_THREAD_FRAME;
+        LogProRes(std::string("[ProResExport] Encoding threads: ") +
+                  std::to_string(vctx->thread_count));
         if (fmt->oformat->flags & AVFMT_GLOBALHEADER)
             vctx->flags |= AV_CODEC_FLAG_GLOBAL_HEADER;
         if (avcodec_open2(vctx, vcodec, nullptr) < 0) {


### PR DESCRIPTION
## Summary
- allocate encoding threads equal to hardware concurrency when exporting ProRes
- log the thread count and document this behavior

## Testing
- `cmake -S . -B build` *(fails to find FFmpeg package)*

------
https://chatgpt.com/codex/tasks/task_e_6867b4e564b48327b3865c590c0c4b29