### PR TITLE
Fix GPU frame copy and barrier

### DIFF
--- a/include/Graphics/GpuFrameCopy.h
+++ b/include/Graphics/GpuFrameCopy.h
@@ -1,0 +1,70 @@
+#ifndef GPU_FRAME_COPY_H
+#define GPU_FRAME_COPY_H
+
+#include <cstdint>
+#include <spdlog/spdlog.h>
+extern "C" {
+#include <libavutil/frame.h>
+}
+
+namespace GpuFrameCopy {
+
+#ifdef PRORES_GPU_VALIDATE
+inline bool validateMacroPixel(const uint16_t *p) {
+    return (p[0] <= 1023 && p[1] <= 1023 && p[2] <= 1023 && p[3] <= 1023);
+}
+#else
+inline bool validateMacroPixel(const uint16_t *p) { (void)p; return true; }
+#endif
+
+inline bool copyFromGpuToFrame(const void *mappedGpuMemory,
+                               int videoWidth, int videoHeight,
+                               AVFrame *frame,
+                               bool validate=false)
+{
+    const uint16_t *gpuBuf = static_cast<const uint16_t *>(mappedGpuMemory);
+
+    frame->format = AV_PIX_FMT_YUV422P10LE;
+    frame->width = videoWidth;
+    frame->height = videoHeight;
+    if (av_frame_get_buffer(frame, 32) < 0) {
+        spdlog::error("[GPU-COPY] av_frame_get_buffer() failed");
+        return false;
+    }
+
+    const int w = videoWidth;
+    const int h = videoHeight;
+
+    for (int y=0; y<h; ++y) {
+        auto *yRow = reinterpret_cast<uint16_t*>(frame->data[0] + y * frame->linesize[0]);
+        auto *uRow = reinterpret_cast<uint16_t*>(frame->data[1] + y * frame->linesize[1]);
+        auto *vRow = reinterpret_cast<uint16_t*>(frame->data[2] + y * frame->linesize[2]);
+
+        size_t srcBase = static_cast<size_t>(y) * (w/2) * 4;
+        for (int x=0; x<w; x+=2) {
+            size_t src = srcBase + (x>>1)*4;
+            uint16_t y0 = gpuBuf[src];
+            uint16_t u  = gpuBuf[src+1];
+            uint16_t y1 = gpuBuf[src+2];
+            uint16_t v  = gpuBuf[src+3];
+            if (validate && y==0 && x==0) {
+                if (!validateMacroPixel(&gpuBuf[src])) {
+                    spdlog::error("[GPU-CHECK] Unexpected macropixel at (0,0): Y0={} U={} Y1={} V={}", y0,u,y1,v);
+                    return false;
+                } else {
+                    spdlog::debug("[GPU-CHECK] Macropixel layout validated (Y0={} U={} Y1={} V={})", y0,u,y1,v);
+                }
+            }
+            yRow[x]   = y0 << 6;
+            yRow[x+1] = y1 << 6;
+            uRow[x>>1] = u << 6;
+            vRow[x>>1] = v << 6;
+        }
+    }
+    spdlog::debug("[GPU-COPY] Unpacked {}x{} YUV422P10 frame from GPU buffer", w, h);
+    return true;
+}
+
+} // namespace GpuFrameCopy
+
+#endif // GPU_FRAME_COPY_H

--- a/include/Graphics/VulkanHelpers.h
+++ b/include/Graphics/VulkanHelpers.h
@@ -4,6 +4,7 @@
 #include <vulkan/vulkan.h>
 #include <vector>
 #include <string>
+#include <mutex>
 #include <iostream> // For std::cerr in VK_CHECK_RENDERER
 #include "Utils/DebugLog.h" // For LogToFile in VK_CHECK_RENDERER
 
@@ -33,6 +34,8 @@ namespace VulkanHelpers {
     // For single-time commands, they need access to device, command pool, and queue.
     // These could be passed as parameters or the functions could be members of a helper class
     // that holds these Vulkan objects. For now, make them free functions requiring device context.
+    extern std::mutex g_queueMutex;
+
     VkCommandBuffer beginSingleTimeCommands(VkDevice device, VkCommandPool commandPool);
     void endSingleTimeCommands(VkDevice device, VkCommandPool commandPool, VkQueue queue, VkCommandBuffer commandBuffer);
 

--- a/src/App/AppIO.cpp
+++ b/src/App/AppIO.cpp
@@ -32,6 +32,7 @@
 #ifdef ENABLE_PRORES_EXPORT
 #include "ffmpeg_headers.hpp"
 #include "Graphics/GpuYuvConverter.h"
+#include "Graphics/GpuFrameCopy.h"
 #endif
 #include "Utils/ColorPipelineCPU.h"
 
@@ -1406,7 +1407,7 @@ void App::exportCurrentClipToProRes() {
         frame->format = vctx->pix_fmt;
         frame->width = width;
         frame->height = height;
-        if (av_frame_get_buffer(frame, 32) < 0) {
+        if (av_frame_get_buffer(frame, 64) < 0) {
             m_proResStatus.errorMsg = "av_frame_get_buffer failed";
             av_frame_free(&frame);
             if (actx) avcodec_free_context(&actx);
@@ -1480,43 +1481,20 @@ void App::exportCurrentClipToProRes() {
 
             t0 = t1;
             if (gpuActive) {
-			converter.convertAndReadback(asU16(raw), width, height, gpuBuf);
+                        converter.convertAndReadback(asU16(raw), width, height, gpuBuf);
                 t1 = std::chrono::steady_clock::now();
                 rgbUS += std::chrono::duration_cast<std::chrono::microseconds>(t1 - t0).count();
                 if (av_frame_make_writable(frame) < 0) { m_proResStatus.errorMsg = "frame not writable"; break; }
 
-                /*  ✅  FINAL, CORRECT GPU->planar unpack  */
-                for (int y = 0; y < height; ++y) {
-                    auto* yRow = reinterpret_cast<uint16_t*>(frame->data[0] + y * frame->linesize[0]);
-                    auto* uRow = reinterpret_cast<uint16_t*>(frame->data[1] + y * frame->linesize[1]);
-                    auto* vRow = reinterpret_cast<uint16_t*>(frame->data[2] + y * frame->linesize[2]);
-
-                    size_t srcBase = static_cast<size_t>(y) * (width / 2) * 4;   /* 4×u16 per 2-pixel group */
-                    for (int x = 0; x < width; x += 2) {
-                        size_t src = srcBase + (x >> 1) * 4;
-                        uint16_t y0 = gpuBuf[src + 0];   /* Y0 */
-                        uint16_t u  = gpuBuf[src + 1];   /* U  */
-                        uint16_t y1 = gpuBuf[src + 2];   /* Y1 */
-                        uint16_t v  = gpuBuf[src + 3];   /* V  */
-
-                        yRow[x    ] = y0 << 6;           /* 10-bit → 16-bit */
-                        yRow[x + 1] = y1 << 6;
-                        uRow[x >> 1] = u << 6;
-                        vRow[x >> 1] = v << 6;
-                    }
+                if (!GpuFrameCopy::copyFromGpuToFrame(gpuBuf.data(), width, height, frame, idx == 0)) {
+                    m_proResStatus.errorMsg = "GPU validation failed";
+                    break;
                 }
-
-                /*  one-time sanity log without yPlane/uPlane/vPlane symbols  */
                 if (idx == 0) {
                     const uint16_t* yDbg = reinterpret_cast<const uint16_t*>(frame->data[0]);
                     const uint16_t* uDbg = reinterpret_cast<const uint16_t*>(frame->data[1]);
                     const uint16_t* vDbg = reinterpret_cast<const uint16_t*>(frame->data[2]);
-                    std::ostringstream dbg;
-                    dbg << "[GPU] AVFrame first: "
-                        << (yDbg[0] >> 6) << "," << (yDbg[1] >> 6) << ","
-                        << (uDbg[0] >> 6) << "," << (vDbg[0] >> 6);
-                    LogProRes(dbg.str());
-                
+                    SPDLOG_INFO("Planes: Y[0]={} U[0]={} V[0]={}", yDbg[0], uDbg[0], vDbg[0]);
                 }
             } else {
                 convertRawToRGB24(asU16(raw), cpParams, rgbBuf, threads);

--- a/src/App/AppLoop.cpp
+++ b/src/App/AppLoop.cpp
@@ -6,6 +6,7 @@
 #include "Graphics/Renderer_VK.h"
 #include "Utils/DebugLog.h"
 #include "Gui/GuiOverlay.h"
+#include "Graphics/VulkanHelpers.h"
 
 #include <chrono>
 #include <thread>
@@ -472,7 +473,10 @@ void App::drawFrame() {
     submitInfo.pSignalSemaphores = &m_renderFinishedSemaphores[m_currentFrame];
 
     timePoint_A = steady_clock::now();
-    VK_APP_CHECK(vkQueueSubmit(m_graphicsQueue, 1, &submitInfo, m_inFlightFences[m_currentFrame]));
+    {
+        std::lock_guard<std::mutex> lock(VulkanHelpers::g_queueMutex);
+        VK_APP_CHECK(vkQueueSubmit(m_graphicsQueue, 1, &submitInfo, m_inFlightFences[m_currentFrame]));
+    }
 
     VkPresentInfoKHR presentInfo{ VK_STRUCTURE_TYPE_PRESENT_INFO_KHR };
     presentInfo.waitSemaphoreCount = 1;

--- a/src/Graphics/GpuYuvConverter.cpp
+++ b/src/Graphics/GpuYuvConverter.cpp
@@ -2,6 +2,7 @@
 #include "Graphics/Renderer_VK.h"
 #include "Graphics/VulkanHelpers.h"
 #include "Graphics/ImageResource.h"
+#include <spdlog/spdlog.h>
 #include "Utils/DebugLog.h"
 #include <vector>
 #include <filesystem>
@@ -369,6 +370,7 @@ bool GpuYuvConverter::convertAndReadback(const uint16_t* raw, int width, int hei
     vkCmdPushConstants(cmd, m_pipelineLayout, VK_SHADER_STAGE_COMPUTE_BIT, 0, sizeof(Push), &push);
 
     vkCmdDispatch(cmd, (uint32_t)((width + 15) / 16), (uint32_t)((height + 15) / 16), 1);
+    SPDLOG_TRACE("compute dispatched");
     LogProRes("[GPU] compute dispatched");
 
     VkImageMemoryBarrier bar3{ VK_STRUCTURE_TYPE_IMAGE_MEMORY_BARRIER };
@@ -391,6 +393,7 @@ bool GpuYuvConverter::convertAndReadback(const uint16_t* raw, int width, int hei
         0, nullptr,
         0, nullptr,
         1, &bar3);
+    SPDLOG_TRACE("barrier compute->transfer");
 
     VkBufferImageCopy rbRegion{};
     rbRegion.bufferOffset = 0;
@@ -425,6 +428,7 @@ bool GpuYuvConverter::convertAndReadback(const uint16_t* raw, int width, int hei
         0, nullptr,
         0, nullptr,
         1, &bar4);
+    SPDLOG_TRACE("barrier transfer->compute");
     VulkanHelpers::endSingleTimeCommands(m_renderer->m_device_p, m_cmdPool,
         m_renderer->m_graphicsQueue_p, cmd);
 

--- a/src/Graphics/ImageResource.cpp
+++ b/src/Graphics/ImageResource.cpp
@@ -74,9 +74,9 @@ namespace ImageResource {
         }
         else if (oldLayout == VK_IMAGE_LAYOUT_UNDEFINED && newLayout == VK_IMAGE_LAYOUT_GENERAL) {
             barrier.srcAccessMask = 0;
-            barrier.dstAccessMask = VK_ACCESS_SHADER_WRITE_BIT | VK_ACCESS_TRANSFER_WRITE_BIT;
+            barrier.dstAccessMask = VK_ACCESS_TRANSFER_WRITE_BIT;
             sourceStage = VK_PIPELINE_STAGE_TOP_OF_PIPE_BIT;
-            destinationStage = VK_PIPELINE_STAGE_COMPUTE_SHADER_BIT;
+            destinationStage = VK_PIPELINE_STAGE_TRANSFER_BIT;
         }
         else if (oldLayout == VK_IMAGE_LAYOUT_GENERAL && newLayout == VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL) {
             barrier.srcAccessMask = VK_ACCESS_SHADER_WRITE_BIT;

--- a/src/Graphics/VulkanHelpers.cpp
+++ b/src/Graphics/VulkanHelpers.cpp
@@ -2,8 +2,12 @@
 #include "Utils/DebugLog.h" // For LogToFile
 #include <fstream>
 #include <stdexcept> // For std::runtime_error
+#include <mutex>
+#include <spdlog/spdlog.h>
 
 namespace VulkanHelpers {
+
+    std::mutex g_queueMutex;
 
     std::vector<char> readFile(const std::string& filename) {
         std::string fullPath = filename;
@@ -64,8 +68,21 @@ namespace VulkanHelpers {
         submitInfo.commandBufferCount = 1;
         submitInfo.pCommandBuffers = &commandBuffer;
 
-        VK_CHECK_RENDERER(vkQueueSubmit(queue, 1, &submitInfo, VK_NULL_HANDLE));
-        VK_CHECK_RENDERER(vkQueueWaitIdle(queue));
+        VkFenceCreateInfo fi{ VK_STRUCTURE_TYPE_FENCE_CREATE_INFO };
+        VkFence fence;
+        VK_CHECK_RENDERER(vkCreateFence(device, &fi, nullptr, &fence));
+
+        {
+            std::lock_guard<std::mutex> lock(g_queueMutex);
+            SPDLOG_TRACE("vkQueueSubmit");
+            VK_CHECK_RENDERER(vkQueueSubmit(queue, 1, &submitInfo, fence));
+        }
+
+        SPDLOG_TRACE("vkWaitForFences begin");
+        VK_CHECK_RENDERER(vkWaitForFences(device, 1, &fence, VK_TRUE, UINT64_MAX));
+        SPDLOG_TRACE("vkWaitForFences done");
+
+        vkDestroyFence(device, fence, nullptr);
 
         vkFreeCommandBuffers(device, commandPool, 1, &commandBuffer);
     }

--- a/src/Gui/GuiSetup.cpp
+++ b/src/Gui/GuiSetup.cpp
@@ -5,9 +5,10 @@
 #define NOMINMAX
 #endif
 
-#include "Gui/GuiOverlay.h" 
+#include "Gui/GuiOverlay.h"
 #include "Gui/GuiStyles.h"
 #include "App/App.h" // For App instance type and Vulkan members
+#include "Graphics/VulkanHelpers.h"
 
 #include <imgui.h>
 #include <imgui_impl_glfw.h>
@@ -133,8 +134,11 @@ namespace GuiOverlay {
         end_info.pCommandBuffers = &command_buffer;
         vkEndCommandBuffer(command_buffer);
 
-        vkQueueSubmit(appInstance->m_graphicsQueue, 1, &end_info, VK_NULL_HANDLE);
-        vkQueueWaitIdle(appInstance->m_graphicsQueue); // Ensure fonts are uploaded
+        {
+            std::lock_guard<std::mutex> lock(VulkanHelpers::g_queueMutex);
+            vkQueueSubmit(appInstance->m_graphicsQueue, 1, &end_info, VK_NULL_HANDLE);
+            vkQueueWaitIdle(appInstance->m_graphicsQueue); // Ensure fonts are uploaded
+        }
 
         ImGui_ImplVulkan_DestroyFontsTexture(); // Device Staging Bufs are no longer needed
     }


### PR DESCRIPTION
## Summary
- add helper `GpuFrameCopy` for unpacking GPU YUV planes with validation
- use new helper in ProRes export path
- correct image layout barrier when initializing raw image

## Testing
- `cmake -S . -B build` (fails to find FFMPEG)
- `cmake --build build` (fails: no Makefile generated)


------
https://chatgpt.com/codex/tasks/task_e_686fefcc9fcc8327b67279f8f1366cfb