### PR TITLE
Use all CPU cores for ProRes export

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,8 +45,11 @@ runtime DLLs will be copied automatically.
 - Right-click anywhere in the player window to open the context menu.
 - Choose **Export to ProRes** and select a `.mov` file path.
 - Encoding uses FFmpeg linked via vcpkg. Make sure the libraries are installed in your vcpkg instance.
-- Progress is shown in a modal popup while the encoding thread runs.
-- The export uses the `prores_ks` encoder to create a 10-bit 4:2:2 file.
+ - Progress is shown in a modal popup while the encoding thread runs.
+ - The export uses the `prores_ks` encoder to create a 10-bit 4:2:2 file.
+   All available CPU cores are used for encoding. The log records the detected
+   thread count, thread type, and per‑50‑frame progress with elapsed time so you
+   can analyze encoding performance.
 - Frame rate is derived from the clip's timestamps so the output is constant frame rate.
 - If the clip contains audio, 16‑bit PCM is muxed into the `.mov` container.
 - A `prores_export_log.txt` file is written inside the `Logs` folder for troubleshooting.

--- a/src/App/AppIO.cpp
+++ b/src/App/AppIO.cpp
@@ -19,6 +19,9 @@
 
 
 #include <filesystem>
+#include <thread>
+#include <chrono>
+#include <iomanip>
 #include <iostream>
 #include <fstream>
 #include <numeric>
@@ -1259,7 +1262,7 @@ void App::exportCurrentClipToProRes() {
             avformat_free_context(fmt);
             return;
         }
-        LogProRes("[ProResExport] ProRes encoder found");
+        LogProRes(std::string("[ProResExport] ProRes encoder: ") + avcodec_get_name(vcodec->id));
 
         AVStream* vstream = avformat_new_stream(fmt, nullptr);
         if (!vstream) {
@@ -1276,6 +1279,13 @@ void App::exportCurrentClipToProRes() {
         vctx->height = height;
         vctx->time_base = timeBase;
         vctx->framerate = av_inv_q(timeBase);
+        unsigned threads = std::thread::hardware_concurrency();
+        vctx->thread_count = threads ? threads : 1; // use all CPU cores
+        vctx->thread_type = FF_THREAD_FRAME;
+        LogProRes(std::string("[ProResExport] Encoding threads: ") +
+                  std::to_string(vctx->thread_count));
+        LogProRes(std::string("[ProResExport] Thread type: ") +
+                  (vctx->thread_type == FF_THREAD_FRAME ? "FRAME" : "SLICE"));
         if (fmt->oformat->flags & AVFMT_GLOBALHEADER)
             vctx->flags |= AV_CODEC_FLAG_GLOBAL_HEADER;
         if (avcodec_open2(vctx, vcodec, nullptr) < 0) {
@@ -1349,6 +1359,9 @@ void App::exportCurrentClipToProRes() {
             return;
         }
         LogProRes("[ProResExport] Header written");
+
+        auto encodeStart = std::chrono::steady_clock::now();
+        LogProRes("[ProResExport] Encode loop starting");
 
         AVFrame* frame = av_frame_alloc();
         frame->format = vctx->pix_fmt;
@@ -1442,7 +1455,12 @@ void App::exportCurrentClipToProRes() {
             }
             m_proResStatus.currentFrame.store(static_cast<int>(idx + 1));
             if ((idx + 1) % 50 == 0) {
-                LogProRes(std::string("[ProResExport] Encoded frame ") + std::to_string(idx + 1) + "/" + std::to_string(frames.size()));
+                auto now = std::chrono::steady_clock::now();
+                auto ms = std::chrono::duration_cast<std::chrono::milliseconds>(now - encodeStart).count();
+                std::ostringstream prog;
+                prog << "[ProResExport] Encoded frame " << (idx + 1) << "/" << frames.size()
+                     << " elapsed=" << ms << "ms";
+                LogProRes(prog.str());
             }
         }
 
@@ -1502,6 +1520,15 @@ void App::exportCurrentClipToProRes() {
 
         if (framesEncoded == 0 && m_proResStatus.errorMsg.empty()) {
             m_proResStatus.errorMsg = "No video frames encoded";
+        }
+
+        auto encodeEnd = std::chrono::steady_clock::now();
+        auto totalMs = std::chrono::duration_cast<std::chrono::milliseconds>(encodeEnd - encodeStart).count();
+        double fps = totalMs > 0 ? (framesEncoded * 1000.0) / totalMs : 0.0;
+        {
+            std::ostringstream finfo;
+            finfo << "[ProResExport] Encode duration=" << totalMs << "ms fps=" << std::fixed << std::setprecision(2) << fps;
+            LogProRes(finfo.str());
         }
 
         av_write_trailer(fmt);


### PR DESCRIPTION
## Summary
- allocate encoding threads equal to hardware concurrency when exporting ProRes
- log the thread count and document this behavior
- add detailed progress logs with elapsed time and total encode duration

## Testing
- `cmake -S . -B build` *(fails to find FFmpeg package)*

------
https://chatgpt.com/codex/tasks/task_e_6867b4e564b48327b3865c590c0c4b29