### PR TITLE
Add HEVC batch export with high quality

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,3 +67,12 @@ runtime DLLs will be copied automatically.
   video packets were written.
 - You can override the detected CFA pattern at runtime by pressing the number
   keys `1`‑`4` which map to **BGGR**, **RGGB**, **GBRG**, and **GRBG** respectively.
+
+## HEVC Export
+
+- The application searches for available HEVC encoders in FFmpeg.
+  It tries `hevc_amf`, `hevc_nvenc`, and `libx265` in that order.
+- Build FFmpeg with one of these encoders enabled (use vcpkg features
+  such as `amf`, `nvcodec`, or `x265`).
+- Exports are always 10-bit and configure high quality options for the
+  selected encoder. Files can be queued via **Add to HEVC Batch**.

--- a/include/App/App.h
+++ b/include/App/App.h
@@ -43,6 +43,12 @@
 
 enum class ProResQuality { Proxy=0, LT=1, Standard=2, HQ=3 };
 
+struct HevcExportOptions {
+    int         playlistIndex{-1};
+    std::string inputPath;
+    std::string outputPath;
+};
+
 struct ProResExportOptions {
     ProResQuality quality{ProResQuality::HQ};
     GammaCurve    gamma{GammaCurve::SRGB};
@@ -130,8 +136,9 @@ public:
     void saveCurrentFrameAsDng();
     void convertCurrentFileToDngs();
     void exportCurrentClipToProRes(const ProResExportOptions& options = {});
-    void exportCurrentClipToHevc();
+    void exportCurrentClipToHevc(const HevcExportOptions& options = {});
     void startProResBatch();
+    void startHevcBatch();
     void performSeek(size_t new_frame_index);
     void triggerOpenFileViaDialog();
 	void setPlaybackMode(PlaybackController::PlaybackMode mode);
@@ -256,6 +263,8 @@ private:
         int totalFrames{ 0 };
         std::string errorMsg;
     } m_hevcStatus;
+    std::vector<HevcExportOptions> m_hevcBatchOptions;
+    std::atomic<bool> m_showHevcBatchWindow{false};
     std::atomic<bool> m_showHevcProgressPopup{ false };
     std::thread m_hevcThread;
 #endif

--- a/src/App/AppIO.cpp
+++ b/src/App/AppIO.cpp
@@ -17,6 +17,8 @@
 #endif
 #include <tinydng/tiny_dng_writer.h>
 
+#include <string>
+
 
 #include <filesystem>
 #include <thread>
@@ -1639,13 +1641,13 @@ void App::exportCurrentClipToProRes(const ProResExportOptions& options) {
     });
 }
 
-void App::exportCurrentClipToHevc() {
+void App::exportCurrentClipToHevc(const HevcExportOptions& options) {
     if (m_hevcStatus.active.load()) {
         showActionMessage("Export already running");
         return;
     }
 
-    std::string outputPath = openSaveMovDialog();
+    std::string outputPath = options.outputPath.empty() ? openSaveMovDialog() : options.outputPath;
     if (outputPath.empty()) return;
     if (outputPath.size() < 4 || outputPath.substr(outputPath.size() - 4) != ".mp4") {
         outputPath += ".mp4";
@@ -1719,14 +1721,20 @@ void App::exportCurrentClipToHevc() {
         }
         LogHevc("[HevcExport] Output context created");
 
-        const AVCodec* vcodec = avcodec_find_encoder_by_name("hevc_amf");
+        const char* hevcNames[] = { "hevc_amf", "hevc_nvenc", "libx265", nullptr };
+        const AVCodec* vcodec = nullptr;
+        const char* usedName = nullptr;
+        for (int i = 0; hevcNames[i]; ++i) {
+            vcodec = avcodec_find_encoder_by_name(hevcNames[i]);
+            if (vcodec) { usedName = hevcNames[i]; break; }
+        }
         if (!vcodec) {
             m_hevcStatus.errorMsg = "HEVC encoder not found";
             m_hevcStatus.active.store(false);
             avformat_free_context(fmt);
             return;
         }
-        LogHevc(std::string("[HevcExport] HEVC encoder: ") + avcodec_get_name(vcodec->id));
+        LogHevc(std::string("[HevcExport] HEVC encoder: ") + usedName);
 
         AVStream* vstream = avformat_new_stream(fmt, nullptr);
         if (!vstream) {
@@ -1738,7 +1746,10 @@ void App::exportCurrentClipToHevc() {
         AVCodecContext* vctx = avcodec_alloc_context3(vcodec);
         vctx->codec_id = vcodec->id;
         vctx->codec_type = AVMEDIA_TYPE_VIDEO;
-        vctx->pix_fmt = AV_PIX_FMT_P010LE;
+        if (usedName && std::string(usedName) == "libx265")
+            vctx->pix_fmt = AV_PIX_FMT_YUV420P10LE;
+        else
+            vctx->pix_fmt = AV_PIX_FMT_P010LE;
         vctx->width = width;
         vctx->height = height;
         vctx->time_base = timeBase;
@@ -1748,6 +1759,19 @@ void App::exportCurrentClipToHevc() {
 
         AVDictionary* encOpts = nullptr;
         av_dict_set(&encOpts, "profile", "main10", 0);
+        if (usedName && std::string(usedName) == "hevc_amf") {
+            av_dict_set(&encOpts, "usage", "high_quality", 0);
+            av_dict_set(&encOpts, "quality", "quality", 0);
+            av_dict_set(&encOpts, "rc", "hqvbr", 0);
+            av_dict_set(&encOpts, "qvbr_quality_level", "15", 0);
+        } else if (usedName && std::string(usedName) == "hevc_nvenc") {
+            av_dict_set(&encOpts, "preset", "p7", 0); // slowest/highest quality
+            av_dict_set(&encOpts, "rc", "vbrhq", 0);
+            av_dict_set(&encOpts, "cq", "19", 0);
+        } else { // libx265
+            av_dict_set(&encOpts, "preset", "slow", 0);
+            av_dict_set(&encOpts, "crf", "18", 0);
+        }
         if (avcodec_open2(vctx, vcodec, &encOpts) < 0) {
             m_hevcStatus.errorMsg = "avcodec_open2 failed";
             m_hevcStatus.active.store(false);
@@ -1904,7 +1928,7 @@ void App::exportCurrentClipToHevc() {
 void App::exportCurrentClipToProRes(const ProResExportOptions&) {
     showActionMessage("FFmpeg support not built");
 }
-void App::exportCurrentClipToHevc() {
+void App::exportCurrentClipToHevc(const HevcExportOptions&) {
     showActionMessage("FFmpeg support not built");
 }
 #endif
@@ -1927,6 +1951,26 @@ void App::startProResBatch() {
 }
 #else
 void App::startProResBatch() { showActionMessage("FFmpeg support not built"); }
+#endif
+
+#ifdef ENABLE_PRORES_EXPORT
+void App::startHevcBatch() {
+    if (m_hevcBatchOptions.empty()) return;
+    if (m_hevcStatus.active.load()) {
+        showActionMessage("Export already running");
+        return;
+    }
+    for (auto& opts : m_hevcBatchOptions) {
+        if (opts.playlistIndex >= 0 && static_cast<size_t>(opts.playlistIndex) < m_fileList.size()) {
+            loadFileAtIndex(opts.playlistIndex);
+        }
+        exportCurrentClipToHevc(opts);
+        if (m_hevcThread.joinable()) m_hevcThread.join();
+    }
+    m_hevcBatchOptions.clear();
+}
+#else
+void App::startHevcBatch() { showActionMessage("FFmpeg support not built"); }
 #endif
 
 void App::setPlaybackMode(PlaybackController::PlaybackMode mode) {

--- a/src/Gui/GuiRender.cpp
+++ b/src/Gui/GuiRender.cpp
@@ -259,6 +259,20 @@ namespace GuiOverlay {
                     }
                 }
             }
+            if (ImGui::MenuItem("Add Current to HEVC Batch", nullptr, false, canOperateOnCurrentFile)) {
+                if (appInstance) {
+                    appInstance->m_showHevcBatchWindow.store(true);
+                    HevcExportOptions hopts{};
+                    if (appInstance->m_currentFileIndex >= 0 &&
+                        static_cast<size_t>(appInstance->m_currentFileIndex) < appInstance->m_fileList.size()) {
+                        hopts.playlistIndex = appInstance->m_currentFileIndex;
+                        hopts.inputPath = appInstance->m_fileList[appInstance->m_currentFileIndex];
+                        hopts.outputPath = appInstance->openSaveMovDialog();
+                        if (!hopts.outputPath.empty())
+                            appInstance->m_hevcBatchOptions.push_back(hopts);
+                    }
+                }
+            }
 #else
             ImGui::MenuItem("Export to ProRes", nullptr, false, false);
 #endif
@@ -306,6 +320,7 @@ namespace GuiOverlay {
                         if (ImGui::BeginDragDropSource()) {
                             int payloadIndex = i;
                             ImGui::SetDragDropPayload("PRORES_INDEX", &payloadIndex, sizeof(int));
+                            ImGui::SetDragDropPayload("HEVC_INDEX", &payloadIndex, sizeof(int));
                             ImGui::Text("%s", filename_to_display.c_str());
                             ImGui::EndDragDropSource();
                         }
@@ -318,6 +333,16 @@ namespace GuiOverlay {
                                 if (!opts.outputPath.empty()) {
                                     appInstance->m_batchOptions.push_back(opts);
                                     appInstance->m_showBatchWindow.store(true);
+                                }
+                            }
+                            if (ImGui::MenuItem("Add to HEVC Batch")) {
+                                HevcExportOptions hopts{};
+                                hopts.playlistIndex = i;
+                                hopts.inputPath = filePath;
+                                hopts.outputPath = appInstance->openSaveMovDialog();
+                                if (!hopts.outputPath.empty()) {
+                                    appInstance->m_hevcBatchOptions.push_back(hopts);
+                                    appInstance->m_showHevcBatchWindow.store(true);
                                 }
                             }
                             ImGui::EndPopup();
@@ -425,6 +450,52 @@ namespace GuiOverlay {
                 ImGui::SameLine();
                 if (ImGui::Button("Close")) {
                     appInstance->m_showBatchWindow.store(false);
+                }
+            }
+            ImGui::End();
+        }
+        if (appInstance->m_showHevcBatchWindow.load()) {
+            ImGui::SetNextWindowSize(ImVec2(420,280), ImGuiCond_FirstUseEver);
+            if (ImGui::Begin("HEVC Batch", nullptr, ImGuiWindowFlags_NoCollapse)) {
+                if (ImGui::BeginDragDropTarget()) {
+                    if (const ImGuiPayload* payload = ImGui::AcceptDragDropPayload("HEVC_INDEX")) {
+                        int pindex = *(const int*)payload->Data;
+                        if (pindex >= 0 && static_cast<size_t>(pindex) < appInstance->m_fileList.size()) {
+                            HevcExportOptions opts{};
+                            opts.playlistIndex = pindex;
+                            opts.inputPath = appInstance->m_fileList[pindex];
+                            opts.outputPath = "";
+                            appInstance->m_hevcBatchOptions.push_back(opts);
+                        }
+                    }
+                    ImGui::EndDragDropTarget();
+                }
+                ImGui::Text("Drag files here or use context menu to add.");
+                ImGui::Separator();
+                for (size_t i = 0; i < appInstance->m_hevcBatchOptions.size(); ++i) {
+                    HevcExportOptions &opts = appInstance->m_hevcBatchOptions[i];
+                    ImGui::PushID(static_cast<int>(i));
+                    ImGui::Text("%s", fs::path(opts.inputPath).filename().string().c_str());
+                    ImGui::Text("Output: %s", opts.outputPath.c_str());
+                    ImGui::SameLine();
+                    if (ImGui::Button("Browse")) {
+                        std::string newPath = appInstance->openSaveMovDialog();
+                        if (!newPath.empty()) opts.outputPath = newPath;
+                    }
+                    if (ImGui::Button("Remove")) {
+                        appInstance->m_hevcBatchOptions.erase(appInstance->m_hevcBatchOptions.begin()+i);
+                        ImGui::PopID();
+                        break;
+                    }
+                    ImGui::Separator();
+                    ImGui::PopID();
+                }
+                if (ImGui::Button("Start Batch")) {
+                    appInstance->startHevcBatch();
+                }
+                ImGui::SameLine();
+                if (ImGui::Button("Close")) {
+                    appInstance->m_showHevcBatchWindow.store(false);
                 }
             }
             ImGui::End();


### PR DESCRIPTION
## Summary
- support batch exporting HEVC clips
- expose `HevcExportOptions` and add HEVC batch data to `App`
- add high quality parameters to HEVC encoder with fallback for nvenc/x265
- hook up HEVC batch UI
- document HEVC export requirements

## Testing
- `cmake -S . -B build` *(fails: Could not find package configuration file provided by "FFMPEG")*

------
https://chatgpt.com/codex/tasks/task_e_686cbf6abba48327a06a9eec47d4af3d