### PR TITLE
Fix GPU ProRes export color and add debug logs

### DIFF
--- a/src/App/AppIO.cpp
+++ b/src/App/AppIO.cpp
@@ -1490,10 +1490,10 @@ void App::exportCurrentClipToProRes() {
                 for (int y=0; y<height; ++y) {
                     for (int x=0; x<width/2; ++x) {
                         size_t srcIdx = static_cast<size_t>(y) * (width/2) * 4 + x*4;
-                        uint16_t y0 = gpuBuf[srcIdx] >> 6;
-                        uint16_t u = gpuBuf[srcIdx+1] >> 6;
-                        uint16_t y1 = gpuBuf[srcIdx+2] >> 6;
-                        uint16_t v = gpuBuf[srcIdx+3] >> 6;
+                        uint16_t y0 = gpuBuf[srcIdx];
+                        uint16_t u = gpuBuf[srcIdx+1];
+                        uint16_t y1 = gpuBuf[srcIdx+2];
+                        uint16_t v = gpuBuf[srcIdx+3];
                         yPlane[y*frame->linesize[0]/2 + 2*x] = y0;
                         yPlane[y*frame->linesize[0]/2 + 2*x+1] = y1;
                         uPlane[y*frame->linesize[1]/2 + x] = u;

--- a/src/Graphics/GpuYuvConverter.cpp
+++ b/src/Graphics/GpuYuvConverter.cpp
@@ -6,6 +6,7 @@
 #include <vector>
 #include <filesystem>
 #include <chrono>
+#include <sstream>
 
 extern std::string g_AppBasePath;
 
@@ -160,7 +161,13 @@ void GpuYuvConverter::cleanup() {
 
 bool GpuYuvConverter::convertAndReadback(const uint16_t* raw, int width, int height,
                                          std::vector<uint16_t>& outPacked) {
+    static int callCounter = 0;
     LogProRes("[GPU] convertAndReadback invoked");
+    if (callCounter == 0) {
+        std::ostringstream info;
+        info << "[GPU] first call width=" << width << " height=" << height;
+        LogProRes(info.str());
+    }
     VkDeviceSize rawSize = static_cast<VkDeviceSize>(width) * height * sizeof(uint16_t);
     VkDeviceSize outSize = static_cast<VkDeviceSize>(width) * height * 4;
 
@@ -275,7 +282,15 @@ bool GpuYuvConverter::convertAndReadback(const uint16_t* raw, int width, int hei
     vmaInvalidateAllocation(m_renderer->m_allocator_p, readbackAlloc, 0, outSize);
     outPacked.resize(static_cast<size_t>(outSize / sizeof(uint16_t)));
     memcpy(outPacked.data(), rbAllocInfo.pMappedData, outSize);
+    if (callCounter == 0 && outPacked.size() >= 4) {
+        std::ostringstream vals;
+        vals << "[GPU] first pixel values "
+             << outPacked[0] << "," << outPacked[1] << "," << outPacked[2]
+             << "," << outPacked[3];
+        LogProRes(vals.str());
+    }
     LogProRes("[GPU] readback complete");
+    ++callCounter;
 
     vmaDestroyBuffer(m_renderer->m_allocator_p, stagingBuf, stagingAlloc);
     vmaDestroyBuffer(m_renderer->m_allocator_p, readbackBuf, readbackAlloc);


### PR DESCRIPTION
## Summary
- stop shifting GPU-generated pixel values so YUV data keeps its 10‑bit range
- log first call information and sample values from the GPU converter for troubleshooting

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_686e53669b908327b06ef75c89ba5dfa