### PR TITLE
Fix YUV422 export pipeline

### DIFF
--- a/include/Graphics/GpuYuvConverter.h
+++ b/include/Graphics/GpuYuvConverter.h
@@ -16,8 +16,12 @@ public:
     bool init(int width, int height);
     void cleanup();
 
+    // Convert RAW Bayer data to packed YUV422 on the GPU and copy the
+    // result back to the CPU. Each pair of output pixels is represented
+    // by two uint32_t words. The first word packs U, Y0 and V into
+    // 10-bit fields, the second word contains Y1.
     bool convertAndReadback(const uint16_t* raw, int width, int height,
-                            std::vector<uint16_t>& outPacked);
+                            std::vector<uint32_t>& outPacked);
 private:
     Renderer_VK* m_renderer;
 

--- a/shaders/raw_to_yuv422.comp
+++ b/shaders/raw_to_yuv422.comp
@@ -3,7 +3,7 @@
 layout(local_size_x = 16, local_size_y = 16) in;
 
 layout(binding = 0) uniform usampler2D rawImage;
-layout(binding = 1, rgba16ui) writeonly uniform uimage2D yuvImage;
+layout(binding = 1, rg32ui) writeonly uniform uimage2D yuvImage;
 
 layout(push_constant) uniform PushConsts {
     int width;
@@ -22,9 +22,51 @@ void main() {
     int y = gid.y;
     if (x0 >= pc.width || y >= pc.height) return;
     int x1 = x0 + 1;
-    uint y0 = readU16(x0, y) >> 6;
-    uint y1 = (x1 < pc.width) ? (readU16(x1, y) >> 6) : y0;
-    uint u = 512u;
-    uint v = 512u;
-    imageStore(yuvImage, gid, uvec4(y0, u, y1, v));
+
+    int baseY = (y & ~1);           // even row for 2x2 block
+    int nextY = baseY + 1;
+    uint p00 = readU16(x0, baseY);
+    uint p01 = (x1 < pc.width) ? readU16(x1, baseY) : p00;
+    uint p10 = (nextY < pc.height) ? readU16(x0, nextY) : p00;
+    uint p11 = (x1 < pc.width && nextY < pc.height) ? readU16(x1, nextY) : p10;
+
+    float r0, g0, b0;
+    float r1, g1, b1;
+    if ((y & 1) == 0) {
+        // top row of BGGR 2x2 block: B,G/G,R
+        r0 = float(p11 >> 6);
+        g0 = float((p01 >> 6) + (p10 >> 6)) * 0.5;
+        b0 = float(p00 >> 6);
+
+        r1 = float(p11 >> 6);
+        g1 = float(p01 >> 6);
+        b1 = float(p00 >> 6);
+    } else {
+        // bottom row of BGGR block: G,R/B,G
+        r0 = float(p11 >> 6);
+        g0 = float(p10 >> 6);
+        b0 = float(p00 >> 6);
+
+        r1 = float(p11 >> 6);
+        g1 = float((p01 >> 6) + (p10 >> 6)) * 0.5;
+        b1 = float(p00 >> 6);
+    }
+
+    float y0f = 0.2126*r0 + 0.7152*g0 + 0.0722*b0;
+    float y1f = 0.2126*r1 + 0.7152*g1 + 0.0722*b1;
+    float rAvg = (r0 + r1) * 0.5;
+    float gAvg = (g0 + g1) * 0.5;
+    float bAvg = (b0 + b1) * 0.5;
+    float yAvg = 0.2126*rAvg + 0.7152*gAvg + 0.0722*bAvg;
+    float u_f = (bAvg - yAvg) * 0.5389 + 512.0;
+    float v_f = (rAvg - yAvg) * 0.6350 + 512.0;
+
+    uint y0 = uint(clamp(y0f, 0.0, 1023.0));
+    uint y1 = uint(clamp(y1f, 0.0, 1023.0));
+    uint u  = uint(clamp(u_f, 0.0, 1023.0));
+    uint v  = uint(clamp(v_f, 0.0, 1023.0));
+
+    uint packed0 = (u & 1023u) | ((y0 & 1023u) << 10) | ((v & 1023u) << 20);
+    uint packed1 = (y1 & 1023u);
+    imageStore(yuvImage, gid, uvec4(packed0, packed1, 0u, 0u));
 }

--- a/src/App/AppIO.cpp
+++ b/src/App/AppIO.cpp
@@ -1467,7 +1467,7 @@ void App::exportCurrentClipToProRes() {
         AVPacket pkt{};
 
         std::vector<uint8_t> rgbBuf;
-        std::vector<uint16_t> gpuBuf;
+        std::vector<uint32_t> gpuBuf;
         int64_t pts = 0;
         for (size_t idx = 0; idx < frames.size(); ++idx) {
             RawBytes raw;
@@ -1489,15 +1489,17 @@ void App::exportCurrentClipToProRes() {
                 uint16_t* vPlane = reinterpret_cast<uint16_t*>(frame->data[2]);
                 for (int y=0; y<height; ++y) {
                     for (int x=0; x<width/2; ++x) {
-                        size_t srcIdx = static_cast<size_t>(y) * (width/2) * 4 + x*4;
-                        uint16_t y0 = gpuBuf[srcIdx] >> 6;
-                        uint16_t y1 = gpuBuf[srcIdx+1] >> 6; // Y1 directly
-                        uint16_t u  = gpuBuf[srcIdx+2] >> 6;
-                        uint16_t v  = gpuBuf[srcIdx+3] >> 6;
-                        yPlane[y*frame->linesize[0]/2 + 2*x] = y0;
-                        yPlane[y*frame->linesize[0]/2 + 2*x+1] = y1;
-                        uPlane[y*frame->linesize[1]/2 + x] = u;
-                        vPlane[y*frame->linesize[2]/2 + x] = v;
+                        size_t srcIdx = static_cast<size_t>(y) * (width/2) * 2 + x*2;
+                        uint32_t packed0 = gpuBuf[srcIdx];
+                        uint32_t packed1 = gpuBuf[srcIdx+1];
+                        uint16_t U  =  (packed0 >> 0)  & 0x3FF;
+                        uint16_t Y0 =  (packed0 >> 10) & 0x3FF;
+                        uint16_t V  =  (packed0 >> 20) & 0x3FF;
+                        uint16_t Y1 =  packed1 & 0x3FF;
+                        yPlane[y*frame->linesize[0]/2 + 2*x]     = Y0;
+                        yPlane[y*frame->linesize[0]/2 + 2*x + 1] = Y1;
+                        uPlane[y*frame->linesize[1]/2 + x]       = U;
+                        vPlane[y*frame->linesize[2]/2 + x]       = V;
                     }
                 }
                 if (idx == 0) {

--- a/src/Graphics/GpuYuvConverter.cpp
+++ b/src/Graphics/GpuYuvConverter.cpp
@@ -110,7 +110,10 @@ bool GpuYuvConverter::init(int width, int height) {
     imageInfo.extent.depth = 1;
     imageInfo.mipLevels = 1;
     imageInfo.arrayLayers = 1;
-    imageInfo.format = VK_FORMAT_R16G16B16A16_UINT;
+    // Two uint32_t values hold the packed YUV422 output for a pair of pixels
+    // (U,Y0,V,Y1). Using an RG32 format allows us to store both words without
+    // any loss of precision or component swizzling.
+    imageInfo.format = VK_FORMAT_R32G32_UINT;
     imageInfo.tiling = VK_IMAGE_TILING_OPTIMAL;
     imageInfo.initialLayout = VK_IMAGE_LAYOUT_UNDEFINED;
     imageInfo.usage = VK_IMAGE_USAGE_STORAGE_BIT | VK_IMAGE_USAGE_TRANSFER_SRC_BIT;
@@ -126,7 +129,7 @@ bool GpuYuvConverter::init(int width, int height) {
     viewInfo.sType = VK_STRUCTURE_TYPE_IMAGE_VIEW_CREATE_INFO;
     viewInfo.image = m_yuvImage;
     viewInfo.viewType = VK_IMAGE_VIEW_TYPE_2D;
-    viewInfo.format = VK_FORMAT_R16G16B16A16_UINT;
+    viewInfo.format = VK_FORMAT_R32G32_UINT;
     viewInfo.subresourceRange.aspectMask = VK_IMAGE_ASPECT_COLOR_BIT;
     viewInfo.subresourceRange.baseMipLevel = 0;
     viewInfo.subresourceRange.levelCount = 1;
@@ -248,10 +251,10 @@ void GpuYuvConverter::cleanup() {
 }
 
 bool GpuYuvConverter::convertAndReadback(const uint16_t* raw, int width, int height,
-                                         std::vector<uint16_t>& outPacked) {
+                                         std::vector<uint32_t>& outPacked) {
     LogProRes("[GPU] convertAndReadback invoked");
     VkDeviceSize rawSize = static_cast<VkDeviceSize>(width) * height * sizeof(uint16_t);
-    VkDeviceSize outSize = static_cast<VkDeviceSize>(width) * height * 4;
+    VkDeviceSize outSize = static_cast<VkDeviceSize>(width) * height * sizeof(uint32_t);
 
     VkBuffer stagingBuf = VK_NULL_HANDLE;
     VmaAllocation stagingAlloc = VK_NULL_HANDLE;
@@ -429,7 +432,7 @@ bool GpuYuvConverter::convertAndReadback(const uint16_t* raw, int width, int hei
         m_renderer->m_graphicsQueue_p, cmd);
 
     vmaInvalidateAllocation(m_renderer->m_allocator_p, readbackAlloc, 0, outSize);
-    outPacked.resize(static_cast<size_t>(outSize / sizeof(uint16_t)));
+    outPacked.resize(static_cast<size_t>(outSize / sizeof(uint32_t)));
     memcpy(outPacked.data(), rbAllocInfo.pMappedData, outSize);
     LogProRes("[GPU] readback complete");
 

--- a/src/Graphics/ImageResource.cpp
+++ b/src/Graphics/ImageResource.cpp
@@ -74,7 +74,10 @@ namespace ImageResource {
         }
         else if (oldLayout == VK_IMAGE_LAYOUT_UNDEFINED && newLayout == VK_IMAGE_LAYOUT_GENERAL) {
             barrier.srcAccessMask = 0;
-            barrier.dstAccessMask = VK_ACCESS_SHADER_WRITE_BIT | VK_ACCESS_TRANSFER_WRITE_BIT;
+            // The image will be written by the compute shader. No transfer
+            // access is involved, so limit the destination access mask to
+            // shader writes to avoid validation errors.
+            barrier.dstAccessMask = VK_ACCESS_SHADER_WRITE_BIT;
             sourceStage = VK_PIPELINE_STAGE_TOP_OF_PIPE_BIT;
             destinationStage = VK_PIPELINE_STAGE_COMPUTE_SHADER_BIT;
         }


### PR DESCRIPTION
## Summary
- pack compute shader output into RG32 format
- clarify GPU converter API
- avoid invalid transfer write flag on init

## Testing
- `cmake -S . -B build` *(fails: Could not find a package configuration file provided by "FFMPEG")*

------
https://chatgpt.com/codex/tasks/task_e_686f5b812d98832781e626f9cddfc91a