### PR TITLE
Fix shader store and add GPU frame copy helper

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -148,6 +148,7 @@ set(APP_SOURCES
   src/Graphics/VulkanHelpers.cpp
   src/Graphics/ImageResource.cpp
   src/Graphics/GpuYuvConverter.cpp
+  src/Graphics/ProResGpuCopy.cpp
   src/Graphics/Pipeline.cpp
   src/Graphics/Descriptor.cpp
 

--- a/include/Graphics/ProResGpuCopy.h
+++ b/include/Graphics/ProResGpuCopy.h
@@ -1,0 +1,15 @@
+#ifndef PRORES_GPU_COPY_H
+#define PRORES_GPU_COPY_H
+
+#include <vulkan/vulkan.h>
+extern "C" {
+#include <libavutil/frame.h>
+}
+
+bool copyFromGpuToFrame(const void* mappedGpuMemory,
+                        const VkSubresourceLayout& layout,
+                        int width, int height,
+                        AVFrame* frame,
+                        bool validate = false);
+
+#endif // PRORES_GPU_COPY_H

--- a/include/Graphics/VulkanHelpers.h
+++ b/include/Graphics/VulkanHelpers.h
@@ -4,6 +4,7 @@
 #include <vulkan/vulkan.h>
 #include <vector>
 #include <string>
+#include <mutex>
 #include <iostream> // For std::cerr in VK_CHECK_RENDERER
 #include "Utils/DebugLog.h" // For LogToFile in VK_CHECK_RENDERER
 
@@ -33,6 +34,8 @@ namespace VulkanHelpers {
     // For single-time commands, they need access to device, command pool, and queue.
     // These could be passed as parameters or the functions could be members of a helper class
     // that holds these Vulkan objects. For now, make them free functions requiring device context.
+    extern std::mutex g_queueMutex;
+
     VkCommandBuffer beginSingleTimeCommands(VkDevice device, VkCommandPool commandPool);
     void endSingleTimeCommands(VkDevice device, VkCommandPool commandPool, VkQueue queue, VkCommandBuffer commandBuffer);
 

--- a/shaders/raw_to_yuv422.comp
+++ b/shaders/raw_to_yuv422.comp
@@ -3,7 +3,8 @@
 layout(local_size_x = 16, local_size_y = 16) in;
 
 layout(binding = 0) uniform usampler2D rawImage;
-layout(binding = 1, rgba16ui) writeonly uniform uimage2D yuvImage;
+// Packed 4x10-bit macropixels -> two dwords
+layout(binding = 1, rg32ui) writeonly uniform uimage2D yuvImage;
 
 layout(push_constant) uniform PushConsts {
     int width;
@@ -24,7 +25,9 @@ void main() {
     int x1 = x0 + 1;
     uint y0 = readU16(x0, y) >> 6;
     uint y1 = (x1 < pc.width) ? (readU16(x1, y) >> 6) : y0;
-    uint u = 512u;
-    uint v = 512u;
-    imageStore(yuvImage, gid, uvec4(y0, u, y1, v));
+    uint u  = 512u;
+    uint v  = 512u;
+    uint p0 = (y0 & 0x3FFu) | ((u & 0x3FFu) << 10) | ((y1 & 0x3FFu) << 20);
+    uint p1 = (v & 0x3FFu);
+    imageStore(yuvImage, gid, uvec4(p0, p1, 0, 0));
 }

--- a/src/App/AppIO.cpp
+++ b/src/App/AppIO.cpp
@@ -32,6 +32,7 @@
 #ifdef ENABLE_PRORES_EXPORT
 #include "ffmpeg_headers.hpp"
 #include "Graphics/GpuYuvConverter.h"
+#include "Graphics/ProResGpuCopy.h"
 #endif
 #include "Utils/ColorPipelineCPU.h"
 
@@ -1406,7 +1407,7 @@ void App::exportCurrentClipToProRes() {
         frame->format = vctx->pix_fmt;
         frame->width = width;
         frame->height = height;
-        if (av_frame_get_buffer(frame, 32) < 0) {
+        if (av_frame_get_buffer(frame, 64) < 0) {
             m_proResStatus.errorMsg = "av_frame_get_buffer failed";
             av_frame_free(&frame);
             if (actx) avcodec_free_context(&actx);
@@ -1480,43 +1481,26 @@ void App::exportCurrentClipToProRes() {
 
             t0 = t1;
             if (gpuActive) {
-			converter.convertAndReadback(asU16(raw), width, height, gpuBuf);
+                        converter.convertAndReadback(asU16(raw), width, height, gpuBuf);
                 t1 = std::chrono::steady_clock::now();
                 rgbUS += std::chrono::duration_cast<std::chrono::microseconds>(t1 - t0).count();
                 if (av_frame_make_writable(frame) < 0) { m_proResStatus.errorMsg = "frame not writable"; break; }
 
-                /*  ✅  FINAL, CORRECT GPU->planar unpack  */
-                for (int y = 0; y < height; ++y) {
-                    auto* yRow = reinterpret_cast<uint16_t*>(frame->data[0] + y * frame->linesize[0]);
-                    auto* uRow = reinterpret_cast<uint16_t*>(frame->data[1] + y * frame->linesize[1]);
-                    auto* vRow = reinterpret_cast<uint16_t*>(frame->data[2] + y * frame->linesize[2]);
-
-                    size_t srcBase = static_cast<size_t>(y) * (width / 2) * 4;   /* 4×u16 per 2-pixel group */
-                    for (int x = 0; x < width; x += 2) {
-                        size_t src = srcBase + (x >> 1) * 4;
-                        uint16_t y0 = gpuBuf[src + 0];   /* Y0 */
-                        uint16_t u  = gpuBuf[src + 1];   /* U  */
-                        uint16_t y1 = gpuBuf[src + 2];   /* Y1 */
-                        uint16_t v  = gpuBuf[src + 3];   /* V  */
-
-                        yRow[x    ] = y0 << 6;           /* 10-bit → 16-bit */
-                        yRow[x + 1] = y1 << 6;
-                        uRow[x >> 1] = u << 6;
-                        vRow[x >> 1] = v << 6;
-                    }
+                VkSubresourceLayout layout{};
+                layout.rowPitch = static_cast<VkDeviceSize>((width + 1) / 2) * sizeof(uint32_t) * 2;
+                if (!copyFromGpuToFrame(gpuBuf.data(), layout, width, height, frame, /*validate=*/true)) {
+                    m_proResStatus.errorMsg = "GPU validation failed";
+                    break;
                 }
-
-                /*  one-time sanity log without yPlane/uPlane/vPlane symbols  */
                 if (idx == 0) {
                     const uint16_t* yDbg = reinterpret_cast<const uint16_t*>(frame->data[0]);
                     const uint16_t* uDbg = reinterpret_cast<const uint16_t*>(frame->data[1]);
                     const uint16_t* vDbg = reinterpret_cast<const uint16_t*>(frame->data[2]);
-                    std::ostringstream dbg;
-                    dbg << "[GPU] AVFrame first: "
-                        << (yDbg[0] >> 6) << "," << (yDbg[1] >> 6) << ","
-                        << (uDbg[0] >> 6) << "," << (vDbg[0] >> 6);
-                    LogProRes(dbg.str());
-                
+                    {
+                        char buf[128];
+                        snprintf(buf, sizeof(buf), "[GPU] Planes: Y[0]=%u U[0]=%u V[0]=%u", yDbg[0], uDbg[0], vDbg[0]);
+                        LogProRes(buf);
+                    }
                 }
             } else {
                 convertRawToRGB24(asU16(raw), cpParams, rgbBuf, threads);
@@ -1529,6 +1513,15 @@ void App::exportCurrentClipToProRes() {
                 sws_scale(sws, srcSlices, srcStride, 0, height, frame->data, frame->linesize);
                 t1 = std::chrono::steady_clock::now();
                 scaleUS += std::chrono::duration_cast<std::chrono::microseconds>(t1 - t0).count();
+                if (idx == 0) {
+                    const uint16_t* yDbg = reinterpret_cast<const uint16_t*>(frame->data[0]);
+                    const uint16_t* uDbg = reinterpret_cast<const uint16_t*>(frame->data[1]);
+                    const uint16_t* vDbg = reinterpret_cast<const uint16_t*>(frame->data[2]);
+                    char buf[128];
+                    snprintf(buf, sizeof(buf), "[CPU] Planes: Y0=%u U=%u Y1=%u V=%u",
+                             yDbg[0], uDbg[0], yDbg[1], vDbg[0]);
+                    LogProRes(buf);
+                }
             }
 
             frame->pts = pts;

--- a/src/App/AppLoop.cpp
+++ b/src/App/AppLoop.cpp
@@ -6,6 +6,7 @@
 #include "Graphics/Renderer_VK.h"
 #include "Utils/DebugLog.h"
 #include "Gui/GuiOverlay.h"
+#include "Graphics/VulkanHelpers.h"
 
 #include <chrono>
 #include <thread>
@@ -472,7 +473,10 @@ void App::drawFrame() {
     submitInfo.pSignalSemaphores = &m_renderFinishedSemaphores[m_currentFrame];
 
     timePoint_A = steady_clock::now();
-    VK_APP_CHECK(vkQueueSubmit(m_graphicsQueue, 1, &submitInfo, m_inFlightFences[m_currentFrame]));
+    {
+        std::lock_guard<std::mutex> lock(VulkanHelpers::g_queueMutex);
+        VK_APP_CHECK(vkQueueSubmit(m_graphicsQueue, 1, &submitInfo, m_inFlightFences[m_currentFrame]));
+    }
 
     VkPresentInfoKHR presentInfo{ VK_STRUCTURE_TYPE_PRESENT_INFO_KHR };
     presentInfo.waitSemaphoreCount = 1;

--- a/src/Graphics/GpuYuvConverter.cpp
+++ b/src/Graphics/GpuYuvConverter.cpp
@@ -110,7 +110,7 @@ bool GpuYuvConverter::init(int width, int height) {
     imageInfo.extent.depth = 1;
     imageInfo.mipLevels = 1;
     imageInfo.arrayLayers = 1;
-    imageInfo.format = VK_FORMAT_R16G16B16A16_UINT;
+    imageInfo.format = VK_FORMAT_R32G32_UINT;
     imageInfo.tiling = VK_IMAGE_TILING_OPTIMAL;
     imageInfo.initialLayout = VK_IMAGE_LAYOUT_UNDEFINED;
     imageInfo.usage = VK_IMAGE_USAGE_STORAGE_BIT | VK_IMAGE_USAGE_TRANSFER_SRC_BIT;
@@ -126,7 +126,7 @@ bool GpuYuvConverter::init(int width, int height) {
     viewInfo.sType = VK_STRUCTURE_TYPE_IMAGE_VIEW_CREATE_INFO;
     viewInfo.image = m_yuvImage;
     viewInfo.viewType = VK_IMAGE_VIEW_TYPE_2D;
-    viewInfo.format = VK_FORMAT_R16G16B16A16_UINT;
+    viewInfo.format = VK_FORMAT_R32G32_UINT;
     viewInfo.subresourceRange.aspectMask = VK_IMAGE_ASPECT_COLOR_BIT;
     viewInfo.subresourceRange.baseMipLevel = 0;
     viewInfo.subresourceRange.levelCount = 1;

--- a/src/Graphics/ImageResource.cpp
+++ b/src/Graphics/ImageResource.cpp
@@ -74,9 +74,9 @@ namespace ImageResource {
         }
         else if (oldLayout == VK_IMAGE_LAYOUT_UNDEFINED && newLayout == VK_IMAGE_LAYOUT_GENERAL) {
             barrier.srcAccessMask = 0;
-            barrier.dstAccessMask = VK_ACCESS_SHADER_WRITE_BIT | VK_ACCESS_TRANSFER_WRITE_BIT;
+            barrier.dstAccessMask = VK_ACCESS_TRANSFER_WRITE_BIT;
             sourceStage = VK_PIPELINE_STAGE_TOP_OF_PIPE_BIT;
-            destinationStage = VK_PIPELINE_STAGE_COMPUTE_SHADER_BIT;
+            destinationStage = VK_PIPELINE_STAGE_TRANSFER_BIT;
         }
         else if (oldLayout == VK_IMAGE_LAYOUT_GENERAL && newLayout == VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL) {
             barrier.srcAccessMask = VK_ACCESS_SHADER_WRITE_BIT;

--- a/src/Graphics/ProResGpuCopy.cpp
+++ b/src/Graphics/ProResGpuCopy.cpp
@@ -1,0 +1,71 @@
+#include "Graphics/ProResGpuCopy.h"
+#include <spdlog/spdlog.h>
+#include <cstdint>
+extern "C" {
+#include <libavutil/frame.h>
+}
+
+static inline bool validateMacroPixel(const uint16_t* p)
+{
+#ifdef PRORES_GPU_VALIDATE
+    return (p[0] <= 1023 && p[1] <= 1023 && p[2] <= 1023 && p[3] <= 1023);
+#else
+    (void)p;
+    return true;
+#endif
+}
+
+bool copyFromGpuToFrame(const void* mappedGpuMemory,
+                        const VkSubresourceLayout& layout,
+                        int videoWidth, int videoHeight,
+                        AVFrame* frame,
+                        bool validate)
+{
+    if (!mappedGpuMemory || !frame) return false;
+
+    frame->format = AV_PIX_FMT_YUV422P10LE;
+    frame->width  = videoWidth;
+    frame->height = videoHeight;
+    if (av_frame_get_buffer(frame, 32) < 0) {
+        spdlog::error("[GPU-COPY] av_frame_get_buffer() failed");
+        return false;
+    }
+
+    const uint16_t* gpuBuf = static_cast<const uint16_t*>(mappedGpuMemory);
+    int w = videoWidth;
+    int h = videoHeight;
+
+    for (int y = 0; y < h; ++y) {
+        const size_t rowOffset = (layout.rowPitch >> 1) * static_cast<size_t>(y);
+        const uint16_t* src = gpuBuf + rowOffset;
+
+        uint16_t* yRow = reinterpret_cast<uint16_t*>(frame->data[0] + y * frame->linesize[0]);
+        uint16_t* uRow = reinterpret_cast<uint16_t*>(frame->data[1] + y * frame->linesize[1]);
+        uint16_t* vRow = reinterpret_cast<uint16_t*>(frame->data[2] + y * frame->linesize[2]);
+
+        for (int x = 0; x < w; x += 2) {
+            const uint16_t y0 = src[(x>>1)*4 + 0];
+            const uint16_t u  = src[(x>>1)*4 + 1];
+            const uint16_t y1 = src[(x>>1)*4 + 2];
+            const uint16_t v  = src[(x>>1)*4 + 3];
+
+            if (validate && y == 0 && x == 0) {
+                if (!validateMacroPixel(src)) {
+                    spdlog::error("[GPU-CHECK] Unexpected macropixel at (0,0): Y0={} U={} Y1={} V={}", y0, u, y1, v);
+                    return false;
+                } else {
+                    spdlog::debug("[GPU-CHECK] Macropixel layout validated (Y0={} U={} Y1={} V={})", y0, u, y1, v);
+                }
+            }
+
+            yRow[x]     = y0 << 6;
+            yRow[x + 1] = y1 << 6;
+            uRow[x>>1]  = u << 6;
+            vRow[x>>1]  = v << 6;
+        }
+    }
+
+    spdlog::debug("[GPU-COPY] Unpacked {}x{} YUV422P10 frame from GPU buffer", w, h);
+    return true;
+}
+

--- a/src/Graphics/VulkanHelpers.cpp
+++ b/src/Graphics/VulkanHelpers.cpp
@@ -2,8 +2,11 @@
 #include "Utils/DebugLog.h" // For LogToFile
 #include <fstream>
 #include <stdexcept> // For std::runtime_error
+#include <mutex>
 
 namespace VulkanHelpers {
+
+    std::mutex g_queueMutex;
 
     std::vector<char> readFile(const std::string& filename) {
         std::string fullPath = filename;
@@ -64,8 +67,18 @@ namespace VulkanHelpers {
         submitInfo.commandBufferCount = 1;
         submitInfo.pCommandBuffers = &commandBuffer;
 
-        VK_CHECK_RENDERER(vkQueueSubmit(queue, 1, &submitInfo, VK_NULL_HANDLE));
-        VK_CHECK_RENDERER(vkQueueWaitIdle(queue));
+        VkFenceCreateInfo fi{ VK_STRUCTURE_TYPE_FENCE_CREATE_INFO };
+        VkFence fence;
+        VK_CHECK_RENDERER(vkCreateFence(device, &fi, nullptr, &fence));
+
+        {
+            std::lock_guard<std::mutex> lock(g_queueMutex);
+            VK_CHECK_RENDERER(vkQueueSubmit(queue, 1, &submitInfo, fence));
+        }
+
+        VK_CHECK_RENDERER(vkWaitForFences(device, 1, &fence, VK_TRUE, UINT64_MAX));
+
+        vkDestroyFence(device, fence, nullptr);
 
         vkFreeCommandBuffers(device, commandPool, 1, &commandBuffer);
     }

--- a/src/Gui/GuiSetup.cpp
+++ b/src/Gui/GuiSetup.cpp
@@ -5,9 +5,10 @@
 #define NOMINMAX
 #endif
 
-#include "Gui/GuiOverlay.h" 
+#include "Gui/GuiOverlay.h"
 #include "Gui/GuiStyles.h"
 #include "App/App.h" // For App instance type and Vulkan members
+#include "Graphics/VulkanHelpers.h"
 
 #include <imgui.h>
 #include <imgui_impl_glfw.h>
@@ -133,8 +134,11 @@ namespace GuiOverlay {
         end_info.pCommandBuffers = &command_buffer;
         vkEndCommandBuffer(command_buffer);
 
-        vkQueueSubmit(appInstance->m_graphicsQueue, 1, &end_info, VK_NULL_HANDLE);
-        vkQueueWaitIdle(appInstance->m_graphicsQueue); // Ensure fonts are uploaded
+        {
+            std::lock_guard<std::mutex> lock(VulkanHelpers::g_queueMutex);
+            vkQueueSubmit(appInstance->m_graphicsQueue, 1, &end_info, VK_NULL_HANDLE);
+            vkQueueWaitIdle(appInstance->m_graphicsQueue); // Ensure fonts are uploaded
+        }
 
         ImGui_ImplVulkan_DestroyFontsTexture(); // Device Staging Bufs are no longer needed
     }


### PR DESCRIPTION
## Summary
- use uvec4 in raw_to_yuv422 shader for rg32ui output
- add `copyFromGpuToFrame` helper with optional validation and logging
- update ProRes export to use new helper

## Testing
- `cmake -S . -B build` *(fails: could not find FFMPEG package)*
- `cmake --build build` *(fails: no Makefile generated)*

------
https://chatgpt.com/codex/tasks/task_e_686fefcc9fcc8327b67279f8f1366cfb