### PR TITLE
Fix Vulkan barriers and queue race

### DIFF
--- a/include/Graphics/VulkanHelpers.h
+++ b/include/Graphics/VulkanHelpers.h
@@ -4,6 +4,7 @@
 #include <vulkan/vulkan.h>
 #include <vector>
 #include <string>
+#include <mutex>
 #include <iostream> // For std::cerr in VK_CHECK_RENDERER
 #include "Utils/DebugLog.h" // For LogToFile in VK_CHECK_RENDERER
 
@@ -35,6 +36,8 @@ namespace VulkanHelpers {
     // that holds these Vulkan objects. For now, make them free functions requiring device context.
     VkCommandBuffer beginSingleTimeCommands(VkDevice device, VkCommandPool commandPool);
     void endSingleTimeCommands(VkDevice device, VkCommandPool commandPool, VkQueue queue, VkCommandBuffer commandBuffer);
+
+    extern std::mutex queueMutex;
 
 } // namespace VulkanHelpers
 

--- a/src/App/AppLoop.cpp
+++ b/src/App/AppLoop.cpp
@@ -4,6 +4,7 @@
 #include "Decoder/DecoderWrapper.h"
 #include "Playback/PlaybackController.h"
 #include "Graphics/Renderer_VK.h"
+#include "Graphics/VulkanHelpers.h"
 #include "Utils/DebugLog.h"
 #include "Gui/GuiOverlay.h"
 
@@ -472,7 +473,10 @@ void App::drawFrame() {
     submitInfo.pSignalSemaphores = &m_renderFinishedSemaphores[m_currentFrame];
 
     timePoint_A = steady_clock::now();
-    VK_APP_CHECK(vkQueueSubmit(m_graphicsQueue, 1, &submitInfo, m_inFlightFences[m_currentFrame]));
+    {
+        std::scoped_lock lock(VulkanHelpers::queueMutex);
+        VK_APP_CHECK(vkQueueSubmit(m_graphicsQueue, 1, &submitInfo, m_inFlightFences[m_currentFrame]));
+    }
 
     VkPresentInfoKHR presentInfo{ VK_STRUCTURE_TYPE_PRESENT_INFO_KHR };
     presentInfo.waitSemaphoreCount = 1;

--- a/src/Graphics/ImageResource.cpp
+++ b/src/Graphics/ImageResource.cpp
@@ -74,7 +74,10 @@ namespace ImageResource {
         }
         else if (oldLayout == VK_IMAGE_LAYOUT_UNDEFINED && newLayout == VK_IMAGE_LAYOUT_GENERAL) {
             barrier.srcAccessMask = 0;
-            barrier.dstAccessMask = VK_ACCESS_SHADER_WRITE_BIT | VK_ACCESS_TRANSFER_WRITE_BIT;
+            // When transitioning to GENERAL for compute we only expose shader
+            // accesses. Using TRANSFER bits here would be invalid with the
+            // COMPUTE stage destination.
+            barrier.dstAccessMask = VK_ACCESS_SHADER_WRITE_BIT | VK_ACCESS_SHADER_READ_BIT;
             sourceStage = VK_PIPELINE_STAGE_TOP_OF_PIPE_BIT;
             destinationStage = VK_PIPELINE_STAGE_COMPUTE_SHADER_BIT;
         }

--- a/src/Graphics/VulkanHelpers.cpp
+++ b/src/Graphics/VulkanHelpers.cpp
@@ -5,6 +5,8 @@
 
 namespace VulkanHelpers {
 
+    std::mutex queueMutex;
+
     std::vector<char> readFile(const std::string& filename) {
         std::string fullPath = filename;
         LogToFile(std::string("[VulkanHelpers::readFile] Attempting to read shader file: ") + fullPath);
@@ -39,6 +41,7 @@ namespace VulkanHelpers {
         return shaderModule;
     }
 
+
     VkCommandBuffer beginSingleTimeCommands(VkDevice device, VkCommandPool commandPool) {
         VkCommandBufferAllocateInfo allocInfo{};
         allocInfo.sType = VK_STRUCTURE_TYPE_COMMAND_BUFFER_ALLOCATE_INFO;
@@ -64,8 +67,11 @@ namespace VulkanHelpers {
         submitInfo.commandBufferCount = 1;
         submitInfo.pCommandBuffers = &commandBuffer;
 
-        VK_CHECK_RENDERER(vkQueueSubmit(queue, 1, &submitInfo, VK_NULL_HANDLE));
-        VK_CHECK_RENDERER(vkQueueWaitIdle(queue));
+        {
+            std::scoped_lock lock(queueMutex);
+            VK_CHECK_RENDERER(vkQueueSubmit(queue, 1, &submitInfo, VK_NULL_HANDLE));
+            VK_CHECK_RENDERER(vkQueueWaitIdle(queue));
+        }
 
         vkFreeCommandBuffers(device, commandPool, 1, &commandBuffer);
     }

--- a/src/Gui/GuiSetup.cpp
+++ b/src/Gui/GuiSetup.cpp
@@ -12,6 +12,7 @@
 #include <imgui.h>
 #include <imgui_impl_glfw.h>
 #include <imgui_impl_vulkan.h>
+#include "Graphics/VulkanHelpers.h"
 
 #include <GLFW/glfw3.h>
 #include <vulkan/vulkan.h>
@@ -133,8 +134,11 @@ namespace GuiOverlay {
         end_info.pCommandBuffers = &command_buffer;
         vkEndCommandBuffer(command_buffer);
 
-        vkQueueSubmit(appInstance->m_graphicsQueue, 1, &end_info, VK_NULL_HANDLE);
-        vkQueueWaitIdle(appInstance->m_graphicsQueue); // Ensure fonts are uploaded
+        {
+            std::scoped_lock lock(VulkanHelpers::queueMutex);
+            vkQueueSubmit(appInstance->m_graphicsQueue, 1, &end_info, VK_NULL_HANDLE);
+            vkQueueWaitIdle(appInstance->m_graphicsQueue); // Ensure fonts are uploaded
+        }
 
         ImGui_ImplVulkan_DestroyFontsTexture(); // Device Staging Bufs are no longer needed
     }


### PR DESCRIPTION
## Summary
- correct UNDEFINED→GENERAL barrier for compute stage
- serialize queue submissions using a global mutex

## Testing
- `cmake -S . -B build` *(fails: could not find FFMPEG)*

------
https://chatgpt.com/codex/tasks/task_e_686fe9b3420c8327992818cc49ec7e3f