### PR TITLE
Fix GPU ProRes export queue issues

### DIFF
--- a/include/Graphics/VulkanHelpers.h
+++ b/include/Graphics/VulkanHelpers.h
@@ -5,6 +5,7 @@
 #include <vector>
 #include <string>
 #include <iostream> // For std::cerr in VK_CHECK_RENDERER
+#include <mutex>
 #include "Utils/DebugLog.h" // For LogToFile in VK_CHECK_RENDERER
 
 // Macro for Vulkan error checking, specific to Renderer context or general Vulkan calls.
@@ -27,6 +28,8 @@
 
 namespace VulkanHelpers {
 
+extern std::mutex g_vulkanQueueMutex;
+
     std::vector<char> readFile(const std::string& filename);
     VkShaderModule createShaderModule(VkDevice device, const std::vector<char>& code);
 
@@ -37,5 +40,4 @@ namespace VulkanHelpers {
     void endSingleTimeCommands(VkDevice device, VkCommandPool commandPool, VkQueue queue, VkCommandBuffer commandBuffer);
 
 } // namespace VulkanHelpers
-
 #endif // VULKAN_HELPERS_H

--- a/src/Graphics/GpuYuvConverter.cpp
+++ b/src/Graphics/GpuYuvConverter.cpp
@@ -276,6 +276,12 @@ bool GpuYuvConverter::convertAndReadback(const uint16_t* raw, int width, int hei
     outPacked.resize(static_cast<size_t>(outSize / sizeof(uint16_t)));
     memcpy(outPacked.data(), rbAllocInfo.pMappedData, outSize);
     LogProRes("[GPU] readback complete");
+    if (outPacked.size() >= 4) {
+        std::ostringstream oss;
+        oss << "[GPU] first values: " << outPacked[0] << "," << outPacked[1]
+            << "," << outPacked[2] << "," << outPacked[3];
+        LogProRes(oss.str());
+    }
 
     vmaDestroyBuffer(m_renderer->m_allocator_p, stagingBuf, stagingAlloc);
     vmaDestroyBuffer(m_renderer->m_allocator_p, readbackBuf, readbackAlloc);

--- a/src/Graphics/VulkanHelpers.cpp
+++ b/src/Graphics/VulkanHelpers.cpp
@@ -2,6 +2,9 @@
 #include "Utils/DebugLog.h" // For LogToFile
 #include <fstream>
 #include <stdexcept> // For std::runtime_error
+#include <mutex>
+
+std::mutex g_vulkanQueueMutex; // Protect queue submissions
 
 namespace VulkanHelpers {
 
@@ -64,10 +67,14 @@ namespace VulkanHelpers {
         submitInfo.commandBufferCount = 1;
         submitInfo.pCommandBuffers = &commandBuffer;
 
-        VK_CHECK_RENDERER(vkQueueSubmit(queue, 1, &submitInfo, VK_NULL_HANDLE));
-        VK_CHECK_RENDERER(vkQueueWaitIdle(queue));
+        LogToFile("[VulkanHelpers] Submitting single-time command buffer");
+        {
+            std::lock_guard<std::mutex> lock(g_vulkanQueueMutex);
+            VK_CHECK_RENDERER(vkQueueSubmit(queue, 1, &submitInfo, VK_NULL_HANDLE));
+            VK_CHECK_RENDERER(vkQueueWaitIdle(queue));
+        }
+        LogToFile("[VulkanHelpers] Command buffer completed");
 
         vkFreeCommandBuffers(device, commandPool, 1, &commandBuffer);
     }
-
 } // namespace VulkanHelpers


### PR DESCRIPTION
## Summary
- protect Vulkan queue submissions with mutex to avoid device lost
- add debug messages for queue submissions
- log first pixels from GPU readback for troubleshooting

## Testing
- `cmake --version`

------
https://chatgpt.com/codex/tasks/task_e_686e53669b908327b06ef75c89ba5dfa