### PR TITLE
Fix GPU ProRes export path and add diagnostics

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -320,3 +320,6 @@ message(STATUS "  Target Executable: MotionCam Player")
 message(STATUS "  Output Directory:  ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${CMAKE_CFG_INTDIR}")
 message(STATUS "  Output Executable: ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${CMAKE_CFG_INTDIR}/MotionCam Player${CMAKE_EXECUTABLE_SUFFIX}")
 message(STATUS "---------------------------------------------------------------------")
+
+enable_testing()
+add_subdirectory(tests)

--- a/include/App/App.h
+++ b/include/App/App.h
@@ -230,6 +230,8 @@ private:
     std::thread m_proResThread;
 #endif
 
+    // When true the render loop skips drawFrame() allowing export threads to own the GPU
+    std::atomic<bool> m_renderPaused{ false };
 
 #ifdef _WIN32
     HWND _ipcWnd = nullptr;

--- a/include/Graphics/GpuYuvConverter.h
+++ b/include/Graphics/GpuYuvConverter.h
@@ -17,6 +17,7 @@ public:
     void cleanup();
 
     bool convertAndReadback(const uint16_t* raw, int width, int height,
+                            int frameIndex,
                             std::vector<uint16_t>& outPacked);
 private:
     Renderer_VK* m_renderer;

--- a/include/Utils/DebugLog.h
+++ b/include/Utils/DebugLog.h
@@ -14,4 +14,10 @@ void LogFFmpegStatus();
 // On other platforms it falls back to the application base path.
 std::string getLogDirectory();
 
+// Convenience macros used throughout the player for rich diagnostics
+#define DBG_INFO(msg)  LogProRes(std::string("[INFO] ")  + (msg))
+#define DBG_WARN(msg)  LogProRes(std::string("[WARN] ")  + (msg))
+#define DBG_ERROR(msg) LogProRes(std::string("[ERROR] ") + (msg))
+#define DBG_TRACE(msg) LogProRes(std::string("[TRACE] ") + (msg))
+
 #endif // DEBUG_LOG_H

--- a/src/App/AppIO.cpp
+++ b/src/App/AppIO.cpp
@@ -35,6 +35,8 @@
 #endif
 #include "Utils/ColorPipelineCPU.h"
 
+#define MC_GPU_EXPORT_DEBUG 1
+
 namespace fs = std::filesystem;
 
 #ifdef ENABLE_PRORES_EXPORT
@@ -1205,6 +1207,10 @@ void App::exportCurrentClipToProRes() {
     m_showExportProgressPopup.store(true);
     showActionMessage("Export Started");
 
+    DBG_INFO("Render paused for export…");
+    m_renderPaused.store(true);
+    vkDeviceWaitIdle(m_device);
+
     if (m_proResThread.joinable()) {
         m_proResThread.join();
     }
@@ -1480,33 +1486,49 @@ void App::exportCurrentClipToProRes() {
 
             t0 = t1;
             if (gpuActive) {
-                converter.convertAndReadback(asU16(raw), width, height, gpuBuf);
+                converter.convertAndReadback(asU16(raw), width, height, static_cast<int>(idx), gpuBuf);
                 t1 = std::chrono::steady_clock::now();
                 rgbUS += std::chrono::duration_cast<std::chrono::microseconds>(t1 - t0).count();
                 if (av_frame_make_writable(frame) < 0) { m_proResStatus.errorMsg = "frame not writable"; break; }
                 uint16_t* yPlane = reinterpret_cast<uint16_t*>(frame->data[0]);
                 uint16_t* uPlane = reinterpret_cast<uint16_t*>(frame->data[1]);
                 uint16_t* vPlane = reinterpret_cast<uint16_t*>(frame->data[2]);
+
+                auto scale10 = [](uint16_t v){ return static_cast<uint16_t>((static_cast<uint32_t>(v) * 1023 + 32767) / 65535); };
+                uint64_t sumY=0,sumU=0,sumV=0;
+
+                DBG_INFO(std::string("[Export] frame ") + std::to_string(idx) + " → AVFrame planes");
                 for (int y=0; y<height; ++y) {
                     for (int x=0; x<width/2; ++x) {
                         size_t srcIdx = static_cast<size_t>(y) * (width/2) * 4 + x*4;
-                        uint16_t y0 = gpuBuf[srcIdx] >> 6;
-                        uint16_t y1 = gpuBuf[srcIdx+1] >> 6; // Y1 directly
-                        uint16_t u  = gpuBuf[srcIdx+2] >> 6;
-                        uint16_t v  = gpuBuf[srcIdx+3] >> 6;
+                        uint16_t y0 = scale10(gpuBuf[srcIdx]);
+                        uint16_t u  = scale10(gpuBuf[srcIdx+1]);
+                        uint16_t y1 = scale10(gpuBuf[srcIdx+2]);
+                        uint16_t v  = scale10(gpuBuf[srcIdx+3]);
                         yPlane[y*frame->linesize[0]/2 + 2*x] = y0;
                         yPlane[y*frame->linesize[0]/2 + 2*x+1] = y1;
                         uPlane[y*frame->linesize[1]/2 + x] = u;
                         vPlane[y*frame->linesize[2]/2 + x] = v;
+                        sumY += y0 + y1;
+                        sumU += u;
+                        sumV += v;
+                        if (idx==0 && y==0 && x==0) {
+                            std::ostringstream first;
+                            first << "[Export] first samples " << y0 << "," << y1 << " U=" << u << " V=" << v;
+                            DBG_INFO(first.str());
+                        }
                     }
                 }
-                if (idx == 0) {
-                    std::ostringstream dbg;
-                    dbg << "[GPU] AVFrame first: "
-                        << yPlane[0] << "," << yPlane[1] << "," << uPlane[0]
-                        << "," << vPlane[0];
-                    LogProRes(dbg.str());
+                double avgY = static_cast<double>(sumY) / (width*height);
+                double avgU = static_cast<double>(sumU) / ((width/2)*height);
+                double avgV = static_cast<double>(sumV) / ((width/2)*height);
+                {
+                    std::ostringstream ss;
+                    ss << "[Export] avgY=" << avgY << " avgU=" << avgU << " avgV=" << avgV;
+                    DBG_TRACE(ss.str());
                 }
+                if (std::abs(avgU-512)+std::abs(avgV-512) < 5)
+                    DBG_WARN("Chroma is ~zero ⇒ green frame risk");
             } else {
                 convertRawToRGB24(asU16(raw), cpParams, rgbBuf, threads);
                 t1 = std::chrono::steady_clock::now();
@@ -1668,6 +1690,8 @@ void App::exportCurrentClipToProRes() {
             LogToFile(std::string("[ProResExport] Error: ") + m_proResStatus.errorMsg);
             LogProRes(std::string("[ProResExport] Error: ") + m_proResStatus.errorMsg);
         }
+        m_renderPaused.store(false);
+        DBG_INFO("Render resumed");
         m_proResStatus.active.store(false);
         g_useGpuProRes = false;
     });

--- a/src/App/AppLoop.cpp
+++ b/src/App/AppLoop.cpp
@@ -55,6 +55,10 @@ bool App::run() {
 
         appLogicStartTime = steady_clock::now();
         glfwPollEvents();
+        if (m_renderPaused.load()) {
+            std::this_thread::sleep_for(std::chrono::milliseconds(5));
+            continue;
+        }
 
         bool paused = (m_playbackController ? m_playbackController->isPaused() : true);
         bool segment_looped_or_ended = false;

--- a/src/Graphics/GpuYuvConverter.cpp
+++ b/src/Graphics/GpuYuvConverter.cpp
@@ -36,6 +36,12 @@ bool GpuYuvConverter::init(int width, int height) {
     ci.queueFamilyIndex = graphicsFamily;
     ci.flags = VK_COMMAND_POOL_CREATE_RESET_COMMAND_BUFFER_BIT | VK_COMMAND_POOL_CREATE_TRANSIENT_BIT;
     VK_CHECK_RENDERER(vkCreateCommandPool(m_renderer->m_device_p, &ci, nullptr, &m_cmdPool));
+    {
+        std::ostringstream oss;
+        oss << "[GPU] converter init qFamily=" << graphicsFamily
+            << " pool=" << m_cmdPool;
+        DBG_INFO(oss.str());
+    }
 
     VkDescriptorSetLayoutBinding bindings[2]{};
     bindings[0].binding = 0;
@@ -248,8 +254,12 @@ void GpuYuvConverter::cleanup() {
 }
 
 bool GpuYuvConverter::convertAndReadback(const uint16_t* raw, int width, int height,
+                                         int frameIndex,
                                          std::vector<uint16_t>& outPacked) {
-    LogProRes("[GPU] convertAndReadback invoked");
+    std::ostringstream inf;
+    inf << "[GPU] convertAndReadback frame=" << frameIndex
+        << " size=" << width << "x" << height;
+    DBG_TRACE(inf.str());
     VkDeviceSize rawSize = static_cast<VkDeviceSize>(width) * height * sizeof(uint16_t);
     VkDeviceSize outSize = static_cast<VkDeviceSize>(width) * height * 4;
 
@@ -283,6 +293,11 @@ bool GpuYuvConverter::convertAndReadback(const uint16_t* raw, int width, int hei
 
     VkCommandBuffer cmd = VulkanHelpers::beginSingleTimeCommands(m_renderer->m_device_p,
                                                                 m_cmdPool);
+    {
+        std::ostringstream oss;
+        oss << "[GPU] cmdBuf=" << cmd;
+        DBG_TRACE(oss.str());
+    }
 
     VkImageMemoryBarrier bar1{ VK_STRUCTURE_TYPE_IMAGE_MEMORY_BARRIER };
     bar1.oldLayout = VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL;
@@ -429,6 +444,21 @@ bool GpuYuvConverter::convertAndReadback(const uint16_t* raw, int width, int hei
         m_renderer->m_graphicsQueue_p, cmd);
 
     vmaInvalidateAllocation(m_renderer->m_allocator_p, readbackAlloc, 0, outSize);
+    {
+        const uint16_t* dumpPtr = static_cast<const uint16_t*>(rbAllocInfo.pMappedData);
+        std::ostringstream dump;
+        dump << "[GPU] dump:";
+        int words = std::min<int>(16, static_cast<int>(outSize/sizeof(uint16_t)));
+        for (int i=0;i<words;++i) {
+            dump << " 0x" << std::hex << std::setw(4) << std::setfill('0') << dumpPtr[i];
+        }
+        DBG_TRACE(dump.str());
+        if (words>=4) {
+            if (dumpPtr[2]==0 && dumpPtr[3]==0 && (dumpPtr[0]!=dumpPtr[1])) {
+                DBG_WARN("Chroma looks constant – packing order may be wrong");
+            }
+        }
+    }
     outPacked.resize(static_cast<size_t>(outSize / sizeof(uint16_t)));
     memcpy(outPacked.data(), rbAllocInfo.pMappedData, outSize);
     LogProRes("[GPU] readback complete");

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,0 +1,6 @@
+add_executable(UnitTests GpuYuvConverterTest.cpp)
+find_package(GTest REQUIRED)
+target_link_libraries(UnitTests PRIVATE ${GTEST_BOTH_LIBRARIES} pthread
+    motioncam_decoder imgui glm Vulkan::Vulkan)
+
+add_test(NAME UnitTests COMMAND UnitTests)

--- a/tests/GpuYuvConverterTest.cpp
+++ b/tests/GpuYuvConverterTest.cpp
@@ -1,0 +1,51 @@
+#include <gtest/gtest.h>
+#include "Graphics/GpuYuvConverter.h"
+#include "Graphics/Renderer_VK.h"
+#include <vulkan/vulkan.h>
+
+// Minimal Vulkan setup for test
+struct MinimalVk {
+    VkInstance instance{VK_NULL_HANDLE};
+    VkPhysicalDevice phys{VK_NULL_HANDLE};
+    VkDevice device{VK_NULL_HANDLE};
+    VmaAllocator alloc{VK_NULL_HANDLE};
+    VkQueue queue{VK_NULL_HANDLE};
+    VkCommandPool pool{VK_NULL_HANDLE};
+    bool init(){
+        VkApplicationInfo app{VK_STRUCTURE_TYPE_APPLICATION_INFO};
+        app.apiVersion = VK_API_VERSION_1_1;
+        VkInstanceCreateInfo ci{VK_STRUCTURE_TYPE_INSTANCE_CREATE_INFO};
+        ci.pApplicationInfo=&app;
+        if(vkCreateInstance(&ci,nullptr,&instance)!=VK_SUCCESS) return false;
+        uint32_t count=0; vkEnumeratePhysicalDevices(instance,&count,nullptr);
+        if(count==0) return false; std::vector<VkPhysicalDevice> devs(count); vkEnumeratePhysicalDevices(instance,&count,devs.data());
+        phys=devs[0];
+        uint32_t qCount=0; vkGetPhysicalDeviceQueueFamilyProperties(phys,&qCount,nullptr);
+        std::vector<VkQueueFamilyProperties> qProps(qCount); vkGetPhysicalDeviceQueueFamilyProperties(phys,&qCount,qProps.data());
+        uint32_t qFamily=0; for(uint32_t i=0;i<qCount;++i){ if(qProps[i].queueFlags&VK_QUEUE_GRAPHICS_BIT){qFamily=i;break;}}
+        float pr=1.f; VkDeviceQueueCreateInfo qci{VK_STRUCTURE_TYPE_DEVICE_QUEUE_CREATE_INFO};
+        qci.queueFamilyIndex=qFamily; qci.queueCount=1; qci.pQueuePriorities=&pr;
+        VkDeviceCreateInfo dci{VK_STRUCTURE_TYPE_DEVICE_CREATE_INFO}; dci.queueCreateInfoCount=1; dci.pQueueCreateInfos=&qci;
+        if(vkCreateDevice(phys,&dci,nullptr,&device)!=VK_SUCCESS) return false;
+        vkGetDeviceQueue(device,qFamily,0,&queue);
+        VkCommandPoolCreateInfo pci{VK_STRUCTURE_TYPE_COMMAND_POOL_CREATE_INFO};
+        pci.queueFamilyIndex=qFamily; pci.flags=VK_COMMAND_POOL_CREATE_RESET_COMMAND_BUFFER_BIT;
+        if(vkCreateCommandPool(device,&pci,nullptr,&pool)!=VK_SUCCESS) return false;
+        VmaAllocatorCreateInfo ai{}; ai.vulkanApiVersion=VK_API_VERSION_1_1; ai.physicalDevice=phys; ai.device=device; ai.instance=instance; VmaVulkanFunctions funcs{}; funcs.vkGetInstanceProcAddr=vkGetInstanceProcAddr; funcs.vkGetDeviceProcAddr=vkGetDeviceProcAddr; ai.pVulkanFunctions=&funcs;
+        if(vmaCreateAllocator(&ai,&alloc)!=VK_SUCCESS) return false;
+        return true;
+    }
+    void cleanup(){ if(alloc) vmaDestroyAllocator(alloc); if(pool) vkDestroyCommandPool(device,pool,nullptr); if(device) vkDestroyDevice(device,nullptr); if(instance) vkDestroyInstance(instance,nullptr); }
+};
+
+TEST(GpuYuvConverterTest, SimpleConversion){
+    MinimalVk vk; if(!vk.init()) GTEST_SKIP();
+    Renderer_VK renderer(vk.phys,vk.device,vk.alloc,vk.queue,vk.pool);
+    GpuYuvConverter conv(&renderer);
+    ASSERT_TRUE(conv.init(2,2));
+    uint16_t pattern[4]={0,65535,65535,0};
+    std::vector<uint16_t> out; conv.convertAndReadback(pattern,2,2,0,out);
+    double sumU=0,sumV=0; for(size_t i=0;i<out.size();i+=4){ sumU+=out[i+1]; sumV+=out[i+3]; }
+    ASSERT_NE(sumU/2.0,0); ASSERT_NE(sumV/2.0,0);
+    conv.cleanup(); vk.cleanup();
+}


### PR DESCRIPTION
## Summary
- add debug macros in DebugLog
- pause render thread during export and resume after
- add logging for GPU converter initialization and operations
- validate YUV packing order and per-frame stats during export
- support frame index parameter for converter
- add basic GTest for GPU path

## Testing
- `cmake -S . -B build` *(fails: Could not find a package configuration file provided by "FFMPEG"...)*

------
https://chatgpt.com/codex/tasks/task_e_686e6a4778bc8327b90f5e1e518418c1