### PR TITLE
Fix GPU YUV export regression

### DIFF
--- a/include/Graphics/GpuYuvConverter.h
+++ b/include/Graphics/GpuYuvConverter.h
@@ -5,6 +5,7 @@
 #include <vector>
 #include <cstdint>
 #include "Utils/vma_usage.h"
+#include "Utils/ColorPipelineCPU.h"
 
 class Renderer_VK;
 
@@ -17,6 +18,7 @@ public:
     void cleanup();
 
     bool convertAndReadback(const uint16_t* raw, int width, int height,
+                            const CPUColorParams& params,
                             std::vector<uint16_t>& outPacked);
 private:
     Renderer_VK* m_renderer;

--- a/shaders/raw_to_yuv422.comp
+++ b/shaders/raw_to_yuv422.comp
@@ -8,7 +8,19 @@ layout(binding = 1, rgba16ui) writeonly uniform uimage2D yuvImage;
 layout(push_constant) uniform PushConsts {
     int width;
     int height;
+    int cfaType;
+    float blackLevel;
+    float invRange;
+    float gainR;
+    float gainG;
+    float gainB;
+    mat3 ccm;
+    float saturation;
 } pc;
+
+float linFromRaw(uint v) {
+    return clamp((float(v) - pc.blackLevel) * pc.invRange, 0.0, 1.0);
+}
 
 uint readU16(int x, int y) {
     x = clamp(x, 0, pc.width - 1);
@@ -16,15 +28,54 @@ uint readU16(int x, int y) {
     return texelFetch(rawImage, ivec2(x, y), 0).r;
 }
 
-void main() {
+float lin(int x,int y){ return linFromRaw(readU16(x,y)); }
+float interpG(int x,int y){ return 0.25*(lin(x+1,y)+lin(x-1,y)+lin(x,y+1)+lin(x,y-1)); }
+float interpH(int x,int y){ return 0.5*(lin(x+1,y)+lin(x-1,y)); }
+float interpV(int x,int y){ return 0.5*(lin(x,y+1)+lin(x,y-1)); }
+float interpD(int x,int y){ return 0.25*(lin(x+1,y+1)+lin(x-1,y+1)+lin(x+1,y-1)+lin(x-1,y-1)); }
+
+float srgb_eotf(float v){ v = clamp(v,0.0,1.0); return (v<=0.0031308)? v*12.92 : 1.055*pow(v,1.0/2.4)-0.055; }
+
+vec3 processPixel(int x,int y){
+    bool ye = (y%2)==0;
+    bool xe = (x%2)==0;
+    float r=0.0,g=0.0,b=0.0;
+    if(pc.cfaType==0){
+        if(ye){ if(xe){ b=lin(x,y); g=interpG(x,y); r=interpD(x,y); } else { g=lin(x,y); r=interpV(x,y); b=interpH(x,y); } }
+        else{ if(xe){ g=lin(x,y); r=interpH(x,y); b=interpV(x,y); } else { r=lin(x,y); g=interpG(x,y); b=interpD(x,y); } }
+    }else if(pc.cfaType==1){
+        if(ye){ if(xe){ r=lin(x,y); g=interpG(x,y); b=interpD(x,y); } else { g=lin(x,y); r=interpH(x,y); b=interpV(x,y); } }
+        else{ if(xe){ g=lin(x,y); r=interpV(x,y); b=interpH(x,y); } else { b=lin(x,y); g=interpG(x,y); r=interpD(x,y); } }
+    }else if(pc.cfaType==2){
+        if(ye){ if(xe){ g=lin(x,y); r=interpV(x,y); b=interpH(x,y); } else { b=lin(x,y); g=interpG(x,y); r=interpD(x,y); } }
+        else{ if(xe){ r=lin(x,y); g=interpG(x,y); b=interpD(x,y); } else { g=lin(x,y); r=interpH(x,y); b=interpV(x,y); } }
+    }else{
+        if(ye){ if(xe){ g=lin(x,y); r=interpH(x,y); b=interpV(x,y); } else { r=lin(x,y); g=interpG(x,y); b=interpD(x,y); } }
+        else{ if(xe){ b=lin(x,y); g=interpG(x,y); r=interpD(x,y); } else { g=lin(x,y); r=interpV(x,y); b=interpH(x,y); } }
+    }
+    vec3 wb = clamp(vec3(r,g,b) * vec3(pc.gainR, pc.gainG, pc.gainB), 0.0, 1.0);
+    vec3 cc = clamp(pc.ccm * wb, 0.0, 1.0);
+    float lum = dot(cc, vec3(0.2126,0.7152,0.0722));
+    vec3 sat = mix(vec3(lum), cc, pc.saturation);
+    return vec3(srgb_eotf(sat.r), srgb_eotf(sat.g), srgb_eotf(sat.b));
+}
+
+void main(){
     ivec2 gid = ivec2(gl_GlobalInvocationID.xy);
     int x0 = gid.x * 2;
     int y = gid.y;
-    if (x0 >= pc.width || y >= pc.height) return;
+    if(x0 >= pc.width || y >= pc.height) return;
     int x1 = x0 + 1;
-    uint y0 = readU16(x0, y) >> 6;
-    uint y1 = (x1 < pc.width) ? (readU16(x1, y) >> 6) : y0;
-    uint u = 512u;
-    uint v = 512u;
-    imageStore(yuvImage, gid, uvec4(y0, u, y1, v));
+    vec3 rgb0 = processPixel(x0, y);
+    vec3 rgb1 = (x1 < pc.width) ? processPixel(x1, y) : rgb0;
+    float y0 = clamp(0.2126*rgb0.r + 0.7152*rgb0.g + 0.0722*rgb0.b, 0.0, 1.0);
+    float y1 = clamp(0.2126*rgb1.r + 0.7152*rgb1.g + 0.0722*rgb1.b, 0.0, 1.0);
+    vec3 avg = 0.5*(rgb0 + rgb1);
+    float u = clamp((avg.b - (0.2126*avg.r + 0.7152*avg.g + 0.0722*avg.b))/1.8556 + 0.5, 0.0, 1.0);
+    float v = clamp((avg.r - (0.2126*avg.r + 0.7152*avg.g + 0.0722*avg.b))/1.5748 + 0.5, 0.0, 1.0);
+    uint Y0 = uint(y0 * 1023.0 + 0.5);
+    uint Y1 = uint(y1 * 1023.0 + 0.5);
+    uint U = uint(u * 1023.0 + 0.5);
+    uint V = uint(v * 1023.0 + 0.5);
+    imageStore(yuvImage, gid, uvec4(Y0, U, Y1, V));
 }

--- a/src/App/AppIO.cpp
+++ b/src/App/AppIO.cpp
@@ -1501,7 +1501,7 @@ void App::exportCurrentClipToProRes() {
 
             t0 = t1;
             if (gpuActive) {
-			converter.convertAndReadback(asU16(raw), width, height, gpuBuf);
+                        converter.convertAndReadback(asU16(raw), width, height, cpParams, gpuBuf);
                 t1 = std::chrono::steady_clock::now();
                 rgbUS += std::chrono::duration_cast<std::chrono::microseconds>(t1 - t0).count();
                 if (av_frame_make_writable(frame) < 0) { m_proResStatus.errorMsg = "frame not writable"; break; }

--- a/src/Graphics/GpuYuvConverter.cpp
+++ b/src/Graphics/GpuYuvConverter.cpp
@@ -3,11 +3,25 @@
 #include "Graphics/VulkanHelpers.h"
 #include "Graphics/ImageResource.h"
 #include "Utils/DebugLog.h"
+#include "Utils/ColorPipelineCPU.h"
 #include <vector>
 #include <filesystem>
 #include <chrono>
 
 extern std::string g_AppBasePath;
+
+struct PushConsts {
+    int width;
+    int height;
+    int cfaType;
+    float blackLevel;
+    float invRange;
+    float gainR;
+    float gainG;
+    float gainB;
+    float ccm[12]; // 3x4 to match std430 alignment of mat3
+    float saturation;
+};
 
 GpuYuvConverter::GpuYuvConverter(Renderer_VK* renderer)
     : m_renderer(renderer) {}
@@ -56,7 +70,7 @@ bool GpuYuvConverter::init(int width, int height) {
     VkPushConstantRange pcRange{};
     pcRange.stageFlags = VK_SHADER_STAGE_COMPUTE_BIT;
     pcRange.offset = 0;
-    pcRange.size = sizeof(int) * 2;
+    pcRange.size = sizeof(PushConsts);
 
     VkPipelineLayoutCreateInfo pli{};
     pli.sType = VK_STRUCTURE_TYPE_PIPELINE_LAYOUT_CREATE_INFO;
@@ -248,6 +262,7 @@ void GpuYuvConverter::cleanup() {
 }
 
 bool GpuYuvConverter::convertAndReadback(const uint16_t* raw, int width, int height,
+                                         const CPUColorParams& params,
                                          std::vector<uint16_t>& outPacked) {
     LogProRes("[GPU] convertAndReadback invoked");
     VkDeviceSize rawSize = static_cast<VkDeviceSize>(width) * height * sizeof(uint16_t);
@@ -365,8 +380,27 @@ bool GpuYuvConverter::convertAndReadback(const uint16_t* raw, int width, int hei
     vkCmdBindPipeline(cmd, VK_PIPELINE_BIND_POINT_COMPUTE, m_pipeline);
     vkCmdBindDescriptorSets(cmd, VK_PIPELINE_BIND_POINT_COMPUTE, m_pipelineLayout, 0, 1, &m_descSet, 0, nullptr);
 
-    struct Push { int w; int h; } push{ width, height };
-    vkCmdPushConstants(cmd, m_pipelineLayout, VK_SHADER_STAGE_COMPUTE_BIT, 0, sizeof(Push), &push);
+    PushConsts pc{};
+    pc.width = width;
+    pc.height = height;
+    pc.cfaType = params.cfaType;
+    pc.blackLevel = static_cast<float>(params.blackLevel);
+    pc.invRange = (params.whiteLevel - params.blackLevel != 0.0) ?
+                   static_cast<float>(1.0 / (params.whiteLevel - params.blackLevel)) : 1.0f;
+    pc.gainR = params.gainR;
+    pc.gainG = params.gainG;
+    pc.gainB = params.gainB;
+    for (int c = 0; c < 3; ++c) {
+        for (int r = 0; r < 3; ++r) {
+            // GLSL matrices are column-major; transpose the row-major CPU
+            // matrix when packing push constants
+            pc.ccm[c*4 + r] = params.ccm[r*3 + c];
+        }
+        pc.ccm[c*4 + 3] = 0.0f; // padding per column
+    }
+    pc.saturation = params.saturation;
+    vkCmdPushConstants(cmd, m_pipelineLayout, VK_SHADER_STAGE_COMPUTE_BIT,
+                       0, sizeof(PushConsts), &pc);
 
     vkCmdDispatch(cmd, (uint32_t)((width + 15) / 16), (uint32_t)((height + 15) / 16), 1);
     LogProRes("[GPU] compute dispatched");


### PR DESCRIPTION
## Summary
- revert accidental removal of GPU YUV pipeline
- restore compute shader color conversion and parameter passing

## Testing
- `cmake -S . -B build` *(fails: Could not find package configuration file provided by "FFMPEG")*

------
https://chatgpt.com/codex/tasks/task_e_687152ea43d88327a37b9ea76874da11