### PR TITLE
Fix YUV422 export pipeline

### DIFF
--- a/include/Graphics/GpuYuvConverter.h
+++ b/include/Graphics/GpuYuvConverter.h
@@ -16,8 +16,12 @@ public:
     bool init(int width, int height);
     void cleanup();
 
+    // Convert RAW Bayer data to packed YUV422 on the GPU and copy the
+    // result back to the CPU. The returned buffer contains 2 uint32_t
+    // values for every pair of output pixels as produced by the compute
+    // shader.
     bool convertAndReadback(const uint16_t* raw, int width, int height,
-                            std::vector<uint16_t>& outPacked);
+                            std::vector<uint32_t>& outPacked);
 private:
     Renderer_VK* m_renderer;
 

--- a/src/App/AppIO.cpp
+++ b/src/App/AppIO.cpp
@@ -1467,7 +1467,7 @@ void App::exportCurrentClipToProRes() {
         AVPacket pkt{};
 
         std::vector<uint8_t> rgbBuf;
-        std::vector<uint16_t> gpuBuf;
+        std::vector<uint32_t> gpuBuf;
         int64_t pts = 0;
         for (size_t idx = 0; idx < frames.size(); ++idx) {
             RawBytes raw;
@@ -1489,15 +1489,17 @@ void App::exportCurrentClipToProRes() {
                 uint16_t* vPlane = reinterpret_cast<uint16_t*>(frame->data[2]);
                 for (int y=0; y<height; ++y) {
                     for (int x=0; x<width/2; ++x) {
-                        size_t srcIdx = static_cast<size_t>(y) * (width/2) * 4 + x*4;
-                        uint16_t y0 = gpuBuf[srcIdx] >> 6;
-                        uint16_t y1 = gpuBuf[srcIdx+1] >> 6; // Y1 directly
-                        uint16_t u  = gpuBuf[srcIdx+2] >> 6;
-                        uint16_t v  = gpuBuf[srcIdx+3] >> 6;
-                        yPlane[y*frame->linesize[0]/2 + 2*x] = y0;
-                        yPlane[y*frame->linesize[0]/2 + 2*x+1] = y1;
-                        uPlane[y*frame->linesize[1]/2 + x] = u;
-                        vPlane[y*frame->linesize[2]/2 + x] = v;
+                        size_t srcIdx = static_cast<size_t>(y) * (width/2) * 2 + x*2;
+                        uint32_t packed0 = gpuBuf[srcIdx];
+                        uint32_t packed1 = gpuBuf[srcIdx+1];
+                        uint16_t U  =  (packed0 >> 0)  & 0x3FF;
+                        uint16_t Y0 =  (packed0 >> 10) & 0x3FF;
+                        uint16_t V  =  (packed0 >> 20) & 0x3FF;
+                        uint16_t Y1 =  packed1 & 0x3FF;
+                        yPlane[y*frame->linesize[0]/2 + 2*x]     = Y0;
+                        yPlane[y*frame->linesize[0]/2 + 2*x + 1] = Y1;
+                        uPlane[y*frame->linesize[1]/2 + x]       = U;
+                        vPlane[y*frame->linesize[2]/2 + x]       = V;
                     }
                 }
                 if (idx == 0) {

--- a/src/Graphics/GpuYuvConverter.cpp
+++ b/src/Graphics/GpuYuvConverter.cpp
@@ -110,7 +110,10 @@ bool GpuYuvConverter::init(int width, int height) {
     imageInfo.extent.depth = 1;
     imageInfo.mipLevels = 1;
     imageInfo.arrayLayers = 1;
-    imageInfo.format = VK_FORMAT_R16G16B16A16_UINT;
+    // Two uint32_t values hold the packed YUV422 output for a pair of pixels
+    // (U,Y0,V,Y1). Using an RG32 format allows us to store both words without
+    // any loss of precision or component swizzling.
+    imageInfo.format = VK_FORMAT_R32G32_UINT;
     imageInfo.tiling = VK_IMAGE_TILING_OPTIMAL;
     imageInfo.initialLayout = VK_IMAGE_LAYOUT_UNDEFINED;
     imageInfo.usage = VK_IMAGE_USAGE_STORAGE_BIT | VK_IMAGE_USAGE_TRANSFER_SRC_BIT;
@@ -126,7 +129,7 @@ bool GpuYuvConverter::init(int width, int height) {
     viewInfo.sType = VK_STRUCTURE_TYPE_IMAGE_VIEW_CREATE_INFO;
     viewInfo.image = m_yuvImage;
     viewInfo.viewType = VK_IMAGE_VIEW_TYPE_2D;
-    viewInfo.format = VK_FORMAT_R16G16B16A16_UINT;
+    viewInfo.format = VK_FORMAT_R32G32_UINT;
     viewInfo.subresourceRange.aspectMask = VK_IMAGE_ASPECT_COLOR_BIT;
     viewInfo.subresourceRange.baseMipLevel = 0;
     viewInfo.subresourceRange.levelCount = 1;
@@ -248,10 +251,10 @@ void GpuYuvConverter::cleanup() {
 }
 
 bool GpuYuvConverter::convertAndReadback(const uint16_t* raw, int width, int height,
-                                         std::vector<uint16_t>& outPacked) {
+                                         std::vector<uint32_t>& outPacked) {
     LogProRes("[GPU] convertAndReadback invoked");
     VkDeviceSize rawSize = static_cast<VkDeviceSize>(width) * height * sizeof(uint16_t);
-    VkDeviceSize outSize = static_cast<VkDeviceSize>(width) * height * 4;
+    VkDeviceSize outSize = static_cast<VkDeviceSize>(width) * height * sizeof(uint32_t);
 
     VkBuffer stagingBuf = VK_NULL_HANDLE;
     VmaAllocation stagingAlloc = VK_NULL_HANDLE;
@@ -429,7 +432,7 @@ bool GpuYuvConverter::convertAndReadback(const uint16_t* raw, int width, int hei
         m_renderer->m_graphicsQueue_p, cmd);
 
     vmaInvalidateAllocation(m_renderer->m_allocator_p, readbackAlloc, 0, outSize);
-    outPacked.resize(static_cast<size_t>(outSize / sizeof(uint16_t)));
+    outPacked.resize(static_cast<size_t>(outSize / sizeof(uint32_t)));
     memcpy(outPacked.data(), rbAllocInfo.pMappedData, outSize);
     LogProRes("[GPU] readback complete");
 


### PR DESCRIPTION
## Summary
- update converter to output packed data as `uint32_t`
- unpack GPU buffer into planar YUV422 before handing to FFmpeg
- use `VK_FORMAT_R32G32_UINT` for compute output

## Testing
- `cmake -S . -B build` *(fails: Could not find a package configuration file provided by "FFMPEG")*

------
https://chatgpt.com/codex/tasks/task_e_686f5b812d98832781e626f9cddfc91a