### PR TITLE
Add basic batch export UI

### DIFF
--- a/include/App/App.h
+++ b/include/App/App.h
@@ -39,6 +39,8 @@ class DecoderWrapper;
 // class PlaybackController; // Already included above
 class Renderer_VK;
 
+#include "Utils/ColorEnums.h"
+
 #include "Gui/GuiOverlay.h"
 #include "Utils/ThreadSafeQueue.h"
 #include "Decoder/DecoderTypes.h"
@@ -112,6 +114,8 @@ public:
     void saveCurrentFrameAsDng();
     void convertCurrentFileToDngs();
     void exportCurrentClipToProRes();
+    void addCurrentToBatch();
+    void startBatchExport();
     void exportCurrentClipToHevcAmf();
     void performSeek(size_t new_frame_index);
     void triggerOpenFileViaDialog();
@@ -220,6 +224,18 @@ private:
     float m_uiFadeSpeed = 3.0f;
 
 #ifdef ENABLE_PRORES_EXPORT
+    struct ExportSettings {
+        ProResQuality quality{ ProResQuality::HQ };
+        GammaCurve    gamma{ GammaCurve::SRGB };
+        ColorSpace    color{ ColorSpace::Rec709 };
+    };
+
+    struct BatchJob {
+        std::string inputPath;
+        std::string outputPath;
+        ExportSettings settings;
+    };
+
     struct ProResExportStatus {
         std::atomic<bool> active{ false };
         std::atomic<int> currentFrame{ 0 };
@@ -228,6 +244,9 @@ private:
     } m_proResStatus;
     std::atomic<bool> m_showExportProgressPopup{ false };
     std::thread m_proResThread;
+
+    std::vector<BatchJob> m_batchJobs;
+    bool m_showBatchWindow = false;
 
     struct HevcExportStatus {
         std::atomic<bool> active{ false };

--- a/include/Utils/ColorEnums.h
+++ b/include/Utils/ColorEnums.h
@@ -1,0 +1,20 @@
+#pragma once
+
+enum class GammaCurve {
+    SRGB,
+    CineonLog,
+    Slog3
+};
+
+enum class ColorSpace {
+    Rec709,
+    BT2020,
+    SLogCinema
+};
+
+enum class ProResQuality {
+    Proxy,
+    LT,
+    Standard,
+    HQ
+};

--- a/include/Utils/ColorPipelineCPU.h
+++ b/include/Utils/ColorPipelineCPU.h
@@ -2,6 +2,7 @@
 #include <vector>
 #include <cstdint>
 #include <array>
+#include "Utils/ColorEnums.h"
 
 struct CPUColorParams {
     int width{0};
@@ -14,6 +15,8 @@ struct CPUColorParams {
     float gainB{1.0f};
     std::array<float,9> ccm{1,0,0,0,1,0,0,0,1};
     float saturation{1.0f};
+    GammaCurve gamma{GammaCurve::SRGB};
+    ColorSpace color{ColorSpace::Rec709};
 };
 
 void convertRawToRGB24(const uint16_t* raw, const CPUColorParams& params,

--- a/src/App/AppIO.cpp
+++ b/src/App/AppIO.cpp
@@ -1610,6 +1610,21 @@ void App::exportCurrentClipToProRes() {
     });
 }
 
+void App::addCurrentToBatch() {
+    if (m_currentFileIndex < 0 || m_currentFileIndex >= static_cast<int>(m_fileList.size())) return;
+    BatchJob job;
+    job.inputPath = m_fileList[m_currentFileIndex];
+    std::filesystem::path p(job.inputPath);
+    job.outputPath = (p.parent_path() / (p.stem().string() + ".mov")).string();
+    m_batchJobs.push_back(job);
+    m_showBatchWindow = true;
+    showActionMessage("Added to batch");
+}
+
+void App::startBatchExport() {
+    showActionMessage("Batch export not implemented yet");
+}
+
 void App::exportCurrentClipToHevcAmf() {
     if (m_hevcStatus.active.load()) {
         showActionMessage("Export already running");
@@ -2043,6 +2058,14 @@ void App::exportCurrentClipToHevcAmf() {
 }
 #else
 void App::exportCurrentClipToProRes() {
+    showActionMessage("FFmpeg support not built");
+}
+
+void App::addCurrentToBatch() {
+    showActionMessage("FFmpeg support not built");
+}
+
+void App::startBatchExport() {
     showActionMessage("FFmpeg support not built");
 }
 

--- a/src/Gui/GuiRender.cpp
+++ b/src/Gui/GuiRender.cpp
@@ -19,6 +19,7 @@
 
 
 #include <imgui.h>
+#include <imgui_stdlib.h>
 #include <imgui_impl_glfw.h>
 #include <imgui_impl_vulkan.h>
 
@@ -242,11 +243,19 @@ namespace GuiOverlay {
             if (ImGui::MenuItem("Export to ProRes", nullptr, false, canOperateOnCurrentFile)) {
                 if (appInstance) appInstance->exportCurrentClipToProRes();
             }
+            if (ImGui::MenuItem("Add to Batch Export", nullptr, false, canOperateOnCurrentFile)) {
+                if (appInstance) appInstance->addCurrentToBatch();
+            }
+            if (ImGui::MenuItem("Open Batch Window")) {
+                if (appInstance) appInstance->m_showBatchWindow = true;
+            }
             if (ImGui::MenuItem("Export to HEVC (AMD)", nullptr, false, canOperateOnCurrentFile)) {
                 if (appInstance) appInstance->exportCurrentClipToHevcAmf();
             }
 #else
             ImGui::MenuItem("Export to ProRes", nullptr, false, false);
+            ImGui::MenuItem("Add to Batch Export", nullptr, false, false);
+            ImGui::MenuItem("Open Batch Window", nullptr, false, false);
 #endif
 #ifndef ENABLE_PRORES_EXPORT
             ImGui::MenuItem("Export to HEVC (AMD)", nullptr, false, false);
@@ -303,6 +312,33 @@ namespace GuiOverlay {
         (void)current_playlist_window_width; // Mark as used to suppress warnings if NDEBUG
         (void)playlist_window_is_visible; // Mark as used
 
+        if (appInstance && appInstance->m_showBatchWindow) {
+            ImGui::SetNextWindowSize(ImVec2(420, 300), ImGuiCond_FirstUseEver);
+            if (ImGui::Begin("Batch Export", &appInstance->m_showBatchWindow, ImGuiWindowFlags_NoCollapse | ImGuiWindowFlags_NoSavedSettings)) {
+                for (size_t i = 0; i < appInstance->m_batchJobs.size(); ++i) {
+                    auto& job = appInstance->m_batchJobs[i];
+                    ImGui::PushID(static_cast<int>(i));
+                    ImGui::Text("%s", fs::path(job.inputPath).filename().string().c_str());
+                    ImGui::InputText("Output", &job.outputPath);
+                    const char* qopts[] = {"Proxy","LT","Standard","HQ"};
+                    int q = static_cast<int>(job.settings.quality);
+                    if (ImGui::Combo("Quality", &q, qopts, 4)) job.settings.quality = static_cast<ProResQuality>(q);
+                    const char* gopts[] = {"sRGB","Cineon","Slog3"};
+                    int g = static_cast<int>(job.settings.gamma);
+                    if (ImGui::Combo("Gamma", &g, gopts, 3)) job.settings.gamma = static_cast<GammaCurve>(g);
+                    const char* copts[] = {"Rec709","BT2020","SLogCinema"};
+                    int c = static_cast<int>(job.settings.color);
+                    if (ImGui::Combo("Color", &c, copts, 3)) job.settings.color = static_cast<ColorSpace>(c);
+                    if (ImGui::Button("Remove")) { appInstance->m_batchJobs.erase(appInstance->m_batchJobs.begin()+i); ImGui::PopID(); break; }
+                    ImGui::Separator();
+                    ImGui::PopID();
+                }
+                if (ImGui::Button("Start Batch")) {
+                    appInstance->startBatchExport();
+                }
+            }
+            ImGui::End();
+        }
 
         if (ui.showHelpPage) {
             ImGui::SetNextWindowSize(ImVec2(450, 420), ImGuiCond_FirstUseEver);

--- a/src/Utils/ColorPipelineCPU.cpp
+++ b/src/Utils/ColorPipelineCPU.cpp
@@ -1,4 +1,5 @@
 #include "Utils/ColorPipelineCPU.h"
+#include "Utils/ColorEnums.h"
 #include <algorithm>
 #include <cmath>
 #include <vector>
@@ -7,6 +8,35 @@
 static inline float srgb_eotf(float v) {
     v = std::clamp(v, 0.0f, 1.0f);
     return (v <= 0.0031308f) ? v * 12.92f : 1.055f * std::pow(v, 1.0f/2.4f) - 0.055f;
+}
+
+static inline float cineon_log(float v) {
+    v = std::clamp(v, 1e-6f, 1.0f);
+    return std::log10(v * 9.0f + 1.0f) / std::log10(10.0f);
+}
+
+static inline float slog3(float v) {
+    v = std::clamp(v, 0.0f, 1.0f);
+    if (v >= 0.011f)
+        return 0.432699f * std::log10(v + 0.037584f) + 0.616596f + 0.03f;
+    return (v * 171.2103f / 0.011f) + 0.01f;
+}
+
+static inline float applyGamma(float v, GammaCurve g) {
+    switch (g) {
+        case GammaCurve::CineonLog: return cineon_log(v);
+        case GammaCurve::Slog3:     return slog3(v);
+        default:                    return srgb_eotf(v);
+    }
+}
+
+static inline void applyColorSpace(float& r, float& g, float& b, ColorSpace cs) {
+    if (cs == ColorSpace::BT2020) {
+        float r2 = 1.6605f*r - 0.5876f*g - 0.0728f*b;
+        float g2 = -0.1246f*r + 1.1329f*g - 0.0083f*b;
+        float b2 = -0.0182f*r - 0.1006f*g + 1.1189f*b;
+        r = r2; g = g2; b = b2;
+    }
 }
 
 static inline uint16_t readU16(const uint16_t* src, int x, int y, int w, int h) {
@@ -95,10 +125,11 @@ void convertRawToRGB24(const uint16_t* raw, const CPUColorParams& p,
             r_cc = lum*(1-sat) + r_cc*sat;
             g_cc = lum*(1-sat) + g_cc*sat;
             b_cc = lum*(1-sat) + b_cc*sat;
+            applyColorSpace(r_cc, g_cc, b_cc, p.color);
             uint8_t* dst = &outRGB[(y*p.width + x)*3];
-            dst[0] = (uint8_t)std::clamp(int(srgb_eotf(r_cc)*255.0f + 0.5f),0,255);
-            dst[1] = (uint8_t)std::clamp(int(srgb_eotf(g_cc)*255.0f + 0.5f),0,255);
-            dst[2] = (uint8_t)std::clamp(int(srgb_eotf(b_cc)*255.0f + 0.5f),0,255);
+            dst[0] = (uint8_t)std::clamp(int(applyGamma(r_cc, p.gamma)*255.0f + 0.5f),0,255);
+            dst[1] = (uint8_t)std::clamp(int(applyGamma(g_cc, p.gamma)*255.0f + 0.5f),0,255);
+            dst[2] = (uint8_t)std::clamp(int(applyGamma(b_cc, p.gamma)*255.0f + 0.5f),0,255);
         }
     };
 


### PR DESCRIPTION
## Summary
- introduce `ColorEnums` and extend `CPUColorParams` with gamma and color space options
- add primitive batch export data structures and stubs
- integrate batch queue window in the GUI
- augment color pipeline for gamma and color space transforms

## Testing
- `cmake -S . -B build` *(fails: Could not find a package configuration file provided by "FFMPEG")*

------
https://chatgpt.com/codex/tasks/task_e_6868b1f570748327a8d4f101f5fbe81b