### PR TITLE
Fix GPU->ProRes YUV ordering

### DIFF
--- a/include/App/AppConfig.h
+++ b/include/App/AppConfig.h
@@ -22,10 +22,7 @@ constexpr size_t AvailableStagingIndicesQueueSlack = 8;
 constexpr size_t MAX_LEAD_FRAMES_IO_WORKER = 8;
 constexpr size_t MAX_LAG_FRAMES_IO_WORKER = 4;
 
-#ifndef NDEBUG
+// Always enable Vulkan validation layers for this build
 const bool enableValidationLayers = true;
-#else
-const bool enableValidationLayers = false;
-#endif
 
 #endif // APP_CONFIG_H

--- a/src/App/AppIO.cpp
+++ b/src/App/AppIO.cpp
@@ -1493,11 +1493,16 @@ void App::exportCurrentClipToProRes() {
 
                     size_t srcBase = static_cast<size_t>(y) * (width / 2) * 4;   /* 4×u16 per 2-pixel group */
                     for (int x = 0; x < width; x += 2) {
+                        if (y == 0 && x == 0) {
+                            printf("W0=%u W1=%u W2=%u W3=%u\n",
+                                   gpuBuf[srcBase], gpuBuf[srcBase + 1],
+                                   gpuBuf[srcBase + 2], gpuBuf[srcBase + 3]);
+                        }
                         size_t src = srcBase + (x >> 1) * 4;
                         uint16_t y0 = gpuBuf[src + 0];   /* Y0 */
-                        uint16_t u  = gpuBuf[src + 1];   /* U  */
+                        uint16_t v  = gpuBuf[src + 1];   /* V  */
                         uint16_t y1 = gpuBuf[src + 2];   /* Y1 */
-                        uint16_t v  = gpuBuf[src + 3];   /* V  */
+                        uint16_t u  = gpuBuf[src + 3];   /* U  */
 
                         yRow[x    ] = y0 << 6;           /* 10-bit → 16-bit */
                         yRow[x + 1] = y1 << 6;


### PR DESCRIPTION
## Summary
- enable Vulkan validation layers
- dump the first macropixel in GPU YUV conversion
- swap the unpack order when reading GPU output

## Testing
- `cmake ..` *(fails: Could not find package `FFMPEG`)*

------
https://chatgpt.com/codex/tasks/task_e_686f73b833088327a0285ff5b60ef307