### PR TITLE
Fix GPU export and add diagnostics

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -320,3 +320,6 @@ message(STATUS "  Target Executable: MotionCam Player")
 message(STATUS "  Output Directory:  ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${CMAKE_CFG_INTDIR}")
 message(STATUS "  Output Executable: ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${CMAKE_CFG_INTDIR}/MotionCam Player${CMAKE_EXECUTABLE_SUFFIX}")
 message(STATUS "---------------------------------------------------------------------")
+
+enable_testing()
+add_subdirectory(tests)

--- a/include/App/App.h
+++ b/include/App/App.h
@@ -179,6 +179,7 @@ private:
     std::thread m_ioThread;
     std::thread m_decodeThread;
     std::atomic<bool> m_threadsShouldStop{ false };
+    std::atomic<bool> m_renderPaused{ false };
 
     std::string m_ioThreadCurrentFilePath;
     std::mutex m_ioThreadFileMutex;

--- a/include/Graphics/GpuYuvConverter.h
+++ b/include/Graphics/GpuYuvConverter.h
@@ -17,7 +17,7 @@ public:
     void cleanup();
 
     bool convertAndReadback(const uint16_t* raw, int width, int height,
-                            std::vector<uint16_t>& outPacked);
+                            std::vector<uint16_t>& outPacked, int frameIndex);
 private:
     Renderer_VK* m_renderer;
 

--- a/include/Utils/DebugLog.h
+++ b/include/Utils/DebugLog.h
@@ -14,4 +14,26 @@ void LogFFmpegStatus();
 // On other platforms it falls back to the application base path.
 std::string getLogDirectory();
 
+// Simple logging convenience macros used throughout the player. These prepend
+// a severity tag and send the message to both log files.
+#define DBG_INFO(msg)  do { \ 
+    LogToFile(std::string("[INFO] ") + (msg)); \
+    LogProRes(std::string("[INFO] ") + (msg)); \
+} while(0)
+
+#define DBG_WARN(msg)  do { \
+    LogToFile(std::string("[WARN] ") + (msg)); \
+    LogProRes(std::string("[WARN] ") + (msg)); \
+} while(0)
+
+#define DBG_ERROR(msg) do { \
+    LogToFile(std::string("[ERROR] ") + (msg)); \
+    LogProRes(std::string("[ERROR] ") + (msg)); \
+} while(0)
+
+#define DBG_TRACE(msg) do { \
+    LogToFile(std::string("[TRACE] ") + (msg)); \
+    LogProRes(std::string("[TRACE] ") + (msg)); \
+} while(0)
+
 #endif // DEBUG_LOG_H

--- a/shaders/raw_to_yuv422.comp
+++ b/shaders/raw_to_yuv422.comp
@@ -26,5 +26,6 @@ void main() {
     uint y1 = (x1 < pc.width) ? (readU16(x1, y) >> 6) : y0;
     uint u = 512u;
     uint v = 512u;
+    // Store as {Y0, U, Y1, V} so CPU must read back in same order
     imageStore(yuvImage, gid, uvec4(y0, u, y1, v));
 }

--- a/src/App/AppIO.cpp
+++ b/src/App/AppIO.cpp
@@ -35,11 +35,17 @@
 #endif
 #include "Utils/ColorPipelineCPU.h"
 
+#define MC_GPU_EXPORT_DEBUG 1
+
 namespace fs = std::filesystem;
 
 #ifdef ENABLE_PRORES_EXPORT
 static bool g_useGpuProRes = false;
 #endif
+
+static inline uint16_t scale16to10(uint16_t v) {
+    return static_cast<uint16_t>((static_cast<uint32_t>(v) * 1023 + 32767) / 65535);
+}
 namespace {
     bool writeDngInternal(
         const std::string& outputPath,
@@ -1252,6 +1258,19 @@ void App::exportCurrentClipToProRes() {
             }
         }
 
+        struct PauseGuard {
+            App* app;
+            explicit PauseGuard(App* a) : app(a) {
+                app->m_renderPaused.store(true);
+                DBG_INFO("Render paused for export...");
+                vkDeviceWaitIdle(app->m_device);
+            }
+            ~PauseGuard() {
+                app->m_renderPaused.store(false);
+                DBG_INFO("Render resumed");
+            }
+        } guard(this);
+
         int64_t frameDurationNs = 0;
         if (frames.size() >= 2) {
             frameDurationNs = frames[1] - frames[0];
@@ -1480,33 +1499,53 @@ void App::exportCurrentClipToProRes() {
 
             t0 = t1;
             if (gpuActive) {
-                converter.convertAndReadback(asU16(raw), width, height, gpuBuf);
+                converter.convertAndReadback(asU16(raw), width, height, gpuBuf, static_cast<int>(idx));
                 t1 = std::chrono::steady_clock::now();
                 rgbUS += std::chrono::duration_cast<std::chrono::microseconds>(t1 - t0).count();
                 if (av_frame_make_writable(frame) < 0) { m_proResStatus.errorMsg = "frame not writable"; break; }
                 uint16_t* yPlane = reinterpret_cast<uint16_t*>(frame->data[0]);
                 uint16_t* uPlane = reinterpret_cast<uint16_t*>(frame->data[1]);
                 uint16_t* vPlane = reinterpret_cast<uint16_t*>(frame->data[2]);
+#if MC_GPU_EXPORT_DEBUG
+                DBG_INFO(std::string("[Export] frame ") + std::to_string(idx) + " -> AVFrame planes");
+                uint64_t sumY = 0, sumU = 0, sumV = 0;
+#endif
                 for (int y=0; y<height; ++y) {
                     for (int x=0; x<width/2; ++x) {
                         size_t srcIdx = static_cast<size_t>(y) * (width/2) * 4 + x*4;
-                        uint16_t y0 = gpuBuf[srcIdx] >> 6;
-                        uint16_t y1 = gpuBuf[srcIdx+1] >> 6; // Y1 directly
-                        uint16_t u  = gpuBuf[srcIdx+2] >> 6;
-                        uint16_t v  = gpuBuf[srcIdx+3] >> 6;
+                        uint16_t y0 = scale16to10(gpuBuf[srcIdx]);
+                        uint16_t u  = scale16to10(gpuBuf[srcIdx+1]);
+                        uint16_t y1 = scale16to10(gpuBuf[srcIdx+2]);
+                        uint16_t v  = scale16to10(gpuBuf[srcIdx+3]);
                         yPlane[y*frame->linesize[0]/2 + 2*x] = y0;
                         yPlane[y*frame->linesize[0]/2 + 2*x+1] = y1;
                         uPlane[y*frame->linesize[1]/2 + x] = u;
                         vPlane[y*frame->linesize[2]/2 + x] = v;
+#if MC_GPU_EXPORT_DEBUG
+                        sumY += y0 + y1;
+                        sumU += u;
+                        sumV += v;
+                        if (y==0 && x==0) {
+                            std::ostringstream s;
+                            s << "[Export] first samples: Y0=" << y0 << " Y1=" << y1
+                              << " U=" << u << " V=" << v;
+                            DBG_INFO(s.str());
+                        }
+#endif
                     }
                 }
-                if (idx == 0) {
-                    std::ostringstream dbg;
-                    dbg << "[GPU] AVFrame first: "
-                        << yPlane[0] << "," << yPlane[1] << "," << uPlane[0]
-                        << "," << vPlane[0];
-                    LogProRes(dbg.str());
+#if MC_GPU_EXPORT_DEBUG
+                double avgY = static_cast<double>(sumY) / (width * height);
+                double avgU = static_cast<double>(sumU) / ((width/2) * height);
+                double avgV = static_cast<double>(sumV) / ((width/2) * height);
+                {
+                    std::ostringstream ss;
+                    ss << "[Export] stats Y=" << avgY << " U=" << avgU << " V=" << avgV;
+                    DBG_TRACE(ss.str());
+                    if (std::abs(avgU-512.0) + std::abs(avgV-512.0) < 5.0)
+                        DBG_WARN("Chroma is ~zero => green frame risk");
                 }
+#endif
             } else {
                 convertRawToRGB24(asU16(raw), cpParams, rgbBuf, threads);
                 t1 = std::chrono::steady_clock::now();
@@ -1518,6 +1557,40 @@ void App::exportCurrentClipToProRes() {
                 sws_scale(sws, srcSlices, srcStride, 0, height, frame->data, frame->linesize);
                 t1 = std::chrono::steady_clock::now();
                 scaleUS += std::chrono::duration_cast<std::chrono::microseconds>(t1 - t0).count();
+#if MC_GPU_EXPORT_DEBUG
+                DBG_INFO(std::string("[Export] frame ") + std::to_string(idx) + " -> AVFrame planes");
+                uint64_t sumY = 0, sumU = 0, sumV = 0;
+                uint16_t* yPlane = reinterpret_cast<uint16_t*>(frame->data[0]);
+                uint16_t* uPlane = reinterpret_cast<uint16_t*>(frame->data[1]);
+                uint16_t* vPlane = reinterpret_cast<uint16_t*>(frame->data[2]);
+                for (int y=0; y<height; ++y) {
+                    for (int x=0; x<width/2; ++x) {
+                        uint16_t y0 = yPlane[y*frame->linesize[0]/2 + 2*x];
+                        uint16_t y1 = yPlane[y*frame->linesize[0]/2 + 2*x+1];
+                        uint16_t u = uPlane[y*frame->linesize[1]/2 + x];
+                        uint16_t v = vPlane[y*frame->linesize[2]/2 + x];
+                        sumY += y0 + y1;
+                        sumU += u;
+                        sumV += v;
+                        if (y==0 && x==0) {
+                            std::ostringstream s;
+                            s << "[Export] first samples: Y0=" << y0 << " Y1=" << y1
+                              << " U=" << u << " V=" << v;
+                            DBG_INFO(s.str());
+                        }
+                    }
+                }
+                double avgY = static_cast<double>(sumY) / (width * height);
+                double avgU = static_cast<double>(sumU) / ((width/2) * height);
+                double avgV = static_cast<double>(sumV) / ((width/2) * height);
+                {
+                    std::ostringstream ss;
+                    ss << "[Export] stats Y=" << avgY << " U=" << avgU << " V=" << avgV;
+                    DBG_TRACE(ss.str());
+                    if (std::abs(avgU-512.0) + std::abs(avgV-512.0) < 5.0)
+                        DBG_WARN("Chroma is ~zero => green frame risk");
+                }
+#endif
             }
 
             frame->pts = pts;

--- a/src/Graphics/GpuYuvConverter.cpp
+++ b/src/Graphics/GpuYuvConverter.cpp
@@ -6,6 +6,8 @@
 #include <vector>
 #include <filesystem>
 #include <chrono>
+#include <sstream>
+#include <iomanip>
 
 extern std::string g_AppBasePath;
 
@@ -36,6 +38,12 @@ bool GpuYuvConverter::init(int width, int height) {
     ci.queueFamilyIndex = graphicsFamily;
     ci.flags = VK_COMMAND_POOL_CREATE_RESET_COMMAND_BUFFER_BIT | VK_COMMAND_POOL_CREATE_TRANSIENT_BIT;
     VK_CHECK_RENDERER(vkCreateCommandPool(m_renderer->m_device_p, &ci, nullptr, &m_cmdPool));
+    {
+        std::ostringstream oss;
+        oss << "[GPU] Converter init: queueFamily=" << graphicsFamily
+            << " cmdPool=" << static_cast<uint64_t>(m_cmdPool);
+        DBG_INFO(oss.str());
+    }
 
     VkDescriptorSetLayoutBinding bindings[2]{};
     bindings[0].binding = 0;
@@ -248,8 +256,11 @@ void GpuYuvConverter::cleanup() {
 }
 
 bool GpuYuvConverter::convertAndReadback(const uint16_t* raw, int width, int height,
-                                         std::vector<uint16_t>& outPacked) {
-    LogProRes("[GPU] convertAndReadback invoked");
+                                         std::vector<uint16_t>& outPacked, int frameIndex) {
+    std::ostringstream startMsg;
+    startMsg << "[GPU] convertAndReadback frame=" << frameIndex
+             << " size=" << width << "x" << height;
+    DBG_TRACE(startMsg.str());
     VkDeviceSize rawSize = static_cast<VkDeviceSize>(width) * height * sizeof(uint16_t);
     VkDeviceSize outSize = static_cast<VkDeviceSize>(width) * height * 4;
 
@@ -431,7 +442,18 @@ bool GpuYuvConverter::convertAndReadback(const uint16_t* raw, int width, int hei
     vmaInvalidateAllocation(m_renderer->m_allocator_p, readbackAlloc, 0, outSize);
     outPacked.resize(static_cast<size_t>(outSize / sizeof(uint16_t)));
     memcpy(outPacked.data(), rbAllocInfo.pMappedData, outSize);
-    LogProRes("[GPU] readback complete");
+    {
+        uint16_t* words = static_cast<uint16_t*>(rbAllocInfo.pMappedData);
+        std::ostringstream dump;
+        dump << "[GPU] rb first16:";
+        for (int i=0; i<16 && static_cast<size_t>(i*2)<outSize/sizeof(uint16_t); ++i) {
+            dump << ' ' << std::hex << std::uppercase << std::setw(4) << std::setfill('0') << words[i];
+        }
+        DBG_TRACE(dump.str());
+        if (words[1] < 4 && words[3] < 4 && (words[0] != words[2]))
+            DBG_WARN("Chroma looks constant – packing order may be wrong");
+    }
+    DBG_TRACE("[GPU] readback complete");
 
     vmaDestroyBuffer(m_renderer->m_allocator_p, stagingBuf, stagingAlloc);
     vmaDestroyBuffer(m_renderer->m_allocator_p, readbackBuf, readbackAlloc);

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,0 +1,5 @@
+add_executable(gpu_converter_test gpu_converter_test.cpp)
+target_include_directories(gpu_converter_test PRIVATE ${PROJECT_SOURCE_DIR}/include)
+find_package(GTest CONFIG REQUIRED)
+target_link_libraries(gpu_converter_test PRIVATE GTest::gtest_main)
+add_test(NAME gpu_converter_test COMMAND gpu_converter_test)

--- a/tests/gpu_converter_test.cpp
+++ b/tests/gpu_converter_test.cpp
@@ -1,0 +1,7 @@
+#include <gtest/gtest.h>
+#include "Graphics/GpuYuvConverter.h"
+#include "Graphics/Renderer_VK.h"
+
+TEST(GpuYuvConverter, AverageChromaNonZero) {
+    GTEST_SKIP() << "Vulkan environment not available in test harness";
+}


### PR DESCRIPTION
## Summary
- add DebugLog macros for info/warn/error/trace
- fix YUV plane order and add per-frame diagnostics in `AppIO`
- pause render thread during export with RAII guard
- report queue family and command pool in `GpuYuvConverter`
- dump readback buffer for debugging
- document component order in compute shader
- add skeleton gtest target

## Testing
- `cmake ..` *(fails: Could not find FFMPEG)*

------
https://chatgpt.com/codex/tasks/task_e_686e6a4778bc8327b90f5e1e518418c1