### PR TITLE
Fix GPU barrier and queue submission

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -161,6 +161,7 @@ set(APP_SOURCES
   src/Utils/DebugLog.cpp
   src/Utils/OrientationUtils.cpp
   src/Utils/ColorPipelineCPU.cpp
+  src/Utils/GpuProresFix.cpp
 
   src/main.cpp
 )

--- a/include/Graphics/GpuYuvConverter.h
+++ b/include/Graphics/GpuYuvConverter.h
@@ -17,6 +17,7 @@ public:
     void cleanup();
 
     bool convertAndReadback(const uint16_t* raw, int width, int height,
+                            float gainR, float gainB,
                             std::vector<uint16_t>& outPacked);
 private:
     Renderer_VK* m_renderer;

--- a/include/Graphics/VulkanHelpers.h
+++ b/include/Graphics/VulkanHelpers.h
@@ -4,6 +4,7 @@
 #include <vulkan/vulkan.h>
 #include <vector>
 #include <string>
+#include <mutex>
 #include <iostream> // For std::cerr in VK_CHECK_RENDERER
 #include "Utils/DebugLog.h" // For LogToFile in VK_CHECK_RENDERER
 
@@ -26,6 +27,9 @@
 
 
 namespace VulkanHelpers {
+
+    // Serialises vkQueueSubmit calls from multiple threads
+    extern std::mutex gQueueMutex;
 
     std::vector<char> readFile(const std::string& filename);
     VkShaderModule createShaderModule(VkDevice device, const std::vector<char>& code);

--- a/include/Utils/GpuProresFix.h
+++ b/include/Utils/GpuProresFix.h
@@ -1,0 +1,10 @@
+#pragma once
+#include <cstdint>
+extern "C" {
+#include <libavutil/frame.h>
+}
+
+bool copyFromGpuToFrame(const void *mappedGpuMemory,
+                        int videoWidth, int videoHeight,
+                        AVFrame *frame,
+                        bool validate = false);

--- a/include/spdlog/spdlog.h
+++ b/include/spdlog/spdlog.h
@@ -1,0 +1,25 @@
+#pragma once
+#include <cstdarg>
+#include <cstdio>
+
+namespace spdlog {
+inline void error(const char* fmt, ...) {
+    va_list args;
+    va_start(args, fmt);
+    vfprintf(stderr, fmt, args);
+    fprintf(stderr, "\n");
+    va_end(args);
+}
+
+inline void debug(const char* fmt, ...) {
+#ifndef NDEBUG
+    va_list args;
+    va_start(args, fmt);
+    vfprintf(stderr, fmt, args);
+    fprintf(stderr, "\n");
+    va_end(args);
+#else
+    (void)fmt;
+#endif
+}
+} // namespace spdlog

--- a/shaders/raw_to_yuv422.comp
+++ b/shaders/raw_to_yuv422.comp
@@ -8,6 +8,8 @@ layout(binding = 1, rgba16ui) writeonly uniform uimage2D yuvImage;
 layout(push_constant) uniform PushConsts {
     int width;
     int height;
+    float gainR;
+    float gainB;
 } pc;
 
 uint readU16(int x, int y) {
@@ -22,9 +24,11 @@ void main() {
     int y = gid.y;
     if (x0 >= pc.width || y >= pc.height) return;
     int x1 = x0 + 1;
-    uint y0 = readU16(x0, y) >> 6;
-    uint y1 = (x1 < pc.width) ? (readU16(x1, y) >> 6) : y0;
+    uint y0 = readU16(x0, y);
+    uint y1 = (x1 < pc.width) ? readU16(x1, y) : y0;
+    float f0 = clamp(float(y0) * pc.gainR / 16.0, 0.0, 1023.0);
+    float f1 = clamp(float(y1) * pc.gainB / 16.0, 0.0, 1023.0);
     uint u = 512u;
     uint v = 512u;
-    imageStore(yuvImage, gid, uvec4(y0, u, y1, v));
+    imageStore(yuvImage, gid, uvec4(uint(f0), u, uint(f1), v));
 }

--- a/src/App/AppIO.cpp
+++ b/src/App/AppIO.cpp
@@ -7,6 +7,7 @@
 #include "Utils/DebugLog.h"
 #include "Utils/RawFrameBuffer.h"
 #include "Utils/OrientationUtils.h"
+#include <spdlog/spdlog.h>
 #include <motioncam/Decoder.hpp>
 #include <motioncam/RawData.hpp>
 
@@ -32,6 +33,7 @@
 #ifdef ENABLE_PRORES_EXPORT
 #include "ffmpeg_headers.hpp"
 #include "Graphics/GpuYuvConverter.h"
+#include "Utils/GpuProresFix.h"
 #endif
 #include "Utils/ColorPipelineCPU.h"
 
@@ -1480,43 +1482,38 @@ void App::exportCurrentClipToProRes() {
 
             t0 = t1;
             if (gpuActive) {
-			converter.convertAndReadback(asU16(raw), width, height, gpuBuf);
+                        converter.convertAndReadback(asU16(raw), width, height,
+                                                    cpParams.gainR, cpParams.gainB,
+                                                    gpuBuf);
                 t1 = std::chrono::steady_clock::now();
                 rgbUS += std::chrono::duration_cast<std::chrono::microseconds>(t1 - t0).count();
                 if (av_frame_make_writable(frame) < 0) { m_proResStatus.errorMsg = "frame not writable"; break; }
 
-                /*  ✅  FINAL, CORRECT GPU->planar unpack  */
-                for (int y = 0; y < height; ++y) {
-                    auto* yRow = reinterpret_cast<uint16_t*>(frame->data[0] + y * frame->linesize[0]);
-                    auto* uRow = reinterpret_cast<uint16_t*>(frame->data[1] + y * frame->linesize[1]);
-                    auto* vRow = reinterpret_cast<uint16_t*>(frame->data[2] + y * frame->linesize[2]);
+                if (!copyFromGpuToFrame(gpuBuf.data(), width, height, frame, idx == 0)) {
+                    spdlog::error("[EXPORT-WARN] GPU copy failed – falling back to CPU");
+                    gpuActive = false;
+                    convertRawToRGB24(asU16(raw), cpParams, rgbBuf, threads);
+                    t1 = std::chrono::steady_clock::now();
+                    rgbUS += std::chrono::duration_cast<std::chrono::microseconds>(t1 - t0).count();
+                    if (av_frame_make_writable(frame) < 0) { m_proResStatus.errorMsg = "frame not writable"; break; }
+                    const uint8_t* srcSlices[1] = { rgbBuf.data() };
+                    int srcStride[1] = { width*3 };
+                    t0 = std::chrono::steady_clock::now();
+                    sws_scale(sws, srcSlices, srcStride, 0, height, frame->data, frame->linesize);
+                    t1 = std::chrono::steady_clock::now();
+                    scaleUS += std::chrono::duration_cast<std::chrono::microseconds>(t1 - t0).count();
+                } else {
+                    if (idx == 0) {
+                        const uint16_t* yDbg = reinterpret_cast<const uint16_t*>(frame->data[0]);
+                        const uint16_t* uDbg = reinterpret_cast<const uint16_t*>(frame->data[1]);
+                        const uint16_t* vDbg = reinterpret_cast<const uint16_t*>(frame->data[2]);
+                        std::ostringstream dbg;
+                        dbg << "[GPU] AVFrame first: "
+                            << (yDbg[0] >> 6) << "," << (yDbg[1] >> 6) << ","
+                            << (uDbg[0] >> 6) << "," << (vDbg[0] >> 6);
+                        LogProRes(dbg.str());
 
-                    size_t srcBase = static_cast<size_t>(y) * (width / 2) * 4;   /* 4×u16 per 2-pixel group */
-                    for (int x = 0; x < width; x += 2) {
-                        size_t src = srcBase + (x >> 1) * 4;
-                        uint16_t y0 = gpuBuf[src + 0];   /* Y0 */
-                        uint16_t u  = gpuBuf[src + 1];   /* U  */
-                        uint16_t y1 = gpuBuf[src + 2];   /* Y1 */
-                        uint16_t v  = gpuBuf[src + 3];   /* V  */
-
-                        yRow[x    ] = y0 << 6;           /* 10-bit → 16-bit */
-                        yRow[x + 1] = y1 << 6;
-                        uRow[x >> 1] = u << 6;
-                        vRow[x >> 1] = v << 6;
                     }
-                }
-
-                /*  one-time sanity log without yPlane/uPlane/vPlane symbols  */
-                if (idx == 0) {
-                    const uint16_t* yDbg = reinterpret_cast<const uint16_t*>(frame->data[0]);
-                    const uint16_t* uDbg = reinterpret_cast<const uint16_t*>(frame->data[1]);
-                    const uint16_t* vDbg = reinterpret_cast<const uint16_t*>(frame->data[2]);
-                    std::ostringstream dbg;
-                    dbg << "[GPU] AVFrame first: "
-                        << (yDbg[0] >> 6) << "," << (yDbg[1] >> 6) << ","
-                        << (uDbg[0] >> 6) << "," << (vDbg[0] >> 6);
-                    LogProRes(dbg.str());
-                
                 }
             } else {
                 convertRawToRGB24(asU16(raw), cpParams, rgbBuf, threads);

--- a/src/Graphics/GpuYuvConverter.cpp
+++ b/src/Graphics/GpuYuvConverter.cpp
@@ -56,7 +56,7 @@ bool GpuYuvConverter::init(int width, int height) {
     VkPushConstantRange pcRange{};
     pcRange.stageFlags = VK_SHADER_STAGE_COMPUTE_BIT;
     pcRange.offset = 0;
-    pcRange.size = sizeof(int) * 2;
+    pcRange.size = sizeof(int) * 2 + sizeof(float) * 2;
 
     VkPipelineLayoutCreateInfo pli{};
     pli.sType = VK_STRUCTURE_TYPE_PIPELINE_LAYOUT_CREATE_INFO;
@@ -248,6 +248,7 @@ void GpuYuvConverter::cleanup() {
 }
 
 bool GpuYuvConverter::convertAndReadback(const uint16_t* raw, int width, int height,
+                                         float gainR, float gainB,
                                          std::vector<uint16_t>& outPacked) {
     LogProRes("[GPU] convertAndReadback invoked");
     VkDeviceSize rawSize = static_cast<VkDeviceSize>(width) * height * sizeof(uint16_t);
@@ -365,7 +366,7 @@ bool GpuYuvConverter::convertAndReadback(const uint16_t* raw, int width, int hei
     vkCmdBindPipeline(cmd, VK_PIPELINE_BIND_POINT_COMPUTE, m_pipeline);
     vkCmdBindDescriptorSets(cmd, VK_PIPELINE_BIND_POINT_COMPUTE, m_pipelineLayout, 0, 1, &m_descSet, 0, nullptr);
 
-    struct Push { int w; int h; } push{ width, height };
+    struct Push { int w; int h; float gainR; float gainB; } push{ width, height, gainR, gainB };
     vkCmdPushConstants(cmd, m_pipelineLayout, VK_SHADER_STAGE_COMPUTE_BIT, 0, sizeof(Push), &push);
 
     vkCmdDispatch(cmd, (uint32_t)((width + 15) / 16), (uint32_t)((height + 15) / 16), 1);

--- a/src/Graphics/ImageResource.cpp
+++ b/src/Graphics/ImageResource.cpp
@@ -74,7 +74,7 @@ namespace ImageResource {
         }
         else if (oldLayout == VK_IMAGE_LAYOUT_UNDEFINED && newLayout == VK_IMAGE_LAYOUT_GENERAL) {
             barrier.srcAccessMask = 0;
-            barrier.dstAccessMask = VK_ACCESS_SHADER_WRITE_BIT | VK_ACCESS_TRANSFER_WRITE_BIT;
+            barrier.dstAccessMask = VK_ACCESS_SHADER_WRITE_BIT;
             sourceStage = VK_PIPELINE_STAGE_TOP_OF_PIPE_BIT;
             destinationStage = VK_PIPELINE_STAGE_COMPUTE_SHADER_BIT;
         }

--- a/src/Graphics/VulkanHelpers.cpp
+++ b/src/Graphics/VulkanHelpers.cpp
@@ -5,6 +5,9 @@
 
 namespace VulkanHelpers {
 
+    // Global mutex ensuring queue submissions are serialised across threads
+    std::mutex gQueueMutex;
+
     std::vector<char> readFile(const std::string& filename) {
         std::string fullPath = filename;
         LogToFile(std::string("[VulkanHelpers::readFile] Attempting to read shader file: ") + fullPath);
@@ -64,8 +67,11 @@ namespace VulkanHelpers {
         submitInfo.commandBufferCount = 1;
         submitInfo.pCommandBuffers = &commandBuffer;
 
-        VK_CHECK_RENDERER(vkQueueSubmit(queue, 1, &submitInfo, VK_NULL_HANDLE));
-        VK_CHECK_RENDERER(vkQueueWaitIdle(queue));
+        {
+            std::lock_guard<std::mutex> lock(gQueueMutex);
+            VK_CHECK_RENDERER(vkQueueSubmit(queue, 1, &submitInfo, VK_NULL_HANDLE));
+            VK_CHECK_RENDERER(vkQueueWaitIdle(queue));
+        }
 
         vkFreeCommandBuffers(device, commandPool, 1, &commandBuffer);
     }

--- a/src/Utils/GpuProresFix.cpp
+++ b/src/Utils/GpuProresFix.cpp
@@ -1,0 +1,59 @@
+#include "Utils/GpuProresFix.h"
+#include <spdlog/spdlog.h>
+extern "C" {
+#include <libavutil/frame.h>
+#include <libavutil/imgutils.h>
+#include <libavutil/intreadwrite.h>
+}
+#include <vector>
+
+static inline bool validateMacroPixel(const uint16_t *p)
+{
+#ifdef PRORES_GPU_VALIDATE
+    return (p[0] <= 1023 && p[1] <= 1023 && p[2] <= 1023 && p[3] <= 1023);
+#else
+    (void)p; return true;
+#endif
+}
+
+bool copyFromGpuToFrame(const void *mappedGpuMemory,
+                        int w, int h,
+                        AVFrame *f, bool validate)
+{
+    const uint16_t *gpu = static_cast<const uint16_t *>(mappedGpuMemory);
+    f->format = AV_PIX_FMT_YUV422P10LE;
+    f->width = w;
+    f->height = h;
+    if (av_frame_get_buffer(f, 32) < 0) {
+        spdlog::error("[GPU-COPY] av_frame_get_buffer failed");
+        return false;
+    }
+
+    for (int y = 0; y < h; ++y) {
+        uint8_t* Y = f->data[0] + y * f->linesize[0];
+        uint8_t* U = f->data[1] + y * f->linesize[1];
+        uint8_t* V = f->data[2] + y * f->linesize[2];
+        size_t base = static_cast<size_t>(y) * (w / 2) * 4;
+        for (int x = 0; x < w; x += 2) {
+            size_t src = base + (x >> 1) * 4;
+            uint16_t y0 = gpu[src + 0];
+            uint16_t u  = gpu[src + 1];
+            uint16_t y1 = gpu[src + 2];
+            uint16_t v  = gpu[src + 3];
+            if (validate && !y && !x) {
+                if (!validateMacroPixel(&gpu[src])) {
+                    spdlog::error("[GPU-CHECK] Bad macro-pixel layout: Y0=%u U=%u Y1=%u V=%u", y0, u, y1, v);
+                    return false;
+                } else {
+                    spdlog::debug("[GPU-CHECK] Macropixel layout validated (Y0=%u U=%u Y1=%u V=%u)", y0, u, y1, v);
+                }
+            }
+            AV_WL16(Y + (x << 1),     y0 << 6);
+            AV_WL16(Y + ((x + 1) << 1), y1 << 6);
+            AV_WL16(U + ((x >> 1) << 1), u << 6);
+            AV_WL16(V + ((x >> 1) << 1), v << 6);
+        }
+    }
+    spdlog::debug("[GPU-COPY] Unpacked %dx%d frame", w, h);
+    return true;
+}


### PR DESCRIPTION
## Summary
- fix incorrect access mask in image layout transition for compute
- serialize vkQueueSubmit with a global mutex for thread safety
- pass white balance gains to compute shader and rebuild SPIR-V
- ensure ProRes GPU readback writes little-endian samples

## Testing
- `cmake -S . -B build` *(fails: Could not find FFMPEGConfig.cmake)*

------
https://chatgpt.com/codex/tasks/task_e_686ff18e9dbc8327af1d836719a4d8dd