### PR TITLE
Fix GPU ProRes export green frames

### DIFF
--- a/shaders/raw_to_yuv422.comp
+++ b/shaders/raw_to_yuv422.comp
@@ -22,9 +22,48 @@ void main() {
     int y = gid.y;
     if (x0 >= pc.width || y >= pc.height) return;
     int x1 = x0 + 1;
-    uint y0 = readU16(x0, y) >> 6;
-    uint y1 = (x1 < pc.width) ? (readU16(x1, y) >> 6) : y0;
-    uint u = 512u;
-    uint v = 512u;
+
+    int baseY = (y & ~1); // even row for 2x2 block
+    int nextY = baseY + 1;
+    uint p00 = readU16(x0, baseY);
+    uint p01 = (x1 < pc.width) ? readU16(x1, baseY) : p00;
+    uint p10 = (nextY < pc.height) ? readU16(x0, nextY) : p00;
+    uint p11 = (x1 < pc.width && nextY < pc.height) ? readU16(x1, nextY) : p10;
+
+    float r0, g0, b0;
+    float r1, g1, b1;
+    if ((y & 1) == 0) {
+        // top row of BGGR 2x2 block: B,G/G,R
+        r0 = float(p11 >> 6);
+        g0 = float((p01 >> 6) + (p10 >> 6)) * 0.5;
+        b0 = float(p00 >> 6);
+
+        r1 = float(p11 >> 6);
+        g1 = float(p01 >> 6);
+        b1 = float(p00 >> 6);
+    } else {
+        // bottom row of BGGR block: G,R/B,G
+        r0 = float(p11 >> 6);
+        g0 = float(p10 >> 6);
+        b0 = float(p00 >> 6);
+
+        r1 = float(p11 >> 6);
+        g1 = float((p01 >> 6) + (p10 >> 6)) * 0.5;
+        b1 = float(p00 >> 6);
+    }
+
+    float y0f = 0.2126*r0 + 0.7152*g0 + 0.0722*b0;
+    float y1f = 0.2126*r1 + 0.7152*g1 + 0.0722*b1;
+    float rAvg = (r0 + r1) * 0.5;
+    float gAvg = (g0 + g1) * 0.5;
+    float bAvg = (b0 + b1) * 0.5;
+    float yAvg = 0.2126*rAvg + 0.7152*gAvg + 0.0722*bAvg;
+    float u_f = (bAvg - yAvg) * 0.5389 + 512.0;
+    float v_f = (rAvg - yAvg) * 0.6350 + 512.0;
+
+    uint y0 = uint(clamp(y0f, 0.0, 1023.0));
+    uint y1 = uint(clamp(y1f, 0.0, 1023.0));
+    uint u = uint(clamp(u_f, 0.0, 1023.0));
+    uint v = uint(clamp(v_f, 0.0, 1023.0));
     imageStore(yuvImage, gid, uvec4(y0, u, y1, v));
 }

--- a/src/App/AppIO.cpp
+++ b/src/App/AppIO.cpp
@@ -1490,10 +1490,10 @@ void App::exportCurrentClipToProRes() {
                 for (int y=0; y<height; ++y) {
                     for (int x=0; x<width/2; ++x) {
                         size_t srcIdx = static_cast<size_t>(y) * (width/2) * 4 + x*4;
-                        uint16_t y0 = gpuBuf[srcIdx] >> 6;
-                        uint16_t y1 = gpuBuf[srcIdx+1] >> 6; // Y1 directly
-                        uint16_t u  = gpuBuf[srcIdx+2] >> 6;
-                        uint16_t v  = gpuBuf[srcIdx+3] >> 6;
+                        uint16_t y0 = gpuBuf[srcIdx];
+                        uint16_t y1 = gpuBuf[srcIdx+1];
+                        uint16_t u  = gpuBuf[srcIdx+2];
+                        uint16_t v  = gpuBuf[srcIdx+3];
                         yPlane[y*frame->linesize[0]/2 + 2*x] = y0;
                         yPlane[y*frame->linesize[0]/2 + 2*x+1] = y1;
                         uPlane[y*frame->linesize[1]/2 + x] = u;


### PR DESCRIPTION
## Summary
- compute U and V values in `raw_to_yuv422.comp`
- avoid shifting YUV data twice when reading GPU buffers

## Testing
- `glslangValidator -V shaders/raw_to_yuv422.comp -o /tmp/out.spv`
- `cmake ..` *(fails: could not find FFMPEG)*

------
https://chatgpt.com/codex/tasks/task_e_686f4d9d79a08327a1b213c8ebf42be1