### PR TITLE
Fix YUV shader outputs for ProRes export

### DIFF
--- a/shaders/raw_to_yuv422.comp
+++ b/shaders/raw_to_yuv422.comp
@@ -22,9 +22,22 @@ void main() {
     int y = gid.y;
     if (x0 >= pc.width || y >= pc.height) return;
     int x1 = x0 + 1;
-    uint y0 = readU16(x0, y) >> 6;
-    uint y1 = (x1 < pc.width) ? (readU16(x1, y) >> 6) : y0;
-    uint u = 512u;
-    uint v = 512u;
+    uint raw0 = readU16(x0, y);
+    uint raw1 = (x1 < pc.width) ? readU16(x1, y) : raw0;
+    uint raw2 = readU16(x0, y + 1);
+    uint raw3 = (x1 < pc.width) ? readU16(x1, y + 1) : raw2;
+
+    uint y0 = raw0 >> 6;
+    uint y1 = raw1 >> 6;
+
+    float r = float(raw3) / 65535.0;
+    float g = float(raw1 + raw2) * 0.5 / 65535.0;
+    float b = float(raw0) / 65535.0;
+    float lum = 0.2126 * r + 0.7152 * g + 0.0722 * b;
+    float uNorm = clamp((b - lum) / (2.0 * (1.0 - 0.0722)) + 0.5, 0.0, 1.0);
+    float vNorm = clamp((r - lum) / (2.0 * (1.0 - 0.2126)) + 0.5, 0.0, 1.0);
+    uint u = uint(round(uNorm * 1023.0));
+    uint v = uint(round(vNorm * 1023.0));
+
     imageStore(yuvImage, gid, uvec4(y0, u, y1, v));
 }

--- a/src/App/AppIO.cpp
+++ b/src/App/AppIO.cpp
@@ -1490,10 +1490,10 @@ void App::exportCurrentClipToProRes() {
                 for (int y=0; y<height; ++y) {
                     for (int x=0; x<width/2; ++x) {
                         size_t srcIdx = static_cast<size_t>(y) * (width/2) * 4 + x*4;
-                        uint16_t y0 = gpuBuf[srcIdx] >> 6;
-                        uint16_t y1 = gpuBuf[srcIdx+1] >> 6; // Y1 directly
-                        uint16_t u  = gpuBuf[srcIdx+2] >> 6;
-                        uint16_t v  = gpuBuf[srcIdx+3] >> 6;
+                        uint16_t y0 = gpuBuf[srcIdx];
+                        uint16_t y1 = gpuBuf[srcIdx+1]; // Y1 directly
+                        uint16_t u  = gpuBuf[srcIdx+2];
+                        uint16_t v  = gpuBuf[srcIdx+3];
                         yPlane[y*frame->linesize[0]/2 + 2*x] = y0;
                         yPlane[y*frame->linesize[0]/2 + 2*x+1] = y1;
                         uPlane[y*frame->linesize[1]/2 + x] = u;


### PR DESCRIPTION
## Summary
- compute real chroma values in `raw_to_yuv422.comp`
- stop double-shifting GPU ProRes output values

## Testing
- `cmake -S . -B build` *(fails: Could not find FFMPEG)*

------
https://chatgpt.com/codex/tasks/task_e_686f4d9d79a08327a1b213c8ebf42be1