### PR TITLE
Fix GPU ProRes unpack order

### DIFF
--- a/include/App/AppConfig.h
+++ b/include/App/AppConfig.h
@@ -22,10 +22,7 @@ constexpr size_t AvailableStagingIndicesQueueSlack = 8;
 constexpr size_t MAX_LEAD_FRAMES_IO_WORKER = 8;
 constexpr size_t MAX_LAG_FRAMES_IO_WORKER = 4;
 
-#ifndef NDEBUG
-const bool enableValidationLayers = true;
-#else
-const bool enableValidationLayers = false;
-#endif
+// Always enable Vulkan validation layers for this build
+constexpr bool enableValidationLayers = true;
 
 #endif // APP_CONFIG_H

--- a/src/App/AppIO.cpp
+++ b/src/App/AppIO.cpp
@@ -1495,9 +1495,9 @@ void App::exportCurrentClipToProRes() {
                     for (int x = 0; x < width; x += 2) {
                         size_t src = srcBase + (x >> 1) * 4;
                         uint16_t y0 = gpuBuf[src + 0];   /* Y0 */
-                        uint16_t u  = gpuBuf[src + 1];   /* U  */
+                        uint16_t v  = gpuBuf[src + 1];   /* V  */
                         uint16_t y1 = gpuBuf[src + 2];   /* Y1 */
-                        uint16_t v  = gpuBuf[src + 3];   /* V  */
+                        uint16_t u  = gpuBuf[src + 3];   /* U  */
 
                         yRow[x    ] = y0 << 6;           /* 10-bit → 16-bit */
                         yRow[x + 1] = y1 << 6;


### PR DESCRIPTION
## Summary
- keep Vulkan validation layers on at all times
- correct the GPU YUV422 planar unpack order for ProRes export

## Testing
- `cmake -S . -B build` *(fails: could not find FFMPEG)*

------
https://chatgpt.com/codex/tasks/task_e_686f73b833088327a0285ff5b60ef307