### PR TITLE
Fix GPU ProRes YUV plane ordering

### DIFF
--- a/src/App/AppIO.cpp
+++ b/src/App/AppIO.cpp
@@ -1508,8 +1508,8 @@ void App::exportCurrentClipToProRes() {
                     for (int x=0; x<width/2; ++x) {
                         size_t srcIdx = static_cast<size_t>(y) * (width/2) * 4 + x*4;
                         uint16_t y0 = gpuBuf[srcIdx];
-                        uint16_t y1 = gpuBuf[srcIdx+1];
-                        uint16_t u  = gpuBuf[srcIdx+2];
+                        uint16_t u  = gpuBuf[srcIdx+1];
+                        uint16_t y1 = gpuBuf[srcIdx+2];
                         uint16_t v  = gpuBuf[srcIdx+3];
                         yPlane[y*frame->linesize[0]/2 + 2*x] = y0;
                         yPlane[y*frame->linesize[0]/2 + 2*x+1] = y1;


### PR DESCRIPTION
## Summary
- correct mapping from GPU output buffer to AVFrame YUV planes

## Testing
- `cmake -S . -B build` *(fails: could not find FFMPEG)*

------
https://chatgpt.com/codex/tasks/task_e_686f5682ed0483278dea4986c70730d5