### PR TITLE
Fix GPU YUV compute and add debug logs

### DIFF
--- a/shaders/raw_to_yuv422.comp
+++ b/shaders/raw_to_yuv422.comp
@@ -22,9 +22,49 @@ void main() {
     int y = gid.y;
     if (x0 >= pc.width || y >= pc.height) return;
     int x1 = x0 + 1;
-    uint y0 = readU16(x0, y) >> 6;
-    uint y1 = (x1 < pc.width) ? (readU16(x1, y) >> 6) : y0;
-    uint u = 512u;
-    uint v = 512u;
+
+    int baseY = (y & ~1);           // even row for 2x2 block
+    int nextY = baseY + 1;
+    uint p00 = readU16(x0, baseY);
+    uint p01 = (x1 < pc.width) ? readU16(x1, baseY) : p00;
+    uint p10 = (nextY < pc.height) ? readU16(x0, nextY) : p00;
+    uint p11 = (x1 < pc.width && nextY < pc.height) ? readU16(x1, nextY) : p10;
+
+    float r0, g0, b0;
+    float r1, g1, b1;
+    if ((y & 1) == 0) {
+        // top row of BGGR 2x2 block: B,G/G,R
+        r0 = float(p11 >> 6);
+        g0 = float((p01 >> 6) + (p10 >> 6)) * 0.5;
+        b0 = float(p00 >> 6);
+
+        r1 = float(p11 >> 6);
+        g1 = float(p01 >> 6);
+        b1 = float(p00 >> 6);
+    } else {
+        // bottom row of BGGR block: G,R/B,G
+        r0 = float(p11 >> 6);
+        g0 = float(p10 >> 6);
+        b0 = float(p00 >> 6);
+
+        r1 = float(p11 >> 6);
+        g1 = float((p01 >> 6) + (p10 >> 6)) * 0.5;
+        b1 = float(p00 >> 6);
+    }
+
+    float y0f = 0.2126*r0 + 0.7152*g0 + 0.0722*b0;
+    float y1f = 0.2126*r1 + 0.7152*g1 + 0.0722*b1;
+    float rAvg = (r0 + r1) * 0.5;
+    float gAvg = (g0 + g1) * 0.5;
+    float bAvg = (b0 + b1) * 0.5;
+    float yAvg = 0.2126*rAvg + 0.7152*gAvg + 0.0722*bAvg;
+    float u_f = (bAvg - yAvg) * 0.5389 + 512.0;
+    float v_f = (rAvg - yAvg) * 0.6350 + 512.0;
+
+    uint y0 = uint(clamp(y0f, 0.0, 1023.0));
+    uint y1 = uint(clamp(y1f, 0.0, 1023.0));
+    uint u  = uint(clamp(u_f, 0.0, 1023.0));
+    uint v  = uint(clamp(v_f, 0.0, 1023.0));
+
     imageStore(yuvImage, gid, uvec4(y0, u, y1, v));
 }

--- a/src/App/AppIO.cpp
+++ b/src/App/AppIO.cpp
@@ -28,6 +28,7 @@
 #include <algorithm>
 #include <cmath>
 #include <cstdio>
+#include <zlib.h>
 #include <sstream>
 #ifdef ENABLE_PRORES_EXPORT
 #include "ffmpeg_headers.hpp"
@@ -1480,7 +1481,12 @@ void App::exportCurrentClipToProRes() {
 
             t0 = t1;
             if (gpuActive) {
-			converter.convertAndReadback(asU16(raw), width, height, gpuBuf);
+                converter.convertAndReadback(asU16(raw), width, height, gpuBuf);
+                printf("Frame %zu first four GPU words: %u %u %u %u\n", idx,
+                       gpuBuf.size() > 3 ? gpuBuf[0] : 0,
+                       gpuBuf.size() > 3 ? gpuBuf[1] : 0,
+                       gpuBuf.size() > 3 ? gpuBuf[2] : 0,
+                       gpuBuf.size() > 3 ? gpuBuf[3] : 0);
                 t1 = std::chrono::steady_clock::now();
                 rgbUS += std::chrono::duration_cast<std::chrono::microseconds>(t1 - t0).count();
                 if (av_frame_make_writable(frame) < 0) { m_proResStatus.errorMsg = "frame not writable"; break; }
@@ -1505,6 +1511,11 @@ void App::exportCurrentClipToProRes() {
                         vRow[x >> 1] = v << 6;
                     }
                 }
+
+                uint32_t crcY = crc32(0, reinterpret_cast<const unsigned char*>(frame->data[0]), 32);
+                uint32_t crcU = crc32(0, reinterpret_cast<const unsigned char*>(frame->data[1]), 32);
+                uint32_t crcV = crc32(0, reinterpret_cast<const unsigned char*>(frame->data[2]), 32);
+                printf("Y_CRC=%08x U_CRC=%08x V_CRC=%08x\n", crcY, crcU, crcV);
 
                 /*  one-time sanity log without yPlane/uPlane/vPlane symbols  */
                 if (idx == 0) {


### PR DESCRIPTION
## Summary
- restore raw_to_yuv422.comp logic for GPU YUV conversion
- output 10‑bit values as rgba16ui in compute shader
- print GPU buffer words and CRCs during ProRes export for debugging

## Testing
- `glslangValidator -V shaders/raw_to_yuv422.comp -o /tmp/raw_to_yuv422.comp.spv`


------
https://chatgpt.com/codex/tasks/task_e_686f81491c448327a5a13b9a92498cf8