### PR TITLE
Add Vulkan hardware frame export

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,6 +19,8 @@ set(APP_ASSETS_DIR      "${APP_ROOT_DIR}/assets")
 set(APP_SHADERS_SRC_DIR "${APP_ROOT_DIR}/shaders")
 set(APP_CMAKE_DIR       "${APP_ROOT_DIR}/cmake")
 
+list(APPEND CMAKE_MODULE_PATH "${APP_CMAKE_DIR}")
+
 message(STATUS "Application Structure:")
 message(STATUS "  Source files (.cpp):      ${APP_ROOT_DIR}/src (structured)")
 message(STATUS "  Header files (.h):        ${APP_ROOT_DIR}/include (structured)")
@@ -32,7 +34,7 @@ if(NOT Vulkan_FOUND)
     message(FATAL_ERROR "Vulkan SDK not found. Please ensure it is installed and discoverable.")
 endif()
 find_package(Threads REQUIRED)
-find_package(FFMPEG REQUIRED COMPONENTS avcodec avformat avutil swscale swresample)
+find_package(FFMPEG QUIET COMPONENTS avcodec avformat avutil swscale swresample)
 message(STATUS "FFmpeg_FOUND=${FFmpeg_FOUND} FFMPEG_FOUND=${FFMPEG_FOUND}")
 if(FFMPEG_FOUND OR FFmpeg_FOUND)
     message(STATUS "FFmpeg found via vcpkg, enabling ProRes export")
@@ -97,6 +99,7 @@ file(MAKE_DIRECTORY ${SHADER_COMPILED_DIR})
 set(SHADER_FILES
     "${APP_SHADERS_SRC_DIR}/fullscreen_quad.vert"
     "${APP_SHADERS_SRC_DIR}/image_process.frag"
+    "${APP_SHADERS_SRC_DIR}/raw_to_yuv422.comp"
 )
 set(COMPILED_SHADER_OUTPUTS "")
 foreach(SHADER_INPUT_FILE ${SHADER_FILES})
@@ -148,6 +151,7 @@ set(APP_SOURCES
   src/Graphics/ImageResource.cpp
   src/Graphics/Pipeline.cpp
   src/Graphics/Descriptor.cpp
+  src/Graphics/GpuYuvConverter.cpp
 
   src/Gui/GuiSetup.cpp
   src/Gui/GuiRender.cpp
@@ -162,6 +166,10 @@ set(APP_SOURCES
 
   src/main.cpp
 )
+
+if(HAVE_FFMPEG)
+  list(APPEND APP_SOURCES src/Export/ProResExporter.cpp)
+endif()
 
 list(APPEND APP_SOURCES "${IMGUI_SOURCE_DIR}/backends/imgui_impl_glfw.cpp")
 list(APPEND APP_SOURCES "${IMGUI_SOURCE_DIR}/backends/imgui_impl_vulkan.cpp")
@@ -197,6 +205,7 @@ target_include_directories(${PROJECT_NAME} PRIVATE
   "${PROJECT_SOURCE_DIR}/include/Gui"
   "${PROJECT_SOURCE_DIR}/include/Playback"
   "${PROJECT_SOURCE_DIR}/include/Utils"
+  "${PROJECT_SOURCE_DIR}/include/Export"
 
   "${VMA_INCLUDE_DIR}"
   "${Vulkan_INCLUDE_DIRS}"

--- a/cmake/FindFFMPEG.cmake
+++ b/cmake/FindFFMPEG.cmake
@@ -1,0 +1,22 @@
+find_package(PkgConfig)
+
+foreach(_comp avcodec avformat avutil swscale swresample)
+    pkg_check_modules(PKG_${_comp} QUIET lib${_comp})
+    if(PKG_${_comp}_FOUND)
+        set(FFMPEG_${_comp}_LIBRARIES ${PKG_${_comp}_LINK_LIBRARIES})
+        set(FFMPEG_${_comp}_INCLUDE_DIRS ${PKG_${_comp}_INCLUDE_DIRS})
+    else()
+        set(FFMPEG_FOUND FALSE)
+        return()
+    endif()
+endforeach()
+
+set(FFMPEG_LIBRARIES 
+    ${FFMPEG_avcodec_LIBRARIES} ${FFMPEG_avformat_LIBRARIES} 
+    ${FFMPEG_avutil_LIBRARIES} ${FFMPEG_swscale_LIBRARIES} 
+    ${FFMPEG_swresample_LIBRARIES})
+set(FFMPEG_INCLUDE_DIRS 
+    ${FFMPEG_avcodec_INCLUDE_DIRS} ${FFMPEG_avformat_INCLUDE_DIRS} 
+    ${FFMPEG_avutil_INCLUDE_DIRS} ${FFMPEG_swscale_INCLUDE_DIRS} 
+    ${FFMPEG_swresample_INCLUDE_DIRS})
+set(FFMPEG_FOUND TRUE)

--- a/include/Export/ProResExporter.h
+++ b/include/Export/ProResExporter.h
@@ -1,0 +1,37 @@
+#pragma once
+#include <string>
+#include <thread>
+#include <atomic>
+#include <vulkan/vulkan.h>
+#include "ffmpeg_headers.hpp"
+
+class DecoderWrapper;
+class Renderer_VK;
+class AudioController;
+class GpuYuvConverter;
+
+class ProResExporter {
+public:
+    ProResExporter();
+    ~ProResExporter();
+
+    bool start(const std::string& path, const std::string& outMov,
+               DecoderWrapper* decoder, Renderer_VK* renderer,
+               AudioController* audio);
+    void join();
+    bool isRunning() const { return m_running.load(); }
+private:
+    void run();
+    std::string m_path;
+    std::string m_out;
+    DecoderWrapper* m_decoder{nullptr};
+    Renderer_VK* m_renderer{nullptr};
+    AudioController* m_audio{nullptr};
+    std::unique_ptr<GpuYuvConverter> m_converter;
+
+    AVBufferRef* m_hwDevice{nullptr};
+    AVBufferRef* m_hwFrames{nullptr};
+
+    std::thread m_thread;
+    std::atomic<bool> m_running{false};
+};

--- a/include/Graphics/GpuYuvConverter.h
+++ b/include/Graphics/GpuYuvConverter.h
@@ -1,0 +1,49 @@
+#pragma once
+#include <vulkan/vulkan.h>
+#include <vector>
+#include <nlohmann/json.hpp>
+#include "vma_usage.h"
+
+#ifndef VK_FORMAT_G10X6_B10X6_R10X6_2PACK16
+#define VK_FORMAT_G10X6_B10X6_R10X6_2PACK16 VK_FORMAT_G10X6B10X6G10X6R10X6_422_UNORM_4PACK16
+#endif
+
+class Renderer_VK;
+
+class GpuYuvConverter {
+public:
+    GpuYuvConverter();
+    ~GpuYuvConverter();
+
+    bool init(Renderer_VK* renderer, int width, int height, int ringSize);
+    void cleanup();
+
+    // Dispatch conversion for the raw image currently uploaded in Renderer_VK
+    // Returns the ring index containing the converted YUV result.
+    int convert(const nlohmann::json& meta,
+                double blackLevel, double whiteLevel,
+                int cfaOverride);
+    bool readback(VkImage image, std::vector<uint16_t>& out);
+
+    int  getRingSize() const { return m_ringSize; }
+    VkImage getImage(int index) const;
+private:
+    Renderer_VK* m_renderer{nullptr};
+    int m_width{0};
+    int m_height{0};
+    int m_ringSize{0};
+    int m_index{0};
+
+    struct ImageItem {
+        VkImage image{VK_NULL_HANDLE};
+        VmaAllocation allocation{VK_NULL_HANDLE};
+        VkImageView view{VK_NULL_HANDLE};
+        VkDescriptorSet set{VK_NULL_HANDLE};
+    };
+    std::vector<ImageItem> m_images;
+
+    VkDescriptorSetLayout m_descLayout{VK_NULL_HANDLE};
+    VkPipelineLayout m_pipelineLayout{VK_NULL_HANDLE};
+    VkPipeline m_pipeline{VK_NULL_HANDLE};
+    VkDescriptorPool m_descPool{VK_NULL_HANDLE};
+};

--- a/include/ffmpeg_headers.hpp
+++ b/include/ffmpeg_headers.hpp
@@ -4,6 +4,8 @@ extern "C" {
 #include <libavformat/avformat.h>
 #include <libavutil/avutil.h>
 #include <libavutil/opt.h>
+#include <libavutil/hwcontext.h>
+#include <libavutil/hwcontext_vulkan.h>
 #include <libswscale/swscale.h>
 #include <libswresample/swresample.h>
 }

--- a/shaders/raw_to_yuv422.comp
+++ b/shaders/raw_to_yuv422.comp
@@ -1,0 +1,83 @@
+#version 450
+
+// Converts RAW16 to packed YUV422 10-bit.
+// This is a simplified implementation used during export.
+// The demosaic logic mirrors image_process.frag but packs
+// two pixels into one uint4 for FFmpeg zero-copy.
+
+layout(local_size_x = 16, local_size_y = 16, local_size_z = 1) in;
+
+layout(binding = 0) uniform usampler2D rawImage;
+// Storage image uses 16-bit channels. Each pixel encodes YUYV in 10-bit packs.
+// rgba16ui works with VK_FORMAT_G10X6_B10X6_R10X6_2PACK16.
+layout(binding = 1, rgba16ui) writeonly uniform uimage2D outImage;
+
+layout(push_constant) uniform Params {
+    int W;
+    int H;
+    int cfaType;
+    float blackLevel;
+    float whiteLevel;
+    float gainR;
+    float gainG;
+    float gainB;
+    mat3 CCM;
+} params;
+
+float lin(uint v) {
+    float t = (float(v) - params.blackLevel) / (params.whiteLevel - params.blackLevel);
+    return clamp(t, 0.0, 1.0);
+}
+
+uint readU16(int x, int y) {
+    x = clamp(x, 0, params.W - 1);
+    y = clamp(y, 0, params.H - 1);
+    return texelFetch(rawImage, ivec2(x, y), 0).r;
+}
+
+float interpG(int x, int y) { return 0.25*(lin(readU16(x+1,y))+lin(readU16(x-1,y))+lin(readU16(x,y+1))+lin(readU16(x,y-1))); }
+float interpH(int x, int y) { return 0.5*(lin(readU16(x+1,y))+lin(readU16(x-1,y))); }
+float interpV(int x, int y) { return 0.5*(lin(readU16(x,y+1))+lin(readU16(x,y-1))); }
+float interpD(int x, int y) { return 0.25*(lin(readU16(x+1,y+1))+lin(readU16(x-1,y+1))+lin(readU16(x+1,y-1))+lin(readU16(x-1,y-1))); }
+
+vec3 demosaic(int x,int y){
+    bool ye = (y % 2) == 0;
+    bool xe = (x % 2) == 0;
+    float r=0.0,g=0.0,b=0.0;
+    int cfa = params.cfaType;
+    if(cfa==0){ // BGGR
+        if(ye){ if(xe){ b=lin(readU16(x,y)); g=interpG(x,y); r=interpD(x,y); } else { g=lin(readU16(x,y)); r=interpV(x,y); b=interpH(x,y);} }
+        else{ if(xe){ g=lin(readU16(x,y)); r=interpH(x,y); b=interpV(x,y); } else { r=lin(readU16(x,y)); g=interpG(x,y); b=interpD(x,y);} }
+    }else if(cfa==1){ // RGGB
+        if(ye){ if(xe){ r=lin(readU16(x,y)); g=interpG(x,y); b=interpD(x,y); } else { g=lin(readU16(x,y)); r=interpH(x,y); b=interpV(x,y);} }
+        else{ if(xe){ g=lin(readU16(x,y)); r=interpV(x,y); b=interpH(x,y); } else { b=lin(readU16(x,y)); g=interpG(x,y); r=interpD(x,y);} }
+    }else if(cfa==2){ // GBRG
+        if(ye){ if(xe){ g=lin(readU16(x,y)); r=interpV(x,y); b=interpH(x,y); } else { b=lin(readU16(x,y)); g=interpG(x,y); r=interpD(x,y);} }
+        else{ if(xe){ r=lin(readU16(x,y)); g=interpG(x,y); b=interpD(x,y); } else { g=lin(readU16(x,y)); r=interpH(x,y); b=interpV(x,y);} }
+    }else{ // GRBG
+        if(ye){ if(xe){ g=lin(readU16(x,y)); r=interpH(x,y); b=interpV(x,y); } else { r=lin(readU16(x,y)); g=interpG(x,y); b=interpD(x,y);} }
+        else{ if(xe){ b=lin(readU16(x,y)); g=interpG(x,y); r=interpD(x,y); } else { g=lin(readU16(x,y)); r=interpV(x,y); b=interpH(x,y);} }
+    }
+    vec3 rgb = vec3(r*params.gainR, g*params.gainG, b*params.gainB);
+    rgb = params.CCM * rgb;
+    rgb = clamp(rgb, 0.0, 1.0);
+    return rgb;
+}
+
+vec3 rgb_to_yuv(vec3 c){
+    float y = 0.2126*c.r + 0.7152*c.g + 0.0722*c.b;
+    float u = -0.1146*c.r - 0.3854*c.g + 0.5*c.b;
+    float v = 0.5*c.r - 0.4542*c.g - 0.0458*c.b;
+    return vec3(y,u,v);
+}
+
+void main(){
+    ivec2 id = ivec2(gl_GlobalInvocationID.xy);
+    if(id.x>=params.W || id.y>=params.H) return;
+    vec3 yuv0 = rgb_to_yuv(demosaic(id.x,id.y));
+    // Store as 10-bit per component inside uint32.
+    uint y = uint(clamp(yuv0.x,0.0,1.0)*1023.0+0.5);
+    uint u = uint(clamp(yuv0.y*0.5+0.5,0.0,1.0)*1023.0+0.5);
+    uint v = uint(clamp(yuv0.z*0.5+0.5,0.0,1.0)*1023.0+0.5);
+    imageStore(outImage, id, uvec4(y,u,y,v));
+}

--- a/src/Export/ProResExporter.cpp
+++ b/src/Export/ProResExporter.cpp
@@ -1,0 +1,144 @@
+#include "Export/ProResExporter.h"
+#include "Graphics/GpuYuvConverter.h"
+#include "Decoder/DecoderWrapper.h"
+#include "Graphics/Renderer_VK.h"
+#include "Audio/AudioController.h"
+#include "Utils/DebugLog.h"
+#include "Utils/RawFrameBuffer.h"
+#include "Utils/OrientationUtils.h"
+#include <filesystem>
+
+ProResExporter::ProResExporter() = default;
+ProResExporter::~ProResExporter() {
+    join();
+    if(m_hwFrames) av_buffer_unref(&m_hwFrames);
+    if(m_hwDevice) av_buffer_unref(&m_hwDevice);
+}
+
+bool ProResExporter::start(const std::string& path, const std::string& outMov,
+                           DecoderWrapper* decoder, Renderer_VK* renderer,
+                           AudioController* audio){
+    if(m_running.load()) return false;
+    m_path = path;
+    m_out = outMov;
+    m_decoder = decoder;
+    m_renderer = renderer;
+    m_audio = audio;
+    m_converter = std::make_unique<GpuYuvConverter>();
+    m_running.store(true);
+    m_thread = std::thread(&ProResExporter::run, this);
+    return true;
+}
+
+void ProResExporter::join(){
+    if(m_thread.joinable()) m_thread.join();
+    m_running.store(false);
+}
+
+void ProResExporter::run(){
+    av_log_set_level(AV_LOG_ERROR);
+    LogProRes("[ProResExporter] Thread started");
+    if(!m_decoder || !m_renderer){ m_running.store(false); return; }
+
+    auto* dec = m_decoder->getDecoder();
+    const auto& frames = dec->getFrames();
+    if(frames.empty()){ LogProRes("[ProResExporter] No frames to export"); m_running.store(false); return; }
+
+    RawBytes raw; nlohmann::json meta;
+    dec->loadFrame(frames[0], raw, meta);
+    int width = meta.value("width",0); int height = meta.value("height",0);
+    if(width<=0||height<=0){ LogProRes("[ProResExporter] Invalid frame dimensions"); m_running.store(false); return; }
+    m_converter->init(m_renderer,width,height,2);
+
+    if(av_hwdevice_ctx_create(&m_hwDevice, AV_HWDEVICE_TYPE_VULKAN, nullptr, nullptr, 0) < 0){
+        LogProRes("[ProResExporter] av_hwdevice_ctx_create failed");
+        m_running.store(false); return;
+    }
+    m_hwFrames = av_hwframe_ctx_alloc(m_hwDevice);
+    if(!m_hwFrames){ LogProRes("[ProResExporter] av_hwframe_ctx_alloc failed"); m_running.store(false); return; }
+    {
+        AVHWFramesContext* f = (AVHWFramesContext*)m_hwFrames->data;
+        f->format = AV_PIX_FMT_VULKAN;
+        f->sw_format = AV_PIX_FMT_YUV422P10LE;
+        f->width = width;
+        f->height = height;
+        f->initial_pool_size = m_converter->getRingSize();
+        if(av_hwframe_ctx_init(m_hwFrames) < 0){
+            LogProRes("[ProResExporter] av_hwframe_ctx_init failed");
+            m_running.store(false); return;
+        }
+    }
+
+    const AVCodec* vcodec = avcodec_find_encoder_by_name("prores_ks");
+    if(!vcodec){ LogProRes("[ProResExporter] prores_ks encoder not found"); m_running.store(false); return; }
+    AVFormatContext* fmt = nullptr;
+    if(avformat_alloc_output_context2(&fmt,nullptr,nullptr,m_out.c_str())<0 || !fmt){ LogProRes("[ProResExporter] avformat_alloc_output_context2 failed"); m_running.store(false); return; }
+    AVStream* vstream = avformat_new_stream(fmt,nullptr);
+    AVCodecContext* vctx = avcodec_alloc_context3(vcodec);
+    vctx->codec_id = vcodec->id; vctx->codec_type=AVMEDIA_TYPE_VIDEO; vctx->pix_fmt=AV_PIX_FMT_VULKAN;
+    vctx->width=width; vctx->height=height; vctx->time_base={1,24};
+    av_opt_set_int(vctx,"thread_type",FF_THREAD_SLICE,0); av_opt_set_int(vctx,"slices",8,0);
+    if(fmt->oformat->flags & AVFMT_GLOBALHEADER) vctx->flags |= AV_CODEC_FLAG_GLOBAL_HEADER;
+    vctx->hw_frames_ctx = av_buffer_ref(m_hwFrames);
+    if(avcodec_open2(vctx,vcodec,nullptr)<0){ LogProRes("[ProResExporter] avcodec_open2 failed"); avformat_free_context(fmt); m_running.store(false); return; }
+    avcodec_parameters_from_context(vstream->codecpar,vctx); vstream->time_base=vctx->time_base;
+    if(!(fmt->oformat->flags & AVFMT_NOFILE)){ if(avio_open(&fmt->pb,m_out.c_str(),AVIO_FLAG_WRITE)<0){ LogProRes("[ProResExporter] avio_open failed"); avcodec_free_context(&vctx); avformat_free_context(fmt); m_running.store(false); return; } }
+    if(avformat_write_header(fmt,nullptr)<0){ LogProRes("[ProResExporter] write_header failed"); if(!(fmt->oformat->flags & AVFMT_NOFILE)) avio_closep(&fmt->pb); avcodec_free_context(&vctx); avformat_free_context(fmt); m_running.store(false); return; }
+
+    GpuYuvConverter conv; conv.init(m_renderer,width,height,2);
+
+    for(size_t i=0;i<frames.size();++i){
+        dec->loadFrame(frames[i], raw, meta);
+        VkBufferCreateInfo bci{}; bci.sType=VK_STRUCTURE_TYPE_BUFFER_CREATE_INFO; bci.size=raw.size(); bci.usage=VK_BUFFER_USAGE_TRANSFER_SRC_BIT;
+        VmaAllocationCreateInfo aci{}; aci.usage=VMA_MEMORY_USAGE_AUTO_PREFER_HOST; aci.flags=VMA_ALLOCATION_CREATE_MAPPED_BIT | VMA_ALLOCATION_CREATE_HOST_ACCESS_SEQUENTIAL_WRITE_BIT;
+        VkBuffer buf; VmaAllocation alloc; VmaAllocationInfo info{};
+        vmaCreateBuffer(m_renderer->m_allocator_p,&bci,&aci,&buf,&alloc,&info);
+        memcpy(info.pMappedData, raw.data(), raw.size());
+        vmaFlushAllocation(m_renderer->m_allocator_p,alloc,0,VK_WHOLE_SIZE);
+        vmaUnmapMemory(m_renderer->m_allocator_p,alloc);
+        VkCommandBuffer cmd = VulkanHelpers::beginSingleTimeCommands(m_renderer->m_device_p,m_renderer->m_hostSiteCommandPool_p);
+        m_renderer->prepareAndUploadFrameData(cmd,0,buf,width,height,meta,0,65535,0,true,OrientationTag::kNormal,false);
+        VulkanHelpers::endSingleTimeCommands(m_renderer->m_device_p,m_renderer->m_hostSiteCommandPool_p,m_renderer->m_graphicsQueue_p,cmd);
+        vmaDestroyBuffer(m_renderer->m_allocator_p,buf,alloc);
+
+        int idx = conv.convert(meta,0,65535,0);
+        VkImage yuv = conv.getImage(idx);
+
+        AVFrame* hwFrame = av_frame_alloc();
+        hwFrame->format = AV_PIX_FMT_VULKAN;
+        hwFrame->width = width;
+        hwFrame->height = height;
+        if(av_hwframe_get_buffer(m_hwFrames, hwFrame, 0) < 0){
+            LogProRes("[ProResExporter] hwframe_get_buffer failed");
+            av_frame_free(&hwFrame);
+            break;
+        }
+        AVVkFrame* vkf = (AVVkFrame*)hwFrame->data[0];
+        vkf->image[0] = yuv;
+        vkf->image_layout[0] = VK_IMAGE_LAYOUT_GENERAL;
+
+        AVFrame* frame = av_frame_alloc();
+        frame->format = AV_PIX_FMT_YUV422P10LE;
+        frame->width = width;
+        frame->height = height;
+        if(av_hwframe_transfer_data(frame, hwFrame, 0) < 0){
+            LogProRes("[ProResExporter] hwframe_transfer_data failed");
+        }
+        av_frame_free(&hwFrame);
+
+        frame->pts=i;
+        if(avcodec_send_frame(vctx,frame)==0){
+            AVPacket pkt{}; while(avcodec_receive_packet(vctx,&pkt)==0){ pkt.stream_index=vstream->index; pkt.duration=1; pkt.pts=av_rescale_q(pkt.pts,vctx->time_base,vstream->time_base); pkt.dts=pkt.pts; av_interleaved_write_frame(fmt,&pkt); av_packet_unref(&pkt); }
+        }
+        av_frame_free(&frame);
+    }
+
+    avcodec_send_frame(vctx,nullptr); AVPacket pkt{}; while(avcodec_receive_packet(vctx,&pkt)==0){ pkt.stream_index=vstream->index; pkt.duration=1; pkt.pts=av_rescale_q(pkt.pts,vctx->time_base,vstream->time_base); pkt.dts=pkt.pts; av_interleaved_write_frame(fmt,&pkt); av_packet_unref(&pkt); }
+    av_write_trailer(fmt);
+    if(!(fmt->oformat->flags & AVFMT_NOFILE)) avio_closep(&fmt->pb);
+    avcodec_free_context(&vctx); avformat_free_context(fmt);
+    conv.cleanup();
+    if(m_hwFrames) av_buffer_unref(&m_hwFrames);
+    if(m_hwDevice) av_buffer_unref(&m_hwDevice);
+    m_running.store(false);
+}

--- a/src/Graphics/GpuYuvConverter.cpp
+++ b/src/Graphics/GpuYuvConverter.cpp
@@ -1,0 +1,140 @@
+#include "Graphics/GpuYuvConverter.h"
+#include "Graphics/Renderer_VK.h"
+#include "Graphics/VulkanHelpers.h"
+#include "Utils/DebugLog.h"
+#include <stdexcept>
+#include <cstring>
+
+GpuYuvConverter::GpuYuvConverter() = default;
+GpuYuvConverter::~GpuYuvConverter() { cleanup(); }
+
+bool GpuYuvConverter::init(Renderer_VK* renderer, int width, int height, int ringSize){
+    m_renderer = renderer;
+    m_width = width;
+    m_height = height;
+    m_ringSize = ringSize;
+    m_index = 0;
+
+    // Descriptor layout: binding 0 sampled raw image, binding 1 storage image
+    VkDescriptorSetLayoutBinding b0{}; b0.binding = 0; b0.descriptorType = VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER; b0.descriptorCount=1; b0.stageFlags = VK_SHADER_STAGE_COMPUTE_BIT;
+    VkDescriptorSetLayoutBinding b1{}; b1.binding = 1; b1.descriptorType = VK_DESCRIPTOR_TYPE_STORAGE_IMAGE; b1.descriptorCount=1; b1.stageFlags = VK_SHADER_STAGE_COMPUTE_BIT;
+    VkDescriptorSetLayoutBinding bindings[2] = {b0,b1};
+    VkDescriptorSetLayoutCreateInfo dci{}; dci.sType = VK_STRUCTURE_TYPE_DESCRIPTOR_SET_LAYOUT_CREATE_INFO; dci.bindingCount=2; dci.pBindings=bindings;
+    VK_CHECK_RENDERER(vkCreateDescriptorSetLayout(renderer->m_device_p,&dci,nullptr,&m_descLayout));
+
+    VkPipelineLayoutCreateInfo plci{}; plci.sType=VK_STRUCTURE_TYPE_PIPELINE_LAYOUT_CREATE_INFO; plci.setLayoutCount=1; plci.pSetLayouts=&m_descLayout;
+    VK_CHECK_RENDERER(vkCreatePipelineLayout(renderer->m_device_p,&plci,nullptr,&m_pipelineLayout));
+
+    // Load compute shader
+    extern std::string g_AppBasePath;
+    std::string spv = (std::filesystem::path(g_AppBasePath)/"shaders_spv"/"raw_to_yuv422.comp.spv").string();
+    auto code = VulkanHelpers::readFile(spv);
+    VkShaderModule module = VulkanHelpers::createShaderModule(renderer->m_device_p, code);
+
+    VkComputePipelineCreateInfo cpci{}; cpci.sType = VK_STRUCTURE_TYPE_COMPUTE_PIPELINE_CREATE_INFO; cpci.layout=m_pipelineLayout;
+    VkPipelineShaderStageCreateInfo psi{}; psi.sType=VK_STRUCTURE_TYPE_PIPELINE_SHADER_STAGE_CREATE_INFO; psi.stage=VK_SHADER_STAGE_COMPUTE_BIT; psi.module=module; psi.pName="main";
+    cpci.stage = psi;
+    VK_CHECK_RENDERER(vkCreateComputePipelines(renderer->m_device_p,VK_NULL_HANDLE,1,&cpci,nullptr,&m_pipeline));
+    vkDestroyShaderModule(renderer->m_device_p,module,nullptr);
+
+    // Descriptor pool
+    VkDescriptorPoolSize poolSizes[2]{}; poolSizes[0].type=VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER; poolSizes[0].descriptorCount=ringSize; poolSizes[1].type=VK_DESCRIPTOR_TYPE_STORAGE_IMAGE; poolSizes[1].descriptorCount=ringSize;
+    VkDescriptorPoolCreateInfo dpci{}; dpci.sType=VK_STRUCTURE_TYPE_DESCRIPTOR_POOL_CREATE_INFO; dpci.maxSets=ringSize; dpci.poolSizeCount=2; dpci.pPoolSizes=poolSizes;
+    VK_CHECK_RENDERER(vkCreateDescriptorPool(renderer->m_device_p,&dpci,nullptr,&m_descPool));
+
+    m_images.resize(ringSize);
+    std::vector<VkDescriptorSetLayout> layouts(ringSize,m_descLayout);
+    VkDescriptorSetAllocateInfo dsai{}; dsai.sType=VK_STRUCTURE_TYPE_DESCRIPTOR_SET_ALLOCATE_INFO; dsai.descriptorPool=m_descPool; dsai.descriptorSetCount=ringSize; dsai.pSetLayouts=layouts.data();
+    std::vector<VkDescriptorSet> sets(ringSize);
+    VK_CHECK_RENDERER(vkAllocateDescriptorSets(renderer->m_device_p,&dsai,sets.data()));
+
+    for(int i=0;i<ringSize;++i){
+        ImageItem item{}; item.set=sets[i];
+        VkImageCreateInfo ici{}; ici.sType=VK_STRUCTURE_TYPE_IMAGE_CREATE_INFO; ici.imageType=VK_IMAGE_TYPE_2D; ici.extent={static_cast<uint32_t>(width),static_cast<uint32_t>(height),1};
+        ici.mipLevels=1; ici.arrayLayers=1; ici.format=VK_FORMAT_G10X6_B10X6_R10X6_2PACK16; ici.tiling=VK_IMAGE_TILING_OPTIMAL;
+        ici.initialLayout=VK_IMAGE_LAYOUT_UNDEFINED; ici.usage=VK_IMAGE_USAGE_STORAGE_BIT|VK_IMAGE_USAGE_TRANSFER_SRC_BIT; ici.samples=VK_SAMPLE_COUNT_1_BIT;
+        VmaAllocationCreateInfo aci{}; aci.usage=VMA_MEMORY_USAGE_AUTO_PREFER_DEVICE;
+        VK_CHECK_RENDERER(vmaCreateImage(renderer->m_allocator_p,&ici,&aci,&item.image,&item.allocation,nullptr));
+        VkImageViewCreateInfo ivci{}; ivci.sType=VK_STRUCTURE_TYPE_IMAGE_VIEW_CREATE_INFO; ivci.image=item.image; ivci.viewType=VK_IMAGE_VIEW_TYPE_2D; ivci.format=ici.format; ivci.subresourceRange.aspectMask=VK_IMAGE_ASPECT_COLOR_BIT; ivci.subresourceRange.levelCount=1; ivci.subresourceRange.layerCount=1; VK_CHECK_RENDERER(vkCreateImageView(renderer->m_device_p,&ivci,nullptr,&item.view));
+        VkDescriptorImageInfo in{}; in.imageLayout=VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL; in.imageView=renderer->m_rawImageView; in.sampler=renderer->m_rawImageSampler;
+        VkDescriptorImageInfo out{}; out.imageLayout=VK_IMAGE_LAYOUT_GENERAL; out.imageView=item.view; out.sampler=VK_NULL_HANDLE;
+        VkWriteDescriptorSet writes[2]{}; writes[0].sType=VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET; writes[0].dstSet=item.set; writes[0].dstBinding=0; writes[0].descriptorCount=1; writes[0].descriptorType=VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER; writes[0].pImageInfo=&in;
+        writes[1].sType=VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET; writes[1].dstSet=item.set; writes[1].dstBinding=1; writes[1].descriptorCount=1; writes[1].descriptorType=VK_DESCRIPTOR_TYPE_STORAGE_IMAGE; writes[1].pImageInfo=&out;
+        vkUpdateDescriptorSets(renderer->m_device_p,2,writes,0,nullptr);
+        m_images[i]=item;
+    }
+    return true;
+}
+
+void GpuYuvConverter::cleanup(){
+    if(!m_renderer) return;
+    for(auto& it:m_images){
+        if(it.view) vkDestroyImageView(m_renderer->m_device_p,it.view,nullptr);
+        if(it.image) vmaDestroyImage(m_renderer->m_allocator_p,it.image,it.allocation);
+    }
+    m_images.clear();
+    if(m_descPool) vkDestroyDescriptorPool(m_renderer->m_device_p,m_descPool,nullptr); m_descPool=VK_NULL_HANDLE;
+    if(m_pipeline) vkDestroyPipeline(m_renderer->m_device_p,m_pipeline,nullptr); m_pipeline=VK_NULL_HANDLE;
+    if(m_pipelineLayout) vkDestroyPipelineLayout(m_renderer->m_device_p,m_pipelineLayout,nullptr); m_pipelineLayout=VK_NULL_HANDLE;
+    if(m_descLayout) vkDestroyDescriptorSetLayout(m_renderer->m_device_p,m_descLayout,nullptr); m_descLayout=VK_NULL_HANDLE;
+}
+
+int GpuYuvConverter::convert(const nlohmann::json& meta,double black,double white,int cfa){
+    if(m_images.empty()) return -1;
+    int idx = m_index;
+    ImageItem& item = m_images[m_index];
+    m_index = (m_index+1)%m_ringSize;
+
+    VkCommandBuffer cmd = VulkanHelpers::beginSingleTimeCommands(m_renderer->m_device_p,m_renderer->m_hostSiteCommandPool_p);
+    vkCmdBindPipeline(cmd,VK_PIPELINE_BIND_POINT_COMPUTE,m_pipeline);
+    vkCmdBindDescriptorSets(cmd,VK_PIPELINE_BIND_POINT_COMPUTE,m_pipelineLayout,0,1,&item.set,0,nullptr);
+    struct Push{int W;int H;int cfaType;float black;float white;float gainR;float gainG;float gainB;float ccm[9];} push{};
+    push.W=m_width; push.H=m_height; push.cfaType=cfa; push.black=(float)black; push.white=(float)white; push.gainR=1.0f; push.gainG=1.0f; push.gainB=1.0f;
+    auto ccm = meta.value("ColorMatrix", std::vector<float>{1,0,0,0,1,0,0,0,1});
+    for(int i=0;i<9 && i<(int)ccm.size();++i) push.ccm[i]=ccm[i];
+    vkCmdPushConstants(cmd,m_pipelineLayout,VK_SHADER_STAGE_COMPUTE_BIT,0,sizeof(Push),&push);
+    vkCmdDispatch(cmd,(uint32_t)((m_width+15)/16),(uint32_t)((m_height+15)/16),1);
+    VulkanHelpers::endSingleTimeCommands(m_renderer->m_device_p,m_renderer->m_hostSiteCommandPool_p,m_renderer->m_graphicsQueue_p,cmd);
+    return idx;
+}
+
+VkImage GpuYuvConverter::getImage(int index) const {
+    if(index < 0 || index >= m_ringSize) return VK_NULL_HANDLE;
+    return m_images[index].image;
+}
+
+bool GpuYuvConverter::readback(VkImage image, std::vector<uint16_t>& out){
+    if(!m_renderer || image==VK_NULL_HANDLE) return false;
+    VkDevice device = m_renderer->m_device_p;
+    VkCommandPool pool = m_renderer->m_hostSiteCommandPool_p;
+    VkQueue queue = m_renderer->m_graphicsQueue_p;
+    VkDeviceSize bufSize = static_cast<VkDeviceSize>(m_width*m_height*4*sizeof(uint16_t));
+
+    VkBufferCreateInfo bci{}; bci.sType=VK_STRUCTURE_TYPE_BUFFER_CREATE_INFO; bci.size=bufSize; bci.usage=VK_BUFFER_USAGE_TRANSFER_DST_BIT;
+    VmaAllocationCreateInfo aci{}; aci.usage=VMA_MEMORY_USAGE_AUTO_PREFER_HOST; aci.flags = VMA_ALLOCATION_CREATE_MAPPED_BIT | VMA_ALLOCATION_CREATE_HOST_ACCESS_SEQUENTIAL_WRITE_BIT;
+    VkBuffer buf; VmaAllocation alloc; VmaAllocationInfo info{};
+    VK_CHECK_RENDERER(vmaCreateBuffer(m_renderer->m_allocator_p,&bci,&aci,&buf,&alloc,&info));
+
+    VkCommandBuffer cmd = VulkanHelpers::beginSingleTimeCommands(device,pool);
+    VkImageMemoryBarrier bar{}; bar.sType=VK_STRUCTURE_TYPE_IMAGE_MEMORY_BARRIER; bar.srcQueueFamilyIndex=VK_QUEUE_FAMILY_IGNORED; bar.dstQueueFamilyIndex=VK_QUEUE_FAMILY_IGNORED;
+    bar.image=image; bar.subresourceRange.aspectMask=VK_IMAGE_ASPECT_COLOR_BIT; bar.subresourceRange.levelCount=1; bar.subresourceRange.layerCount=1;
+    bar.oldLayout=VK_IMAGE_LAYOUT_GENERAL; bar.newLayout=VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL;
+    bar.srcAccessMask=VK_ACCESS_SHADER_WRITE_BIT; bar.dstAccessMask=VK_ACCESS_TRANSFER_READ_BIT;
+    vkCmdPipelineBarrier(cmd,VK_PIPELINE_STAGE_COMPUTE_SHADER_BIT,VK_PIPELINE_STAGE_TRANSFER_BIT,0,0,nullptr,0,nullptr,1,&bar);
+
+    VkBufferImageCopy region{}; region.bufferOffset=0; region.bufferRowLength=0; region.bufferImageHeight=0;
+    region.imageSubresource.aspectMask=VK_IMAGE_ASPECT_COLOR_BIT; region.imageSubresource.mipLevel=0; region.imageSubresource.baseArrayLayer=0; region.imageSubresource.layerCount=1;
+    region.imageExtent={static_cast<uint32_t>(m_width),static_cast<uint32_t>(m_height),1};
+    vkCmdCopyImageToBuffer(cmd,image,VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL,buf,1,&region);
+
+    bar.oldLayout=VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL; bar.newLayout=VK_IMAGE_LAYOUT_GENERAL; bar.srcAccessMask=VK_ACCESS_TRANSFER_READ_BIT; bar.dstAccessMask=VK_ACCESS_SHADER_WRITE_BIT;
+    vkCmdPipelineBarrier(cmd,VK_PIPELINE_STAGE_TRANSFER_BIT,VK_PIPELINE_STAGE_COMPUTE_SHADER_BIT,0,0,nullptr,0,nullptr,1,&bar);
+
+    VulkanHelpers::endSingleTimeCommands(device,pool,queue,cmd);
+
+    out.resize(bufSize/sizeof(uint16_t));
+    memcpy(out.data(), info.pMappedData, bufSize);
+    vmaUnmapMemory(m_renderer->m_allocator_p, alloc);
+    vmaDestroyBuffer(m_renderer->m_allocator_p, buf, alloc);
+    return true;
+}

--- a/src/Gui/GuiRender.cpp
+++ b/src/Gui/GuiRender.cpp
@@ -239,11 +239,11 @@ namespace GuiOverlay {
             }
             ImGui::Separator();
 #ifdef ENABLE_PRORES_EXPORT
-            if (ImGui::MenuItem("Export to ProRes", nullptr, false, canOperateOnCurrentFile)) {
+            if (ImGui::MenuItem("Export \xE2\x86\x92 ProRes\xE2\x80\xA6", nullptr, false, canOperateOnCurrentFile)) {
                 if (appInstance) appInstance->exportCurrentClipToProRes();
             }
 #else
-            ImGui::MenuItem("Export to ProRes", nullptr, false, false);
+            ImGui::MenuItem("Export \xE2\x86\x92 ProRes\xE2\x80\xA6", nullptr, false, false);
 #endif
             ImGui::EndPopup();
         }

--- a/src/Utils/DebugLog.cpp
+++ b/src/Utils/DebugLog.cpp
@@ -160,7 +160,9 @@ void LogFFmpegStatus() {
         LogProRes("[FFmpeg] Some FFmpeg DLLs could not be loaded; export may fail.");
     }
 #   else
+#if LIBAVFORMAT_VERSION_MAJOR < 58
     av_register_all();
+#endif
     int version = avcodec_version();
     LogToFile(std::string("[FFmpeg] avcodec version ") + std::to_string(version));
     LogProRes(std::string("[FFmpeg] avcodec version ") + std::to_string(version));

--- a/tests/export_prores_test.sh
+++ b/tests/export_prores_test.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+set -e
+
+APP="./MotionCam\ Player"
+IN="sample.mcraw"
+OUT="out.mov"
+
+$APP --headless --export "$IN" --out "$OUT"
+
+ffprobe -v error -select_streams v:0 -show_entries stream=codec_name,profile -show_entries format=duration "$OUT"


### PR DESCRIPTION
## Summary
- extend `GpuYuvConverter` to expose ring indices
- wire up Vulkan AVHWDevice and AVHWFramesContext
- build ProRes frames by transferring from Vulkan images
- expose FFmpeg Vulkan headers

## Testing
- `cmake -S . -B build` *(passes)*
- `cmake --build build -j2` *(fails: missing Windows libs)*
- `bash tests/export_prores_test.sh` *(fails: ./MotionCam\: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_686e0f36402c8327beae12e5d96088b5