### PR TITLE
Add GPU→AVFrame copy helper

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -33,6 +33,7 @@ if(NOT Vulkan_FOUND)
 endif()
 find_package(Threads REQUIRED)
 find_package(FFMPEG REQUIRED COMPONENTS avcodec avformat avutil swscale swresample)
+find_package(spdlog REQUIRED)
 message(STATUS "FFmpeg_FOUND=${FFmpeg_FOUND} FFMPEG_FOUND=${FFMPEG_FOUND}")
 if(FFMPEG_FOUND OR FFmpeg_FOUND)
     message(STATUS "FFmpeg found via vcpkg, enabling ProRes export")
@@ -148,6 +149,7 @@ set(APP_SOURCES
   src/Graphics/VulkanHelpers.cpp
   src/Graphics/ImageResource.cpp
   src/Graphics/GpuYuvConverter.cpp
+  src/Graphics/GpuFrameCopy.cpp
   src/Graphics/Pipeline.cpp
   src/Graphics/Descriptor.cpp
 
@@ -232,6 +234,7 @@ target_link_libraries(${PROJECT_NAME} PRIVATE
     "${GLFW_LIB_PATH_VC_SPECIFIC}"
     "${SDL2_LIBRARY_DIR}/SDL2.lib"
     ${Vulkan_LIBRARIES}
+    spdlog::spdlog_header_only
 )
 
 # ─── FFmpeg link block (uses imported targets) ────────────────────────

--- a/include/Graphics/GpuFrameCopy.h
+++ b/include/Graphics/GpuFrameCopy.h
@@ -1,0 +1,27 @@
+#pragma once
+#include <cstdint>
+#include "ffmpeg_headers.hpp"
+
+/**
+ * \brief Copy GPU-mapped packed 10-bit YUV422 data into an AVFrame.
+ *
+ * The source buffer contains 16-bit words in the order Y0, U, Y1, V for each
+ * pair of pixels. The destination frame must be allocated for the
+ * AV_PIX_FMT_YUV422P10LE format. Values are left-shifted by 6 bits when written
+ * so the 10-bit samples become 16-bit samples with zero-filled LSBs.
+ *
+ * When PRORES_GPU_VALIDATE is defined and \p validate is true, the very first
+ * macropixel is inspected. If it appears invalid the function logs an error and
+ * returns false so the caller may fall back to a CPU implementation.
+ */
+/**
+ * The \p videoWidth must be an even value since the packed GPU buffer stores
+ * two Y samples for every chroma pair. The destination \p frame must already
+ * be allocated using av_frame_alloc() and configured for AV_PIX_FMT_YUV422P10LE
+ * format.
+ */
+bool copyFromGpuToFrame(const void* mappedGpuMemory,
+                        int videoWidth,
+                        int videoHeight,
+                        AVFrame* frame,
+                        bool validate = false);

--- a/src/Graphics/GpuFrameCopy.cpp
+++ b/src/Graphics/GpuFrameCopy.cpp
@@ -1,0 +1,74 @@
+#include "Graphics/GpuFrameCopy.h"
+#include <spdlog/spdlog.h>
+
+bool copyFromGpuToFrame(const void* mappedGpuMemory,
+                        int videoWidth,
+                        int videoHeight,
+                        AVFrame* frame,
+                        bool validate)
+{
+    if (!mappedGpuMemory || !frame) {
+        return false;
+    }
+
+    if (videoWidth % 2 != 0) {
+        spdlog::error("[GPU-COPY] video width must be even: {}", videoWidth);
+        return false;
+    }
+
+    if (frame->format != AV_PIX_FMT_YUV422P10LE) {
+        spdlog::error("[GPU-COPY] unexpected AVFrame format {}", frame->format);
+        return false;
+    }
+
+    const uint16_t* src = static_cast<const uint16_t*>(mappedGpuMemory);
+    const size_t wordsPerRow = static_cast<size_t>(videoWidth) * 2;
+
+#ifdef PRORES_GPU_VALIDATE
+    if (validate) {
+        uint16_t y0 = src[0];
+        uint16_t u  = src[1];
+        uint16_t y1 = src[2];
+        uint16_t v  = src[3];
+        spdlog::debug("[GPU-CHECK] first macropixel: Y0={} U={} Y1={} V={}", y0, u, y1, v);
+        bool ok = (y0 <= 1023 && y1 <= 1023 && u <= 1023 && v <= 1023);
+        if (!ok) {
+            spdlog::error("[GPU-CHECK] validation failed: {} {} {} {}", y0, u, y1, v);
+            return false;
+        }
+    }
+#else
+    (void)validate;
+#endif
+
+    spdlog::debug("[GPU-COPY] begin: {}x{}", videoWidth, videoHeight);
+
+    for (int y = 0; y < videoHeight; ++y) {
+        auto* yRow = reinterpret_cast<uint16_t*>(frame->data[0] + y * frame->linesize[0]);
+        auto* uRow = reinterpret_cast<uint16_t*>(frame->data[1] + y * frame->linesize[1]);
+        auto* vRow = reinterpret_cast<uint16_t*>(frame->data[2] + y * frame->linesize[2]);
+
+        const uint16_t* srcRow = src + static_cast<size_t>(y) * wordsPerRow;
+        for (int x = 0; x < videoWidth; x += 2) {
+            size_t base = (x >> 1) * 4;
+            uint16_t y0 = srcRow[base + 0];
+            uint16_t u  = srcRow[base + 1];
+            uint16_t y1 = srcRow[base + 2];
+            uint16_t v  = srcRow[base + 3];
+
+            yRow[x]     = static_cast<uint16_t>(y0 << 6);
+            yRow[x + 1] = static_cast<uint16_t>(y1 << 6);
+            uRow[x >> 1] = static_cast<uint16_t>(u << 6);
+            vRow[x >> 1] = static_cast<uint16_t>(v << 6);
+        }
+    }
+
+    const uint16_t* dbgY = reinterpret_cast<const uint16_t*>(frame->data[0]);
+    const uint16_t* dbgU = reinterpret_cast<const uint16_t*>(frame->data[1]);
+    const uint16_t* dbgV = reinterpret_cast<const uint16_t*>(frame->data[2]);
+    spdlog::debug("[GPU-COPY] first AVFrame macropixel: Y0={} Y1={} U={} V={}",
+                  dbgY[0] >> 6, dbgY[1] >> 6, dbgU[0] >> 6, dbgV[0] >> 6);
+
+    spdlog::debug("[GPU-COPY] copy complete");
+    return true;
+}


### PR DESCRIPTION
## Summary
- add new helper `copyFromGpuToFrame` for mapping packed GPU YUV422 output into an AVFrame
- hook spdlog into the build
- compile helper into executable via CMake
- add format and width validation in the GPU copy routine

## Testing
- `cmake -S . -B build` *(fails: Could not find a package configuration file provided by "FFMPEG")*

------
https://chatgpt.com/codex/tasks/task_e_686ff0e8a2948327a9e58ad5f455663c