### PR TITLE
Add AMD HEVC hardware export

### DIFF
--- a/include/App/App.h
+++ b/include/App/App.h
@@ -130,6 +130,7 @@ public:
     void saveCurrentFrameAsDng();
     void convertCurrentFileToDngs();
     void exportCurrentClipToProRes(const ProResExportOptions& options = {});
+    void exportCurrentClipToHevc();
     void startProResBatch();
     void performSeek(size_t new_frame_index);
     void triggerOpenFileViaDialog();
@@ -248,6 +249,15 @@ private:
     std::thread m_proResThread;
     std::vector<ProResExportOptions> m_batchOptions;
     std::atomic<bool> m_showBatchWindow{false};
+
+    struct HevcExportStatus {
+        std::atomic<bool> active{ false };
+        std::atomic<int> currentFrame{ 0 };
+        int totalFrames{ 0 };
+        std::string errorMsg;
+    } m_hevcStatus;
+    std::atomic<bool> m_showHevcProgressPopup{ false };
+    std::thread m_hevcThread;
 #endif
 
 

--- a/include/Utils/DebugLog.h
+++ b/include/Utils/DebugLog.h
@@ -6,6 +6,7 @@
 // Simple file logger declaration
 void LogToFile(const std::string& message);
 void LogProRes(const std::string& message);
+void LogHevc(const std::string& message);
 // Logs whether FFmpeg/ProRes support is available at runtime
 void LogFFmpegStatus();
 

--- a/src/App/AppCleanup.cpp
+++ b/src/App/AppCleanup.cpp
@@ -58,6 +58,11 @@ App::~App() {
         m_proResThread.join();
         LogToFile("[App::~App] ProRes export thread joined.");
     }
+    if (m_hevcThread.joinable()) {
+        LogToFile("[App::~App] Joining HEVC export thread...");
+        m_hevcThread.join();
+        LogToFile("[App::~App] HEVC export thread joined.");
+    }
 #endif
 
     destroyPersistentStagingBuffers();

--- a/src/App/AppIO.cpp
+++ b/src/App/AppIO.cpp
@@ -1635,11 +1635,276 @@ void App::exportCurrentClipToProRes(const ProResExportOptions& options) {
             LogToFile(std::string("[ProResExport] Error: ") + m_proResStatus.errorMsg);
             LogProRes(std::string("[ProResExport] Error: ") + m_proResStatus.errorMsg);
         }
-        m_proResStatus.active.store(false);
+    m_proResStatus.active.store(false);
+    });
+}
+
+void App::exportCurrentClipToHevc() {
+    if (m_hevcStatus.active.load()) {
+        showActionMessage("Export already running");
+        return;
+    }
+
+    std::string outputPath = openSaveMovDialog();
+    if (outputPath.empty()) return;
+    if (outputPath.size() < 4 || outputPath.substr(outputPath.size() - 4) != ".mp4") {
+        outputPath += ".mp4";
+    }
+
+    if (!m_decoderWrapper_ptr || !m_decoderWrapper_ptr->getDecoder()) {
+        showActionMessage("No clip loaded");
+        return;
+    }
+
+    LogHevc(std::string("[HevcExport] Starting export to ") + outputPath);
+
+    m_hevcStatus.totalFrames = static_cast<int>(m_decoderWrapper_ptr->getDecoder()->getFrames().size());
+    LogHevc(std::string("[HevcExport] Total frames: ") + std::to_string(m_hevcStatus.totalFrames));
+    m_hevcStatus.currentFrame.store(0);
+    m_hevcStatus.active.store(true);
+    m_hevcStatus.errorMsg.clear();
+    m_showHevcProgressPopup.store(true);
+    showActionMessage("Export Started");
+
+    if (m_hevcThread.joinable()) {
+        m_hevcThread.join();
+    }
+
+    m_hevcThread = std::thread([this, outputPath]() {
+        av_log_set_level(AV_LOG_ERROR);
+        LogHevc("[HevcExport] Thread started");
+
+        auto* dec = m_decoderWrapper_ptr->getDecoder();
+        const auto& frames = dec->getFrames();
+        LogHevc(std::string("[HevcExport] Frames to export: ") + std::to_string(frames.size()));
+        if (frames.empty()) {
+            m_hevcStatus.errorMsg = "No frames to export";
+            m_hevcStatus.active.store(false);
+            return;
+        }
+
+        RawBytes rawBuf;
+        nlohmann::json meta;
+        try {
+            dec->loadFrame(frames[0], rawBuf, meta);
+        } catch (...) {
+            m_hevcStatus.errorMsg = "Failed to load first frame";
+            m_hevcStatus.active.store(false);
+            return;
+        }
+        int width = meta.value("width", 0);
+        int height = meta.value("height", 0);
+        LogHevc(std::string("[HevcExport] Frame dimensions: ") + std::to_string(width) + "x" + std::to_string(height));
+        if (width <= 0 || height <= 0) {
+            m_hevcStatus.errorMsg = "Invalid frame dimensions";
+            m_hevcStatus.active.store(false);
+            return;
+        }
+
+        int64_t frameDurationNs = 0;
+        if (frames.size() >= 2) {
+            frameDurationNs = frames[1] - frames[0];
+        } else {
+            frameDurationNs = 41708333;
+        }
+        AVRational timeBase{ static_cast<int>(frameDurationNs / 1000), 1000000 };
+        LogHevc(std::string("[HevcExport] Time base: ") + std::to_string(timeBase.num) + "/" + std::to_string(timeBase.den));
+
+        LogHevc("[HevcExport] Allocating output context");
+        AVFormatContext* fmt = nullptr;
+        if (avformat_alloc_output_context2(&fmt, nullptr, nullptr, outputPath.c_str()) < 0 || !fmt) {
+            m_hevcStatus.errorMsg = "avformat_alloc_output_context2 failed";
+            m_hevcStatus.active.store(false);
+            return;
+        }
+        LogHevc("[HevcExport] Output context created");
+
+        const AVCodec* vcodec = avcodec_find_encoder_by_name("hevc_amf");
+        if (!vcodec) {
+            m_hevcStatus.errorMsg = "HEVC encoder not found";
+            m_hevcStatus.active.store(false);
+            avformat_free_context(fmt);
+            return;
+        }
+        LogHevc(std::string("[HevcExport] HEVC encoder: ") + avcodec_get_name(vcodec->id));
+
+        AVStream* vstream = avformat_new_stream(fmt, nullptr);
+        if (!vstream) {
+            m_hevcStatus.errorMsg = "avformat_new_stream failed";
+            m_hevcStatus.active.store(false);
+            avformat_free_context(fmt);
+            return;
+        }
+        AVCodecContext* vctx = avcodec_alloc_context3(vcodec);
+        vctx->codec_id = vcodec->id;
+        vctx->codec_type = AVMEDIA_TYPE_VIDEO;
+        vctx->pix_fmt = AV_PIX_FMT_P010LE;
+        vctx->width = width;
+        vctx->height = height;
+        vctx->time_base = timeBase;
+        vctx->framerate = av_inv_q(timeBase);
+        if (fmt->oformat->flags & AVFMT_GLOBALHEADER)
+            vctx->flags |= AV_CODEC_FLAG_GLOBAL_HEADER;
+
+        AVDictionary* encOpts = nullptr;
+        av_dict_set(&encOpts, "profile", "main10", 0);
+        if (avcodec_open2(vctx, vcodec, &encOpts) < 0) {
+            m_hevcStatus.errorMsg = "avcodec_open2 failed";
+            m_hevcStatus.active.store(false);
+            avcodec_free_context(&vctx);
+            avformat_free_context(fmt);
+            av_dict_free(&encOpts);
+            return;
+        }
+        av_dict_free(&encOpts);
+        LogHevc(std::string("[HevcExport] Video encoder initialized"));
+        avcodec_parameters_from_context(vstream->codecpar, vctx);
+        vstream->time_base = timeBase;
+
+        const AVCodec* acodec = avcodec_find_encoder(AV_CODEC_ID_PCM_S16LE);
+        AVStream* astream = nullptr;
+        AVCodecContext* actx = nullptr;
+        if (acodec) {
+            astream = avformat_new_stream(fmt, nullptr);
+            actx = avcodec_alloc_context3(acodec);
+            actx->codec_id = AV_CODEC_ID_PCM_S16LE;
+            actx->sample_rate = 48000;
+            av_channel_layout_default(&actx->ch_layout, 2);
+            actx->sample_fmt = AV_SAMPLE_FMT_S16;
+            actx->time_base = {1, actx->sample_rate};
+            if (fmt->oformat->flags & AVFMT_GLOBALHEADER)
+                actx->flags |= AV_CODEC_FLAG_GLOBAL_HEADER;
+            if (avcodec_open2(actx, acodec, nullptr) >= 0) {
+                avcodec_parameters_from_context(astream->codecpar, actx);
+                astream->time_base = actx->time_base;
+            } else {
+                avcodec_free_context(&actx);
+                actx = nullptr;
+            }
+        }
+
+        if (!(fmt->oformat->flags & AVFMT_NOFILE)) {
+            LogHevc("[HevcExport] Opening output file");
+            if (avio_open(&fmt->pb, outputPath.c_str(), AVIO_FLAG_WRITE) < 0) {
+                m_hevcStatus.errorMsg = "avio_open failed";
+                m_hevcStatus.active.store(false);
+                avcodec_free_context(&vctx);
+                avformat_free_context(fmt);
+                return;
+            }
+            LogHevc("[HevcExport] Output file opened");
+        }
+
+        LogHevc("[HevcExport] Writing header");
+        if (avformat_write_header(fmt, nullptr) < 0) {
+            m_hevcStatus.errorMsg = "avformat_write_header failed";
+            m_hevcStatus.active.store(false);
+            if (!(fmt->oformat->flags & AVFMT_NOFILE)) avio_closep(&fmt->pb);
+            avcodec_free_context(&vctx);
+            avformat_free_context(fmt);
+            return;
+        }
+        LogHevc("[HevcExport] Header written");
+
+        AVFrame* frame = av_frame_alloc();
+        frame->format = vctx->pix_fmt;
+        frame->width = width;
+        frame->height = height;
+        if (av_frame_get_buffer(frame, 32) < 0) {
+            m_hevcStatus.errorMsg = "av_frame_get_buffer failed";
+            av_frame_free(&frame);
+            if (actx) avcodec_free_context(&actx);
+            if (!(fmt->oformat->flags & AVFMT_NOFILE)) avio_closep(&fmt->pb);
+            avcodec_free_context(&vctx);
+            avformat_free_context(fmt);
+            m_hevcStatus.active.store(false);
+            return;
+        }
+
+        unsigned threads = std::thread::hardware_concurrency();
+        if (threads == 0) threads = 1;
+        SwsContext* sws = sws_getContext(width, height, AV_PIX_FMT_RGB24,
+                                         width, height, AV_PIX_FMT_P010LE,
+                                         SWS_BILINEAR, nullptr, nullptr, nullptr);
+        av_opt_set_int(sws, "threads", threads, 0);
+
+        int framesEncoded = 0;
+        CPUColorParams cpParams{};
+        cpParams.width = width;
+        cpParams.height = height;
+        cpParams.cfaType = m_cfaTypeFromMetadata;
+        cpParams.blackLevel = m_staticBlack;
+        cpParams.whiteLevel = m_staticWhite;
+        cpParams.gamma = GammaCurve::SRGB;
+        cpParams.color = ColorSpace::Rec709;
+
+        AVPacket pkt{};
+        std::vector<uint8_t> rgbBuf;
+        int64_t pts = 0;
+        for (size_t idx = 0; idx < frames.size(); ++idx) {
+            RawBytes raw;
+            nlohmann::json metaTmp;
+            try { dec->loadFrame(frames[idx], raw, metaTmp); }
+            catch (...) { m_hevcStatus.errorMsg = "Frame read error"; break; }
+
+            if (av_frame_make_writable(frame) < 0) { m_hevcStatus.errorMsg = "frame not writable"; break; }
+            convertRawToRGB24(asU16(raw), cpParams, rgbBuf, threads);
+            const uint8_t* srcSlices[1] = { rgbBuf.data() };
+            int srcStride[1] = { width * 3 };
+            sws_scale(sws, srcSlices, srcStride, 0, height, frame->data, frame->linesize);
+
+            frame->pts = pts;
+            pts++;
+
+            if (avcodec_send_frame(vctx, frame) < 0) { m_hevcStatus.errorMsg = "send_frame failed"; break; }
+            while (avcodec_receive_packet(vctx, &pkt) == 0) {
+                pkt.stream_index = vstream->index;
+                pkt.duration = 1;
+                pkt.pts = av_rescale_q(pkt.pts, vctx->time_base, vstream->time_base);
+                pkt.dts = pkt.pts;
+                if (av_interleaved_write_frame(fmt, &pkt) < 0) { m_hevcStatus.errorMsg = "write_frame failed"; av_packet_unref(&pkt); break; }
+                av_packet_unref(&pkt);
+                ++framesEncoded;
+            }
+            m_hevcStatus.currentFrame.store(static_cast<int>(idx + 1));
+        }
+
+        avcodec_send_frame(vctx, nullptr);
+        while (avcodec_receive_packet(vctx, &pkt) == 0) {
+            pkt.stream_index = vstream->index;
+            pkt.duration = 1;
+            pkt.pts = av_rescale_q(pkt.pts, vctx->time_base, vstream->time_base);
+            pkt.dts = pkt.pts;
+            av_interleaved_write_frame(fmt, &pkt);
+            av_packet_unref(&pkt);
+            ++framesEncoded;
+        }
+
+        av_write_trailer(fmt);
+        sws_freeContext(sws);
+        if (actx) avcodec_free_context(&actx);
+        if (!(fmt->oformat->flags & AVFMT_NOFILE)) avio_closep(&fmt->pb);
+        avcodec_free_context(&vctx);
+        avformat_free_context(fmt);
+
+        if (framesEncoded == 0 && m_hevcStatus.errorMsg.empty()) {
+            m_hevcStatus.errorMsg = "No video frames encoded";
+        }
+
+        if (m_hevcStatus.errorMsg.empty()) {
+            showActionMessage("Export Finished");
+            LogHevc(std::string("[HevcExport] Export finished successfully, frames encoded: ") + std::to_string(framesEncoded));
+        } else {
+            LogHevc(std::string("[HevcExport] Error: ") + m_hevcStatus.errorMsg);
+        }
+        m_hevcStatus.active.store(false);
     });
 }
 #else
 void App::exportCurrentClipToProRes(const ProResExportOptions&) {
+    showActionMessage("FFmpeg support not built");
+}
+void App::exportCurrentClipToHevc() {
     showActionMessage("FFmpeg support not built");
 }
 #endif

--- a/src/App/AppInit.cpp
+++ b/src/App/AppInit.cpp
@@ -149,6 +149,8 @@ App::App(const std::string& filePath) :
 #ifdef ENABLE_PRORES_EXPORT
     , m_showExportProgressPopup(false)
     , m_proResStatus()
+    , m_showHevcProgressPopup(false)
+    , m_hevcStatus()
 #endif
 {
     LogToFile(std::string("App::App Constructor called for file: ") + this->m_filePath);

--- a/src/Gui/GuiRender.cpp
+++ b/src/Gui/GuiRender.cpp
@@ -242,6 +242,9 @@ namespace GuiOverlay {
             if (ImGui::MenuItem("Export to ProRes", nullptr, false, canOperateOnCurrentFile)) {
                 if (appInstance) appInstance->exportCurrentClipToProRes();
             }
+            if (ImGui::MenuItem("Export to HEVC 10-bit", nullptr, false, canOperateOnCurrentFile)) {
+                if (appInstance) appInstance->exportCurrentClipToHevc();
+            }
             if (ImGui::MenuItem("Add Current to ProRes Batch", nullptr, false, canOperateOnCurrentFile)) {
                 if (appInstance) {
                     appInstance->m_showBatchWindow.store(true);
@@ -764,6 +767,9 @@ namespace GuiOverlay {
         if (appInstance->m_showExportProgressPopup.load()) {
             ImGui::OpenPopup("EXPORT_PROGRESS");
         }
+        if (appInstance->m_showHevcProgressPopup.load()) {
+            ImGui::OpenPopup("HEVC_PROGRESS");
+        }
         if (ImGui::BeginPopupModal("EXPORT_PROGRESS", nullptr, ImGuiWindowFlags_AlwaysAutoResize)) {
             int cur = appInstance->m_proResStatus.currentFrame.load();
             int total = appInstance->m_proResStatus.totalFrames;
@@ -777,6 +783,23 @@ namespace GuiOverlay {
                 if (ImGui::Button("Close")) {
                     ImGui::CloseCurrentPopup();
                     appInstance->m_showExportProgressPopup.store(false);
+                }
+            }
+            ImGui::EndPopup();
+        }
+        if (ImGui::BeginPopupModal("HEVC_PROGRESS", nullptr, ImGuiWindowFlags_AlwaysAutoResize)) {
+            int cur = appInstance->m_hevcStatus.currentFrame.load();
+            int total = appInstance->m_hevcStatus.totalFrames;
+            float progress = total > 0 ? static_cast<float>(cur) / static_cast<float>(total) : 0.0f;
+            ImGui::Text("Exporting to HEVC %d / %d", cur, total);
+            ImGui::ProgressBar(progress, ImVec2(200, 0));
+            if (!appInstance->m_hevcStatus.errorMsg.empty()) {
+                ImGui::TextColored(ImVec4(1,0,0,1), "%s", appInstance->m_hevcStatus.errorMsg.c_str());
+            }
+            if (!appInstance->m_hevcStatus.active.load()) {
+                if (ImGui::Button("Close")) {
+                    ImGui::CloseCurrentPopup();
+                    appInstance->m_showHevcProgressPopup.store(false);
                 }
             }
             ImGui::EndPopup();

--- a/src/Utils/DebugLog.cpp
+++ b/src/Utils/DebugLog.cpp
@@ -88,6 +88,21 @@ static std::ofstream& get_prores_log_file() {
     return log_file;
 }
 
+// Separate log file for HEVC export diagnostics
+static std::ofstream& get_hevc_log_file() {
+    static std::ofstream log_file;
+    static bool initialized = false;
+    if (!initialized) {
+        std::filesystem::path logDir = getLogDirectory();
+        std::error_code ec;
+        std::filesystem::create_directories(logDir, ec);
+        std::filesystem::path logPath = logDir / "hevc_export_log.txt";
+        log_file.open(logPath, std::ios_base::app | std::ios_base::out);
+        initialized = true;
+    }
+    return log_file;
+}
+
 void LogToFile(const std::string& message) {
     std::lock_guard<std::mutex> lock(g_log_mutex); // Lock for thread safety
 
@@ -118,6 +133,15 @@ void LogProRes(const std::string& message) {
     std::lock_guard<std::mutex> lock(g_log_mutex);
 
     std::ofstream& log_file = get_prores_log_file();
+    if (log_file.is_open()) {
+        log_file << "[" << make_timestamp() << "] " << message << std::endl;
+    }
+}
+
+void LogHevc(const std::string& message) {
+    std::lock_guard<std::mutex> lock(g_log_mutex);
+
+    std::ofstream& log_file = get_hevc_log_file();
     if (log_file.is_open()) {
         log_file << "[" << make_timestamp() << "] " << message << std::endl;
     }


### PR DESCRIPTION
## Summary
- add `exportCurrentClipToHevc` using the `hevc_amf` encoder for 10‑bit HEVC
- log HEVC export details to a new log file
- show progress for HEVC export in the GUI
- initialize and cleanup new HEVC export thread

## Testing
- `cmake ..` *(fails: could not find FFMPEG)*

------
https://chatgpt.com/codex/tasks/task_e_686cb9677b3c832783dace09bf894622