### PR TITLE
Fix GPU export order & add diagnostics

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -173,6 +173,9 @@ message(STATUS "Application sources for executable: ${APP_SOURCES}")
 add_executable(${PROJECT_NAME} WIN32 "")
 target_sources(${PROJECT_NAME} PRIVATE ${APP_SOURCES})
 
+enable_testing()
+add_subdirectory(tests)
+
 if(WIN32 AND EXISTS "${APP_ROOT_DIR}/icon.rc")
     target_sources(${PROJECT_NAME} PRIVATE "${APP_ROOT_DIR}/icon.rc")
     message(STATUS "Added Windows icon resource: ${APP_ROOT_DIR}/icon.rc")

--- a/include/App/App.h
+++ b/include/App/App.h
@@ -226,6 +226,7 @@ private:
         int totalFrames{ 0 };
         std::string errorMsg;
     } m_proResStatus;
+    std::atomic<bool> m_renderPaused{ false };
     std::atomic<bool> m_showExportProgressPopup{ false };
     std::thread m_proResThread;
 #endif

--- a/include/Graphics/GpuYuvConverter.h
+++ b/include/Graphics/GpuYuvConverter.h
@@ -17,7 +17,8 @@ public:
     void cleanup();
 
     bool convertAndReadback(const uint16_t* raw, int width, int height,
-                            std::vector<uint16_t>& outPacked);
+                            std::vector<uint16_t>& outPacked,
+                            int frameIndex = -1);
 private:
     Renderer_VK* m_renderer;
 

--- a/include/Utils/DebugLog.h
+++ b/include/Utils/DebugLog.h
@@ -14,4 +14,18 @@ void LogFFmpegStatus();
 // On other platforms it falls back to the application base path.
 std::string getLogDirectory();
 
+// Convenience macros for unified logging with severity tags
+#ifndef DBG_INFO
+#   define DBG_INFO(msg)  do { LogToFile(std::string("[INFO] ") + (msg)); LogProRes(std::string("[INFO] ") + (msg)); } while(0)
+#endif
+#ifndef DBG_WARN
+#   define DBG_WARN(msg)  do { LogToFile(std::string("[WARN] ") + (msg)); LogProRes(std::string("[WARN] ") + (msg)); } while(0)
+#endif
+#ifndef DBG_ERROR
+#   define DBG_ERROR(msg) do { LogToFile(std::string("[ERROR] ") + (msg)); LogProRes(std::string("[ERROR] ") + (msg)); } while(0)
+#endif
+#ifndef DBG_TRACE
+#   define DBG_TRACE(msg) do { LogToFile(std::string("[TRACE] ") + (msg)); LogProRes(std::string("[TRACE] ") + (msg)); } while(0)
+#endif
+
 #endif // DEBUG_LOG_H

--- a/shaders/raw_to_yuv422.comp
+++ b/shaders/raw_to_yuv422.comp
@@ -26,5 +26,6 @@ void main() {
     uint y1 = (x1 < pc.width) ? (readU16(x1, y) >> 6) : y0;
     uint u = 512u;
     uint v = 512u;
+    // Store order: Y0, U, Y1, V (packed as R,G,B,A)
     imageStore(yuvImage, gid, uvec4(y0, u, y1, v));
 }

--- a/src/App/AppIO.cpp
+++ b/src/App/AppIO.cpp
@@ -35,6 +35,9 @@
 #endif
 #include "Utils/ColorPipelineCPU.h"
 
+// Enable verbose GPU export diagnostics
+#define MC_GPU_EXPORT_DEBUG 1
+
 namespace fs = std::filesystem;
 
 #ifdef ENABLE_PRORES_EXPORT
@@ -1215,6 +1218,10 @@ void App::exportCurrentClipToProRes() {
         LogProRes("[ProResExport] Thread started");
         LogProRes(std::string("[ProResExport] MODE = ") + (useGpu ? "GPU (Vulkan hw_frames)" : "CPU (swscale)"));
 
+        m_renderPaused.store(true);
+        vkDeviceWaitIdle(m_device);
+        DBG_INFO("Render paused for export…");
+
         auto* dec = m_decoderWrapper_ptr->getDecoder();
         const auto& frames = dec->getFrames();
         LogProRes(std::string("[ProResExport] Frames to export: ") + std::to_string(frames.size()));
@@ -1478,35 +1485,57 @@ void App::exportCurrentClipToProRes() {
             auto t1 = std::chrono::steady_clock::now();
             readUS += std::chrono::duration_cast<std::chrono::microseconds>(t1 - t0).count();
 
+#if MC_GPU_EXPORT_DEBUG
+            DBG_INFO(std::string("[Export] frame ") + std::to_string(idx) + " \xE2\x86\x92 AVFrame planes");
+#endif
+
             t0 = t1;
             if (gpuActive) {
-                converter.convertAndReadback(asU16(raw), width, height, gpuBuf);
+                converter.convertAndReadback(asU16(raw), width, height, gpuBuf, static_cast<int>(idx));
                 t1 = std::chrono::steady_clock::now();
                 rgbUS += std::chrono::duration_cast<std::chrono::microseconds>(t1 - t0).count();
                 if (av_frame_make_writable(frame) < 0) { m_proResStatus.errorMsg = "frame not writable"; break; }
                 uint16_t* yPlane = reinterpret_cast<uint16_t*>(frame->data[0]);
                 uint16_t* uPlane = reinterpret_cast<uint16_t*>(frame->data[1]);
                 uint16_t* vPlane = reinterpret_cast<uint16_t*>(frame->data[2]);
+                uint64_t sumY = 0, sumU = 0, sumV = 0;
                 for (int y=0; y<height; ++y) {
                     for (int x=0; x<width/2; ++x) {
                         size_t srcIdx = static_cast<size_t>(y) * (width/2) * 4 + x*4;
-                        uint16_t y0 = gpuBuf[srcIdx] >> 6;
-                        uint16_t y1 = gpuBuf[srcIdx+1] >> 6; // Y1 directly
-                        uint16_t u  = gpuBuf[srcIdx+2] >> 6;
-                        uint16_t v  = gpuBuf[srcIdx+3] >> 6;
+                        uint16_t y0 = static_cast<uint16_t>((gpuBuf[srcIdx] * 1023u + 32767u) / 65535u);
+                        uint16_t u  = static_cast<uint16_t>((gpuBuf[srcIdx+1] * 1023u + 32767u) / 65535u);
+                        uint16_t y1 = static_cast<uint16_t>((gpuBuf[srcIdx+2] * 1023u + 32767u) / 65535u);
+                        uint16_t v  = static_cast<uint16_t>((gpuBuf[srcIdx+3] * 1023u + 32767u) / 65535u);
                         yPlane[y*frame->linesize[0]/2 + 2*x] = y0;
                         yPlane[y*frame->linesize[0]/2 + 2*x+1] = y1;
                         uPlane[y*frame->linesize[1]/2 + x] = u;
                         vPlane[y*frame->linesize[2]/2 + x] = v;
+#if MC_GPU_EXPORT_DEBUG
+                        sumY += y0 + y1;
+                        sumU += u;
+                        sumV += v;
+                        if (idx==0 && y==0 && x==0) {
+                            std::ostringstream dbg;
+                            dbg << "[GPU] first samples Y0=" << y0 << " Y1=" << y1
+                                << " U=" << u << " V=" << v;
+                            DBG_TRACE(dbg.str());
+                        }
+#endif
                     }
                 }
-                if (idx == 0) {
-                    std::ostringstream dbg;
-                    dbg << "[GPU] AVFrame first: "
-                        << yPlane[0] << "," << yPlane[1] << "," << uPlane[0]
-                        << "," << vPlane[0];
-                    LogProRes(dbg.str());
+#if MC_GPU_EXPORT_DEBUG
+                double avgY = static_cast<double>(sumY) / (width * height);
+                double avgU = static_cast<double>(sumU) / (width * height / 2);
+                double avgV = static_cast<double>(sumV) / (width * height / 2);
+                {
+                    std::ostringstream stats;
+                    stats << "[GPU] avgY=" << avgY << " avgU=" << avgU << " avgV=" << avgV;
+                    DBG_TRACE(stats.str());
                 }
+                if (std::abs(avgU - 512.0) + std::abs(avgV - 512.0) < 5.0) {
+                    DBG_WARN("Chroma is ~zero ⇒ green frame risk");
+                }
+#endif
             } else {
                 convertRawToRGB24(asU16(raw), cpParams, rgbBuf, threads);
                 t1 = std::chrono::steady_clock::now();
@@ -1668,6 +1697,8 @@ void App::exportCurrentClipToProRes() {
             LogToFile(std::string("[ProResExport] Error: ") + m_proResStatus.errorMsg);
             LogProRes(std::string("[ProResExport] Error: ") + m_proResStatus.errorMsg);
         }
+        DBG_INFO("Render resumed");
+        m_renderPaused.store(false);
         m_proResStatus.active.store(false);
         g_useGpuProRes = false;
     });

--- a/src/Graphics/GpuYuvConverter.cpp
+++ b/src/Graphics/GpuYuvConverter.cpp
@@ -6,6 +6,7 @@
 #include <vector>
 #include <filesystem>
 #include <chrono>
+#include <sstream>
 
 extern std::string g_AppBasePath;
 
@@ -36,6 +37,12 @@ bool GpuYuvConverter::init(int width, int height) {
     ci.queueFamilyIndex = graphicsFamily;
     ci.flags = VK_COMMAND_POOL_CREATE_RESET_COMMAND_BUFFER_BIT | VK_COMMAND_POOL_CREATE_TRANSIENT_BIT;
     VK_CHECK_RENDERER(vkCreateCommandPool(m_renderer->m_device_p, &ci, nullptr, &m_cmdPool));
+    {
+        std::ostringstream info;
+        info << "[GpuYuvConverter] queueFamily=" << graphicsFamily
+             << " cmdPool=" << std::hex << m_cmdPool;
+        DBG_INFO(info.str());
+    }
 
     VkDescriptorSetLayoutBinding bindings[2]{};
     bindings[0].binding = 0;
@@ -248,8 +255,12 @@ void GpuYuvConverter::cleanup() {
 }
 
 bool GpuYuvConverter::convertAndReadback(const uint16_t* raw, int width, int height,
-                                         std::vector<uint16_t>& outPacked) {
-    LogProRes("[GPU] convertAndReadback invoked");
+                                         std::vector<uint16_t>& outPacked,
+                                         int frameIndex) {
+    std::ostringstream trace;
+    trace << "[GPU] convertAndReadback frame=" << frameIndex
+          << " size=" << width << "x" << height;
+    DBG_TRACE(trace.str());
     VkDeviceSize rawSize = static_cast<VkDeviceSize>(width) * height * sizeof(uint16_t);
     VkDeviceSize outSize = static_cast<VkDeviceSize>(width) * height * 4;
 
@@ -283,6 +294,7 @@ bool GpuYuvConverter::convertAndReadback(const uint16_t* raw, int width, int hei
 
     VkCommandBuffer cmd = VulkanHelpers::beginSingleTimeCommands(m_renderer->m_device_p,
                                                                 m_cmdPool);
+    DBG_TRACE(std::string("cmdBuf=") + std::to_string((uint64_t)cmd));
 
     VkImageMemoryBarrier bar1{ VK_STRUCTURE_TYPE_IMAGE_MEMORY_BARRIER };
     bar1.oldLayout = VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL;
@@ -431,6 +443,18 @@ bool GpuYuvConverter::convertAndReadback(const uint16_t* raw, int width, int hei
     vmaInvalidateAllocation(m_renderer->m_allocator_p, readbackAlloc, 0, outSize);
     outPacked.resize(static_cast<size_t>(outSize / sizeof(uint16_t)));
     memcpy(outPacked.data(), rbAllocInfo.pMappedData, outSize);
+
+    uint16_t* dbgData = reinterpret_cast<uint16_t*>(rbAllocInfo.pMappedData);
+    std::ostringstream dump;
+    dump << "[GPU] rb16:";
+    for(int i=0;i<16 && (i*2)<outSize;i++){
+        dump << ' ' << std::hex << std::setw(4) << std::setfill('0') << dbgData[i];
+    }
+    DBG_TRACE(dump.str());
+    if (std::abs(int(dbgData[1])) < 2 && std::abs(int(dbgData[3])) < 2 &&
+        (dbgData[0] != dbgData[2])) {
+        DBG_WARN("Chroma looks constant – packing order may be wrong");
+    }
     LogProRes("[GPU] readback complete");
 
     vmaDestroyBuffer(m_renderer->m_allocator_p, stagingBuf, stagingAlloc);

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,0 +1,4 @@
+add_executable(GpuYuvConverterTest GpuYuvConverterTest.cpp)
+find_package(GTest CONFIG REQUIRED)
+target_link_libraries(GpuYuvConverterTest PRIVATE GTest::gtest_main ${PROJECT_NAME})
+add_test(NAME GpuYuvConverterTest COMMAND GpuYuvConverterTest)

--- a/tests/GpuYuvConverterTest.cpp
+++ b/tests/GpuYuvConverterTest.cpp
@@ -1,0 +1,9 @@
+#include <gtest/gtest.h>
+#include "Graphics/GpuYuvConverter.h"
+#include "Graphics/Renderer_VK.h"
+#include "Utils/DebugLog.h"
+
+TEST(GpuYuvConverter, DISABLED_Simple2x2)
+{
+    GTEST_SKIP() << "Vulkan context not available in test environment";
+}


### PR DESCRIPTION
## Summary
- add unified debug macros
- create render pause flag and guard around GPU export
- correct YUV packing and add per-frame diagnostics
- log command pool info and readback bytes in GPU converter
- document shader output order
- stub out a gtest target

## Testing
- `cmake -S . -B build` *(fails: could not find FFMPEG)*

------
https://chatgpt.com/codex/tasks/task_e_686e6a4778bc8327b90f5e1e518418c1