### PR TITLE
Add GPU ProRes conversion skeleton

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -97,6 +97,7 @@ file(MAKE_DIRECTORY ${SHADER_COMPILED_DIR})
 set(SHADER_FILES
     "${APP_SHADERS_SRC_DIR}/fullscreen_quad.vert"
     "${APP_SHADERS_SRC_DIR}/image_process.frag"
+    "${APP_SHADERS_SRC_DIR}/raw_to_yuv422.comp"
 )
 set(COMPILED_SHADER_OUTPUTS "")
 foreach(SHADER_INPUT_FILE ${SHADER_FILES})
@@ -147,6 +148,7 @@ set(APP_SOURCES
   src/Graphics/VulkanHelpers.cpp
   src/Graphics/ImageResource.cpp
   src/Graphics/Pipeline.cpp
+  src/Graphics/ComputePipeline.cpp
   src/Graphics/Descriptor.cpp
 
   src/Gui/GuiSetup.cpp

--- a/include/App/App.h
+++ b/include/App/App.h
@@ -112,6 +112,7 @@ public:
     void saveCurrentFrameAsDng();
     void convertCurrentFileToDngs();
     void exportCurrentClipToProRes();
+    void convertCurrentClipToProRes();
     void performSeek(size_t new_frame_index);
     void triggerOpenFileViaDialog();
 	void setPlaybackMode(PlaybackController::PlaybackMode mode);

--- a/include/Graphics/ComputePipeline.h
+++ b/include/Graphics/ComputePipeline.h
@@ -1,0 +1,14 @@
+#ifndef COMPUTE_PIPELINE_H
+#define COMPUTE_PIPELINE_H
+
+#include <vulkan/vulkan.h>
+
+class Renderer_VK;
+
+namespace ComputePipeline {
+    bool createRawToYuvPipeline(Renderer_VK* renderer);
+    void cleanup(Renderer_VK* renderer);
+    bool dispatchRawToYuv(Renderer_VK* renderer, VkCommandBuffer commandBuffer, int width, int height);
+}
+
+#endif // COMPUTE_PIPELINE_H

--- a/include/Graphics/ImageResource.h
+++ b/include/Graphics/ImageResource.h
@@ -10,6 +10,8 @@ namespace ImageResource {
 
     bool createRawImageResources(Renderer_VK* renderer, int width, int height);
     void cleanupRawImageResources(Renderer_VK* renderer);
+    bool createYuvImageResources(Renderer_VK* renderer, int width, int height);
+    void cleanupYuvImageResources(Renderer_VK* renderer);
 
     void transitionImageLayout(
         VkDevice device,
@@ -21,5 +23,4 @@ namespace ImageResource {
     );
 
 }
-
 #endif

--- a/include/Graphics/Renderer_VK.h
+++ b/include/Graphics/Renderer_VK.h
@@ -18,9 +18,10 @@
 
 // Include new sub-module headers
 #include "Graphics/VulkanHelpers.h"
-#include "Graphics/ImageResource.h" // ADD THIS LINE
-#include "Graphics/Pipeline.h"      // ADD THIS LINE
-#include "Graphics/Descriptor.h"    // ADD THIS LINE
+#include "Graphics/ImageResource.h"
+#include "Graphics/Pipeline.h"
+#include "Graphics/Descriptor.h"
+#include "Graphics/ComputePipeline.h"
 #include "Utils/OrientationUtils.h"
 // For VK_CHECK_RENDERER, if used, and helper function declarations
 // Other headers like ImageResource.h, Pipeline.h, Descriptor.h are not directly included here
@@ -96,6 +97,17 @@ public:
     std::vector<VkDescriptorSet> m_descriptorSets;
     VkDescriptorPool m_descriptorPool = VK_NULL_HANDLE;
 
+    // Compute pipeline members for RAW -> YUV conversion
+    VkPipeline m_computePipeline = VK_NULL_HANDLE;
+    VkPipelineLayout m_computePipelineLayout = VK_NULL_HANDLE;
+    VkDescriptorSetLayout m_computeDescriptorSetLayout = VK_NULL_HANDLE;
+    VkDescriptorPool m_computeDescriptorPool = VK_NULL_HANDLE;
+    VkDescriptorSet m_computeDescriptorSet = VK_NULL_HANDLE;
+
+    VkImage m_yuvImage = VK_NULL_HANDLE;
+    VmaAllocation m_yuvImageAllocation = VK_NULL_HANDLE;
+    VkImageView m_yuvImageView = VK_NULL_HANDLE;
+
     uint32_t m_swapChainImageCount = 0; // Needed by Descriptor helpers
 
 private:
@@ -138,6 +150,8 @@ private:
     friend void Descriptor::updateDescriptorSetsWithNewRawImage(Renderer_VK* renderer);
     friend bool Descriptor::createUniformBuffers(Renderer_VK* renderer);
     friend void Descriptor::cleanupUniformBuffers(Renderer_VK* renderer);
+    friend bool ComputePipeline::createRawToYuvPipeline(Renderer_VK* renderer);
+    friend void ComputePipeline::cleanup(Renderer_VK* renderer);
+    friend bool ComputePipeline::dispatchRawToYuv(Renderer_VK* renderer, VkCommandBuffer commandBuffer, int width, int height);
 };
-
 #endif // RENDERER_VK_H

--- a/shaders/raw_to_yuv422.comp
+++ b/shaders/raw_to_yuv422.comp
@@ -1,0 +1,26 @@
+#version 450
+
+layout(local_size_x = 16, local_size_y = 16) in;
+
+layout(binding = 0) uniform usampler2D rawImage;
+layout(binding = 1, rgba16ui) writeonly uniform uimage2D yuvImage;
+
+layout(push_constant) uniform PushConsts {
+    int width;
+    int height;
+} pc;
+
+uint readU16(int x, int y) {
+    x = clamp(x, 0, pc.width - 1);
+    y = clamp(y, 0, pc.height - 1);
+    return texelFetch(rawImage, ivec2(x, y), 0).r;
+}
+
+void main() {
+    ivec2 p = ivec2(gl_GlobalInvocationID.xy);
+    if (p.x >= pc.width || p.y >= pc.height) return;
+    uint lum = readU16(p.x, p.y) >> 6; // naive 10-bit
+    uvec4 packed = uvec4(lum, 512u, lum, 512u);
+    imageStore(yuvImage, p, packed);
+}
+

--- a/src/App/AppIO.cpp
+++ b/src/App/AppIO.cpp
@@ -1654,3 +1654,14 @@ void App::setPlaybackMode(PlaybackController::PlaybackMode mode) {
     LogToFile(std::string("[App::setPlaybackMode] Changed from ") + std::to_string(static_cast<int>(oldMode)) +
         " to " + std::to_string(static_cast<int>(mode)));
 }
+
+void App::convertCurrentClipToProRes() {
+#ifdef ENABLE_PRORES_EXPORT
+    // For now this reuses the CPU path. A full GPU implementation would
+    // upload each RAW frame to the Vulkan compute pipeline and dispatch
+    // the raw_to_yuv422 shader before handing frames off to FFmpeg.
+    exportCurrentClipToProRes();
+#else
+    showActionMessage("FFmpeg support not built");
+#endif
+}

--- a/src/Graphics/ComputePipeline.cpp
+++ b/src/Graphics/ComputePipeline.cpp
@@ -1,0 +1,138 @@
+#include "Graphics/ComputePipeline.h"
+#include "Graphics/Renderer_VK.h"
+#include "Graphics/VulkanHelpers.h"
+#include "Graphics/ImageResource.h"
+#include "Utils/DebugLog.h"
+#include <filesystem>
+
+extern std::string g_AppBasePath;
+
+namespace ComputePipeline {
+
+bool createRawToYuvPipeline(Renderer_VK* renderer) {
+    namespace fs = std::filesystem;
+    fs::path shaderPath = fs::path(g_AppBasePath) / "shaders_spv" / "raw_to_yuv422.comp.spv";
+    auto code = VulkanHelpers::readFile(shaderPath.string());
+    VkShaderModule module = VulkanHelpers::createShaderModule(renderer->m_device_p, code);
+
+    VkDescriptorSetLayoutBinding bindings[2]{};
+    bindings[0].binding = 0;
+    bindings[0].descriptorType = VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER;
+    bindings[0].descriptorCount = 1;
+    bindings[0].stageFlags = VK_SHADER_STAGE_COMPUTE_BIT;
+    bindings[1].binding = 1;
+    bindings[1].descriptorType = VK_DESCRIPTOR_TYPE_STORAGE_IMAGE;
+    bindings[1].descriptorCount = 1;
+    bindings[1].stageFlags = VK_SHADER_STAGE_COMPUTE_BIT;
+
+    VkDescriptorSetLayoutCreateInfo layoutCI{};
+    layoutCI.sType = VK_STRUCTURE_TYPE_DESCRIPTOR_SET_LAYOUT_CREATE_INFO;
+    layoutCI.bindingCount = 2;
+    layoutCI.pBindings = bindings;
+    VK_CHECK_RENDERER(vkCreateDescriptorSetLayout(renderer->m_device_p, &layoutCI, nullptr, &renderer->m_computeDescriptorSetLayout));
+
+    VkPushConstantRange pcRange{};
+    pcRange.stageFlags = VK_SHADER_STAGE_COMPUTE_BIT;
+    pcRange.offset = 0;
+    pcRange.size = sizeof(int) * 2;
+
+    VkPipelineLayoutCreateInfo pli{};
+    pli.sType = VK_STRUCTURE_TYPE_PIPELINE_LAYOUT_CREATE_INFO;
+    pli.setLayoutCount = 1;
+    pli.pSetLayouts = &renderer->m_computeDescriptorSetLayout;
+    pli.pushConstantRangeCount = 1;
+    pli.pPushConstantRanges = &pcRange;
+    VK_CHECK_RENDERER(vkCreatePipelineLayout(renderer->m_device_p, &pli, nullptr, &renderer->m_computePipelineLayout));
+
+    VkPipelineShaderStageCreateInfo stage{};
+    stage.sType = VK_STRUCTURE_TYPE_PIPELINE_SHADER_STAGE_CREATE_INFO;
+    stage.stage = VK_SHADER_STAGE_COMPUTE_BIT;
+    stage.module = module;
+    stage.pName = "main";
+
+    VkComputePipelineCreateInfo cp{};
+    cp.sType = VK_STRUCTURE_TYPE_COMPUTE_PIPELINE_CREATE_INFO;
+    cp.stage = stage;
+    cp.layout = renderer->m_computePipelineLayout;
+    VK_CHECK_RENDERER(vkCreateComputePipelines(renderer->m_device_p, VK_NULL_HANDLE, 1, &cp, nullptr, &renderer->m_computePipeline));
+
+    vkDestroyShaderModule(renderer->m_device_p, module, nullptr);
+
+    VkDescriptorPoolSize poolSizes[2]{};
+    poolSizes[0].type = VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER;
+    poolSizes[0].descriptorCount = 1;
+    poolSizes[1].type = VK_DESCRIPTOR_TYPE_STORAGE_IMAGE;
+    poolSizes[1].descriptorCount = 1;
+    VkDescriptorPoolCreateInfo poolCI{};
+    poolCI.sType = VK_STRUCTURE_TYPE_DESCRIPTOR_POOL_CREATE_INFO;
+    poolCI.maxSets = 1;
+    poolCI.poolSizeCount = 2;
+    poolCI.pPoolSizes = poolSizes;
+    VK_CHECK_RENDERER(vkCreateDescriptorPool(renderer->m_device_p, &poolCI, nullptr, &renderer->m_computeDescriptorPool));
+
+    VkDescriptorSetAllocateInfo ai{};
+    ai.sType = VK_STRUCTURE_TYPE_DESCRIPTOR_SET_ALLOCATE_INFO;
+    ai.descriptorPool = renderer->m_computeDescriptorPool;
+    ai.descriptorSetCount = 1;
+    ai.pSetLayouts = &renderer->m_computeDescriptorSetLayout;
+    VK_CHECK_RENDERER(vkAllocateDescriptorSets(renderer->m_device_p, &ai, &renderer->m_computeDescriptorSet));
+
+    return true;
+}
+
+void cleanup(Renderer_VK* renderer) {
+    if (renderer->m_computeDescriptorPool != VK_NULL_HANDLE) {
+        vkDestroyDescriptorPool(renderer->m_device_p, renderer->m_computeDescriptorPool, nullptr);
+        renderer->m_computeDescriptorPool = VK_NULL_HANDLE;
+    }
+    if (renderer->m_computePipeline != VK_NULL_HANDLE) {
+        vkDestroyPipeline(renderer->m_device_p, renderer->m_computePipeline, nullptr);
+        renderer->m_computePipeline = VK_NULL_HANDLE;
+    }
+    if (renderer->m_computePipelineLayout != VK_NULL_HANDLE) {
+        vkDestroyPipelineLayout(renderer->m_device_p, renderer->m_computePipelineLayout, nullptr);
+        renderer->m_computePipelineLayout = VK_NULL_HANDLE;
+    }
+    if (renderer->m_computeDescriptorSetLayout != VK_NULL_HANDLE) {
+        vkDestroyDescriptorSetLayout(renderer->m_device_p, renderer->m_computeDescriptorSetLayout, nullptr);
+        renderer->m_computeDescriptorSetLayout = VK_NULL_HANDLE;
+    }
+}
+
+bool dispatchRawToYuv(Renderer_VK* renderer, VkCommandBuffer cmd, int width, int height) {
+    VkDescriptorImageInfo inputInfo{};
+    inputInfo.sampler = renderer->m_rawImageSampler;
+    inputInfo.imageView = renderer->m_rawImageView;
+    inputInfo.imageLayout = VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL;
+
+    VkDescriptorImageInfo outInfo{};
+    outInfo.imageView = renderer->m_yuvImageView;
+    outInfo.imageLayout = VK_IMAGE_LAYOUT_GENERAL;
+
+    VkWriteDescriptorSet writes[2]{};
+    writes[0].sType = VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET;
+    writes[0].dstSet = renderer->m_computeDescriptorSet;
+    writes[0].dstBinding = 0;
+    writes[0].descriptorCount = 1;
+    writes[0].descriptorType = VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER;
+    writes[0].pImageInfo = &inputInfo;
+    writes[1].sType = VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET;
+    writes[1].dstSet = renderer->m_computeDescriptorSet;
+    writes[1].dstBinding = 1;
+    writes[1].descriptorCount = 1;
+    writes[1].descriptorType = VK_DESCRIPTOR_TYPE_STORAGE_IMAGE;
+    writes[1].pImageInfo = &outInfo;
+    vkUpdateDescriptorSets(renderer->m_device_p, 2, writes, 0, nullptr);
+
+    vkCmdBindPipeline(cmd, VK_PIPELINE_BIND_POINT_COMPUTE, renderer->m_computePipeline);
+    vkCmdBindDescriptorSets(cmd, VK_PIPELINE_BIND_POINT_COMPUTE, renderer->m_computePipelineLayout, 0, 1, &renderer->m_computeDescriptorSet, 0, nullptr);
+
+    struct Push { int w; int h; } push{ width, height };
+    vkCmdPushConstants(cmd, renderer->m_computePipelineLayout, VK_SHADER_STAGE_COMPUTE_BIT, 0, sizeof(Push), &push);
+
+    vkCmdDispatch(cmd, (uint32_t)((width + 15) / 16), (uint32_t)((height + 15) / 16), 1);
+    return true;
+}
+
+} // namespace ComputePipeline
+

--- a/src/Graphics/ImageResource.cpp
+++ b/src/Graphics/ImageResource.cpp
@@ -173,4 +173,60 @@ namespace ImageResource {
         }
     }
 
+    bool createYuvImageResources(Renderer_VK* renderer, int width, int height) {
+        cleanupYuvImageResources(renderer);
+
+        VkImageCreateInfo imageInfo{};
+        imageInfo.sType = VK_STRUCTURE_TYPE_IMAGE_CREATE_INFO;
+        imageInfo.imageType = VK_IMAGE_TYPE_2D;
+        imageInfo.extent.width = static_cast<uint32_t>(width);
+        imageInfo.extent.height = static_cast<uint32_t>(height);
+        imageInfo.extent.depth = 1;
+        imageInfo.mipLevels = 1;
+        imageInfo.arrayLayers = 1;
+        imageInfo.format = VK_FORMAT_R16G16B16A16_UINT;
+        imageInfo.tiling = VK_IMAGE_TILING_OPTIMAL;
+        imageInfo.initialLayout = VK_IMAGE_LAYOUT_UNDEFINED;
+        imageInfo.usage = VK_IMAGE_USAGE_STORAGE_BIT | VK_IMAGE_USAGE_TRANSFER_SRC_BIT;
+        imageInfo.sharingMode = VK_SHARING_MODE_EXCLUSIVE;
+        imageInfo.samples = VK_SAMPLE_COUNT_1_BIT;
+
+        VmaAllocationCreateInfo allocInfo{};
+        allocInfo.usage = VMA_MEMORY_USAGE_AUTO_PREFER_DEVICE;
+
+        VK_CHECK_RENDERER(vmaCreateImage(renderer->m_allocator_p, &imageInfo, &allocInfo, &renderer->m_yuvImage, &renderer->m_yuvImageAllocation, nullptr));
+
+        VkImageViewCreateInfo viewInfo{};
+        viewInfo.sType = VK_STRUCTURE_TYPE_IMAGE_VIEW_CREATE_INFO;
+        viewInfo.image = renderer->m_yuvImage;
+        viewInfo.viewType = VK_IMAGE_VIEW_TYPE_2D;
+        viewInfo.format = VK_FORMAT_R16G16B16A16_UINT;
+        viewInfo.subresourceRange.aspectMask = VK_IMAGE_ASPECT_COLOR_BIT;
+        viewInfo.subresourceRange.baseMipLevel = 0;
+        viewInfo.subresourceRange.levelCount = 1;
+        viewInfo.subresourceRange.baseArrayLayer = 0;
+        viewInfo.subresourceRange.layerCount = 1;
+        VK_CHECK_RENDERER(vkCreateImageView(renderer->m_device_p, &viewInfo, nullptr, &renderer->m_yuvImageView));
+
+        transitionImageLayout(
+            renderer->m_device_p,
+            renderer->m_hostSiteCommandPool_p,
+            renderer->m_graphicsQueue_p,
+            renderer->m_yuvImage,
+            VK_IMAGE_LAYOUT_UNDEFINED,
+            VK_IMAGE_LAYOUT_GENERAL);
+        return true;
+    }
+
+    void cleanupYuvImageResources(Renderer_VK* renderer) {
+        if (renderer->m_yuvImageView != VK_NULL_HANDLE) {
+            vkDestroyImageView(renderer->m_device_p, renderer->m_yuvImageView, nullptr);
+            renderer->m_yuvImageView = VK_NULL_HANDLE;
+        }
+        if (renderer->m_yuvImage != VK_NULL_HANDLE && renderer->m_allocator_p != VK_NULL_HANDLE) {
+            vmaDestroyImage(renderer->m_allocator_p, renderer->m_yuvImage, renderer->m_yuvImageAllocation);
+            renderer->m_yuvImage = VK_NULL_HANDLE;
+            renderer->m_yuvImageAllocation = VK_NULL_HANDLE;
+        }
+    }
 }

--- a/src/Graphics/Renderer_VK.cpp
+++ b/src/Graphics/Renderer_VK.cpp
@@ -6,6 +6,7 @@
 #include "Graphics/Pipeline.h"
 #include "Graphics/Descriptor.h"
 #include "Graphics/VulkanHelpers.h"
+#include "Graphics/ComputePipeline.h"
 #include "Utils/DebugLog.h"
 #include "Utils/RawFrameBuffer.h"
 #include "Utils/OrientationUtils.h"
@@ -54,6 +55,8 @@ bool Renderer_VK::init(VkRenderPass renderPass, uint32_t swapChainImageCount) {
 
     if (!ImageResource::createRawImageResources(this, 1, 1)) { LogToFile("[Renderer_VK::init] ERROR: Failed to create initial raw image resources."); return false; }
     LogToFile("[Renderer_VK::init] Initial raw image resources created.");
+    if (!ImageResource::createYuvImageResources(this, 1, 1)) { LogToFile("[Renderer_VK::init] ERROR: Failed to create initial yuv image resources."); return false; }
+    if (!ComputePipeline::createRawToYuvPipeline(this)) { LogToFile("[Renderer_VK::init] ERROR: Failed to create compute pipeline."); return false; }
 
     onSwapChainRecreated(renderPass, swapChainImageCount);
 
@@ -65,6 +68,8 @@ void Renderer_VK::cleanup() {
     LogToFile("[Renderer_VK::cleanup] Starting cleanup...");
     Pipeline::cleanupSwapChainResources(this);
     ImageResource::cleanupRawImageResources(this);
+    ImageResource::cleanupYuvImageResources(this);
+    ComputePipeline::cleanup(this);
 
     if (m_descriptorSetLayout != VK_NULL_HANDLE) {
         LogToFile("[Renderer_VK::cleanup] Destroying descriptor set layout.");
@@ -363,4 +368,4 @@ void Renderer_VK::ensureRawImageCapacity(uint32_t w, uint32_t h)
         LogToFile("[Renderer_VK::ensureRawImageCapacity] ERROR: Failed to recreate raw image resources for new capacity.");
         throw std::runtime_error("Failed to ensure raw image capacity by recreating resources.");
     }
-}
+    ImageResource::createYuvImageResources(this, static_cast<int>(w), static_cast<int>(h));}

--- a/src/Gui/GuiRender.cpp
+++ b/src/Gui/GuiRender.cpp
@@ -242,6 +242,9 @@ namespace GuiOverlay {
             if (ImGui::MenuItem("Export to ProRes", nullptr, false, canOperateOnCurrentFile)) {
                 if (appInstance) appInstance->exportCurrentClipToProRes();
             }
+            if (ImGui::MenuItem("Convert to ProRes (GPU)", nullptr, false, canOperateOnCurrentFile)) {
+                if (appInstance) appInstance->convertCurrentClipToProRes();
+            }
 #else
             ImGui::MenuItem("Export to ProRes", nullptr, false, false);
 #endif


### PR DESCRIPTION
## Summary
- add new compute shader `raw_to_yuv422.comp`
- introduce ComputePipeline helper for RAW->YUV compute dispatch
- extend Renderer_VK with compute resources and YUV image
- expose new `convertCurrentClipToProRes` function
- hook up menu entry for GPU conversion
- fix compute pipeline includes and formats

## Testing
- `cmake -S . -B build -DCMAKE_BUILD_TYPE=Release` *(fails: FindFFMPEG)*

------
https://chatgpt.com/codex/tasks/task_e_686e10065b8883279e13783862f9d04e