### PR TITLE
Implement planar GPU YUV conversion

### DIFF
--- a/include/Graphics/GpuYuvConverter.h
+++ b/include/Graphics/GpuYuvConverter.h
@@ -4,6 +4,7 @@
 #include <vulkan/vulkan.h>
 #include <vector>
 #include <cstdint>
+#include <libavutil/frame.h>
 #include "Utils/vma_usage.h"
 
 class Renderer_VK;
@@ -16,8 +17,8 @@ public:
     bool init(int width, int height);
     void cleanup();
 
-    bool convertAndReadback(const uint16_t* raw, int width, int height,
-                            std::vector<uint16_t>& outPacked);
+    bool convertToFrame(const uint16_t* raw, int width, int height, AVFrame* frame,
+                        const float wbGains[3], const float rgb2yuv[9]);
 private:
     Renderer_VK* m_renderer;
 
@@ -27,9 +28,9 @@ private:
     VkDescriptorPool m_descPool{VK_NULL_HANDLE};
     VkDescriptorSet m_descSet{VK_NULL_HANDLE};
 
-    VkImage m_yuvImage{VK_NULL_HANDLE};
-    VmaAllocation m_yuvAlloc{VK_NULL_HANDLE};
-    VkImageView m_yuvView{VK_NULL_HANDLE};
+    VkImage m_planeImages[3]{VK_NULL_HANDLE, VK_NULL_HANDLE, VK_NULL_HANDLE};
+    VmaAllocation m_planeAllocs[3]{VK_NULL_HANDLE, VK_NULL_HANDLE, VK_NULL_HANDLE};
+    VkImageView m_planeViews[3]{VK_NULL_HANDLE, VK_NULL_HANDLE, VK_NULL_HANDLE};
 
     VkCommandPool m_cmdPool{VK_NULL_HANDLE};
 

--- a/shaders/raw_to_yuv422.comp
+++ b/shaders/raw_to_yuv422.comp
@@ -3,12 +3,26 @@
 layout(local_size_x = 16, local_size_y = 16) in;
 
 layout(binding = 0) uniform usampler2D rawImage;
-layout(binding = 1, rgba16ui) writeonly uniform uimage2D yuvImage;
+layout(binding = 1, r16ui) writeonly uniform uimage2D yPlane;
+layout(binding = 2, r16ui) writeonly uniform uimage2D uPlane;
+layout(binding = 3, r16ui) writeonly uniform uimage2D vPlane;
 
 layout(push_constant) uniform PushConsts {
     int width;
     int height;
+    vec3 wbGains;
+    mat3 rgb2yuv;
 } pc;
+
+const float kYmul = 876.0;
+const float kCmul = 896.0;
+const float kYoff = 64.0;
+const float kCoff = 512.0;
+const mat3 kRGB2YUV = mat3(
+    0.183,  0.614,  0.062,
+   -0.101, -0.339,  0.439,
+    0.439, -0.399, -0.040
+);
 
 uint readU16(int x, int y) {
     x = clamp(x, 0, pc.width - 1);
@@ -16,15 +30,61 @@ uint readU16(int x, int y) {
     return texelFetch(rawImage, ivec2(x, y), 0).r;
 }
 
+vec3 demosaic(int x, int y) {
+    bool ye = (y & 1) == 0;
+    bool xe = (x & 1) == 0;
+    float r = 0.0, g = 0.0, b = 0.0;
+    if (ye) {
+        if (xe) { // B
+            b = float(readU16(x, y));
+            g = 0.25 * (float(readU16(x+1,y)) + float(readU16(x-1,y)) + float(readU16(x,y+1)) + float(readU16(x,y-1)));
+            r = 0.25 * (float(readU16(x+1,y+1)) + float(readU16(x-1,y+1)) + float(readU16(x+1,y-1)) + float(readU16(x-1,y-1)));
+        } else { // G
+            g = float(readU16(x,y));
+            r = 0.5 * (float(readU16(x+1,y)) + float(readU16(x-1,y)));
+            b = 0.5 * (float(readU16(x,y+1)) + float(readU16(x,y-1)));
+        }
+    } else {
+        if (xe) { // G
+            g = float(readU16(x,y));
+            r = 0.5 * (float(readU16(x,y+1)) + float(readU16(x,y-1)));
+            b = 0.5 * (float(readU16(x+1,y)) + float(readU16(x-1,y)));
+        } else { // R
+            r = float(readU16(x,y));
+            g = 0.25 * (float(readU16(x+1,y)) + float(readU16(x-1,y)) + float(readU16(x,y+1)) + float(readU16(x,y-1)));
+            b = 0.25 * (float(readU16(x+1,y+1)) + float(readU16(x-1,y+1)) + float(readU16(x+1,y-1)) + float(readU16(x-1,y-1)));
+        }
+    }
+    return vec3(r,g,b) * pc.wbGains / 1023.0; // assume 10-bit raw
+}
+
 void main() {
     ivec2 gid = ivec2(gl_GlobalInvocationID.xy);
     int x0 = gid.x * 2;
     int y = gid.y;
     if (x0 >= pc.width || y >= pc.height) return;
-    int x1 = x0 + 1;
-    uint y0 = readU16(x0, y) >> 6;
-    uint y1 = (x1 < pc.width) ? (readU16(x1, y) >> 6) : y0;
-    uint u = 512u;
-    uint v = 512u;
-    imageStore(yuvImage, gid, uvec4(y0, u, y1, v));
+    int x1 = min(x0 + 1, pc.width - 1);
+
+    vec3 rgb0 = demosaic(x0, y);
+    vec3 rgb1 = demosaic(x1, y);
+
+    vec3 yuv0 = (pc.rgb2yuv * rgb0) * kRGB2YUV;
+    vec3 yuv1 = (pc.rgb2yuv * rgb1) * kRGB2YUV;
+
+    float Y0 = yuv0.x * kYmul + kYoff;
+    float U0 = yuv0.y * kCmul + kCoff;
+    float V0 = yuv0.z * kCmul + kCoff;
+    float Y1 = yuv1.x * kYmul + kYoff;
+    float U1 = yuv1.y * kCmul + kCoff;
+    float V1 = yuv1.z * kCmul + kCoff;
+
+    uint y0 = uint(clamp(round(Y0), 0.0, 1023.0)) << 6;
+    uint y1 = uint(clamp(round(Y1), 0.0, 1023.0)) << 6;
+    uint uVal = uint(clamp(round((U0+U1)*0.5), 0.0, 1023.0)) << 6;
+    uint vVal = uint(clamp(round((V0+V1)*0.5), 0.0, 1023.0)) << 6;
+
+    imageStore(yPlane, ivec2(x0, y), uvec4(y0,0,0,0));
+    imageStore(yPlane, ivec2(x1, y), uvec4(y1,0,0,0));
+    imageStore(uPlane, ivec2(x0/2, y), uvec4(uVal,0,0,0));
+    imageStore(vPlane, ivec2(x0/2, y), uvec4(vVal,0,0,0));
 }

--- a/src/App/AppIO.cpp
+++ b/src/App/AppIO.cpp
@@ -1442,6 +1442,15 @@ void App::exportCurrentClipToProRes() {
         }
         cpParams.saturation = 1.0f;
 
+        float wb[3] = { cpParams.gainR, cpParams.gainG, cpParams.gainB };
+        const float rgb2yuvBase[9] = {
+            0.183f, 0.614f, 0.062f,
+           -0.101f,-0.339f, 0.439f,
+            0.439f,-0.399f,-0.040f
+        };
+        float rgb2yuv[9];
+        for(int i=0;i<9;++i) rgb2yuv[i] = rgb2yuvBase[i];
+
         {
             std::ostringstream oss;
             oss << "[ProResExport] Metadata: black=" << cpParams.blackLevel
@@ -1467,7 +1476,6 @@ void App::exportCurrentClipToProRes() {
         AVPacket pkt{};
 
         std::vector<uint8_t> rgbBuf;
-        std::vector<uint16_t> gpuBuf;
         int64_t pts = 0;
         for (size_t idx = 0; idx < frames.size(); ++idx) {
             RawBytes raw;
@@ -1480,44 +1488,10 @@ void App::exportCurrentClipToProRes() {
 
             t0 = t1;
             if (gpuActive) {
-			converter.convertAndReadback(asU16(raw), width, height, gpuBuf);
+                if (av_frame_make_writable(frame) < 0) { m_proResStatus.errorMsg = "frame not writable"; break; }
+                converter.convertToFrame(asU16(raw), width, height, frame, wb, rgb2yuv);
                 t1 = std::chrono::steady_clock::now();
                 rgbUS += std::chrono::duration_cast<std::chrono::microseconds>(t1 - t0).count();
-                if (av_frame_make_writable(frame) < 0) { m_proResStatus.errorMsg = "frame not writable"; break; }
-
-                /*  ✅  FINAL, CORRECT GPU->planar unpack  */
-                for (int y = 0; y < height; ++y) {
-                    auto* yRow = reinterpret_cast<uint16_t*>(frame->data[0] + y * frame->linesize[0]);
-                    auto* uRow = reinterpret_cast<uint16_t*>(frame->data[1] + y * frame->linesize[1]);
-                    auto* vRow = reinterpret_cast<uint16_t*>(frame->data[2] + y * frame->linesize[2]);
-
-                    size_t srcBase = static_cast<size_t>(y) * (width / 2) * 4;   /* 4×u16 per 2-pixel group */
-                    for (int x = 0; x < width; x += 2) {
-                        size_t src = srcBase + (x >> 1) * 4;
-                        uint16_t y0 = gpuBuf[src + 0];   /* Y0 */
-                        uint16_t u  = gpuBuf[src + 1];   /* U  */
-                        uint16_t y1 = gpuBuf[src + 2];   /* Y1 */
-                        uint16_t v  = gpuBuf[src + 3];   /* V  */
-
-                        yRow[x    ] = y0 << 6;           /* 10-bit → 16-bit */
-                        yRow[x + 1] = y1 << 6;
-                        uRow[x >> 1] = u << 6;
-                        vRow[x >> 1] = v << 6;
-                    }
-                }
-
-                /*  one-time sanity log without yPlane/uPlane/vPlane symbols  */
-                if (idx == 0) {
-                    const uint16_t* yDbg = reinterpret_cast<const uint16_t*>(frame->data[0]);
-                    const uint16_t* uDbg = reinterpret_cast<const uint16_t*>(frame->data[1]);
-                    const uint16_t* vDbg = reinterpret_cast<const uint16_t*>(frame->data[2]);
-                    std::ostringstream dbg;
-                    dbg << "[GPU] AVFrame first: "
-                        << (yDbg[0] >> 6) << "," << (yDbg[1] >> 6) << ","
-                        << (uDbg[0] >> 6) << "," << (vDbg[0] >> 6);
-                    LogProRes(dbg.str());
-                
-                }
             } else {
                 convertRawToRGB24(asU16(raw), cpParams, rgbBuf, threads);
                 t1 = std::chrono::steady_clock::now();

--- a/src/Graphics/GpuYuvConverter.cpp
+++ b/src/Graphics/GpuYuvConverter.cpp
@@ -6,6 +6,7 @@
 #include <vector>
 #include <filesystem>
 #include <chrono>
+#include <sstream>
 
 extern std::string g_AppBasePath;
 
@@ -37,26 +38,28 @@ bool GpuYuvConverter::init(int width, int height) {
     ci.flags = VK_COMMAND_POOL_CREATE_RESET_COMMAND_BUFFER_BIT | VK_COMMAND_POOL_CREATE_TRANSIENT_BIT;
     VK_CHECK_RENDERER(vkCreateCommandPool(m_renderer->m_device_p, &ci, nullptr, &m_cmdPool));
 
-    VkDescriptorSetLayoutBinding bindings[2]{};
+    VkDescriptorSetLayoutBinding bindings[4]{};
     bindings[0].binding = 0;
     bindings[0].descriptorType = VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER;
     bindings[0].descriptorCount = 1;
     bindings[0].stageFlags = VK_SHADER_STAGE_COMPUTE_BIT;
-    bindings[1].binding = 1;
-    bindings[1].descriptorType = VK_DESCRIPTOR_TYPE_STORAGE_IMAGE;
-    bindings[1].descriptorCount = 1;
-    bindings[1].stageFlags = VK_SHADER_STAGE_COMPUTE_BIT;
+    for (int i = 0; i < 3; ++i) {
+        bindings[1 + i].binding = 1 + i;
+        bindings[1 + i].descriptorType = VK_DESCRIPTOR_TYPE_STORAGE_IMAGE;
+        bindings[1 + i].descriptorCount = 1;
+        bindings[1 + i].stageFlags = VK_SHADER_STAGE_COMPUTE_BIT;
+    }
 
     VkDescriptorSetLayoutCreateInfo layoutCI{};
     layoutCI.sType = VK_STRUCTURE_TYPE_DESCRIPTOR_SET_LAYOUT_CREATE_INFO;
-    layoutCI.bindingCount = 2;
+    layoutCI.bindingCount = 4;
     layoutCI.pBindings = bindings;
     VK_CHECK_RENDERER(vkCreateDescriptorSetLayout(m_renderer->m_device_p, &layoutCI, nullptr, &m_setLayout));
 
     VkPushConstantRange pcRange{};
     pcRange.stageFlags = VK_SHADER_STAGE_COMPUTE_BIT;
     pcRange.offset = 0;
-    pcRange.size = sizeof(int) * 2;
+    pcRange.size = sizeof(int) * 2 + sizeof(float) * 3 + sizeof(float) * 9;
 
     VkPipelineLayoutCreateInfo pli{};
     pli.sType = VK_STRUCTURE_TYPE_PIPELINE_LAYOUT_CREATE_INFO;
@@ -80,15 +83,17 @@ bool GpuYuvConverter::init(int width, int height) {
 
     vkDestroyShaderModule(m_renderer->m_device_p, module, nullptr);
 
-    VkDescriptorPoolSize poolSizes[2]{};
+    VkDescriptorPoolSize poolSizes[4]{};
     poolSizes[0].type = VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER;
     poolSizes[0].descriptorCount = 1;
-    poolSizes[1].type = VK_DESCRIPTOR_TYPE_STORAGE_IMAGE;
-    poolSizes[1].descriptorCount = 1;
+    for (int i = 0; i < 3; ++i) {
+        poolSizes[1 + i].type = VK_DESCRIPTOR_TYPE_STORAGE_IMAGE;
+        poolSizes[1 + i].descriptorCount = 1;
+    }
     VkDescriptorPoolCreateInfo poolCI{};
     poolCI.sType = VK_STRUCTURE_TYPE_DESCRIPTOR_POOL_CREATE_INFO;
     poolCI.maxSets = 1;
-    poolCI.poolSizeCount = 2;
+    poolCI.poolSizeCount = 4;
     poolCI.pPoolSizes = poolSizes;
     VK_CHECK_RENDERER(vkCreateDescriptorPool(m_renderer->m_device_p, &poolCI, nullptr, &m_descPool));
 
@@ -101,46 +106,48 @@ bool GpuYuvConverter::init(int width, int height) {
     LogProRes("[GPU] Compute pipeline initialized");
     LogProRes("[GPU] init complete");
 
-    // Create YUV image for compute output
-    VkImageCreateInfo imageInfo{};
-    imageInfo.sType = VK_STRUCTURE_TYPE_IMAGE_CREATE_INFO;
-    imageInfo.imageType = VK_IMAGE_TYPE_2D;
-    imageInfo.extent.width = static_cast<uint32_t>((width + 1) / 2);
-    imageInfo.extent.height = static_cast<uint32_t>(height);
-    imageInfo.extent.depth = 1;
-    imageInfo.mipLevels = 1;
-    imageInfo.arrayLayers = 1;
-    imageInfo.format = VK_FORMAT_R16G16B16A16_UINT;
-    imageInfo.tiling = VK_IMAGE_TILING_OPTIMAL;
-    imageInfo.initialLayout = VK_IMAGE_LAYOUT_UNDEFINED;
-    imageInfo.usage = VK_IMAGE_USAGE_STORAGE_BIT | VK_IMAGE_USAGE_TRANSFER_SRC_BIT;
-    imageInfo.sharingMode = VK_SHARING_MODE_EXCLUSIVE;
-    imageInfo.samples = VK_SAMPLE_COUNT_1_BIT;
+    // Create Y, U and V images for compute output
+    for (int i = 0; i < 3; ++i) {
+        VkImageCreateInfo imageInfo{};
+        imageInfo.sType = VK_STRUCTURE_TYPE_IMAGE_CREATE_INFO;
+        imageInfo.imageType = VK_IMAGE_TYPE_2D;
+        imageInfo.extent.width = static_cast<uint32_t>(i == 0 ? width : (width + 1) / 2);
+        imageInfo.extent.height = static_cast<uint32_t>(height);
+        imageInfo.extent.depth = 1;
+        imageInfo.mipLevels = 1;
+        imageInfo.arrayLayers = 1;
+        imageInfo.format = VK_FORMAT_R16_UINT;
+        imageInfo.tiling = VK_IMAGE_TILING_OPTIMAL;
+        imageInfo.initialLayout = VK_IMAGE_LAYOUT_UNDEFINED;
+        imageInfo.usage = VK_IMAGE_USAGE_STORAGE_BIT | VK_IMAGE_USAGE_TRANSFER_SRC_BIT;
+        imageInfo.sharingMode = VK_SHARING_MODE_EXCLUSIVE;
+        imageInfo.samples = VK_SAMPLE_COUNT_1_BIT;
 
-    VmaAllocationCreateInfo allocInfo{};
-    allocInfo.usage = VMA_MEMORY_USAGE_AUTO_PREFER_DEVICE;
+        VmaAllocationCreateInfo allocInfo{};
+        allocInfo.usage = VMA_MEMORY_USAGE_AUTO_PREFER_DEVICE;
 
-    VK_CHECK_RENDERER(vmaCreateImage(m_renderer->m_allocator_p, &imageInfo, &allocInfo, &m_yuvImage, &m_yuvAlloc, nullptr));
+        VK_CHECK_RENDERER(vmaCreateImage(m_renderer->m_allocator_p, &imageInfo, &allocInfo,
+                                         &m_planeImages[i], &m_planeAllocs[i], nullptr));
 
-    VkImageViewCreateInfo viewInfo{};
-    viewInfo.sType = VK_STRUCTURE_TYPE_IMAGE_VIEW_CREATE_INFO;
-    viewInfo.image = m_yuvImage;
-    viewInfo.viewType = VK_IMAGE_VIEW_TYPE_2D;
-    viewInfo.format = VK_FORMAT_R16G16B16A16_UINT;
-    viewInfo.subresourceRange.aspectMask = VK_IMAGE_ASPECT_COLOR_BIT;
-    viewInfo.subresourceRange.baseMipLevel = 0;
-    viewInfo.subresourceRange.levelCount = 1;
-    viewInfo.subresourceRange.baseArrayLayer = 0;
-    viewInfo.subresourceRange.layerCount = 1;
-    VK_CHECK_RENDERER(vkCreateImageView(m_renderer->m_device_p, &viewInfo, nullptr, &m_yuvView));
+        VkImageViewCreateInfo viewInfo{ VK_STRUCTURE_TYPE_IMAGE_VIEW_CREATE_INFO };
+        viewInfo.image = m_planeImages[i];
+        viewInfo.viewType = VK_IMAGE_VIEW_TYPE_2D;
+        viewInfo.format = VK_FORMAT_R16_UINT;
+        viewInfo.subresourceRange.aspectMask = VK_IMAGE_ASPECT_COLOR_BIT;
+        viewInfo.subresourceRange.baseMipLevel = 0;
+        viewInfo.subresourceRange.levelCount = 1;
+        viewInfo.subresourceRange.baseArrayLayer = 0;
+        viewInfo.subresourceRange.layerCount = 1;
+        VK_CHECK_RENDERER(vkCreateImageView(m_renderer->m_device_p, &viewInfo, nullptr, &m_planeViews[i]));
 
-    ImageResource::transitionImageLayout(
-        m_renderer->m_device_p,
-        m_cmdPool,
-        m_renderer->m_graphicsQueue_p,
-        m_yuvImage,
-        VK_IMAGE_LAYOUT_UNDEFINED,
-        VK_IMAGE_LAYOUT_GENERAL);
+        ImageResource::transitionImageLayout(
+            m_renderer->m_device_p,
+            m_cmdPool,
+            m_renderer->m_graphicsQueue_p,
+            m_planeImages[i],
+            VK_IMAGE_LAYOUT_UNDEFINED,
+            VK_IMAGE_LAYOUT_GENERAL);
+    }
 
     // Create private RAW image for input
     VkImageCreateInfo rawInfo{ VK_STRUCTURE_TYPE_IMAGE_CREATE_INFO };
@@ -216,14 +223,16 @@ void GpuYuvConverter::cleanup() {
         m_rawImage = VK_NULL_HANDLE;
         m_rawAlloc = VK_NULL_HANDLE;
     }
-    if (m_yuvView != VK_NULL_HANDLE) {
-        vkDestroyImageView(m_renderer->m_device_p, m_yuvView, nullptr);
-        m_yuvView = VK_NULL_HANDLE;
-    }
-    if (m_yuvImage != VK_NULL_HANDLE) {
-        vmaDestroyImage(m_renderer->m_allocator_p, m_yuvImage, m_yuvAlloc);
-        m_yuvImage = VK_NULL_HANDLE;
-        m_yuvAlloc = VK_NULL_HANDLE;
+    for (int i = 0; i < 3; ++i) {
+        if (m_planeViews[i] != VK_NULL_HANDLE) {
+            vkDestroyImageView(m_renderer->m_device_p, m_planeViews[i], nullptr);
+            m_planeViews[i] = VK_NULL_HANDLE;
+        }
+        if (m_planeImages[i] != VK_NULL_HANDLE) {
+            vmaDestroyImage(m_renderer->m_allocator_p, m_planeImages[i], m_planeAllocs[i]);
+            m_planeImages[i] = VK_NULL_HANDLE;
+            m_planeAllocs[i] = VK_NULL_HANDLE;
+        }
     }
     if (m_descPool != VK_NULL_HANDLE) {
         vkDestroyDescriptorPool(m_renderer->m_device_p, m_descPool, nullptr);
@@ -247,11 +256,13 @@ void GpuYuvConverter::cleanup() {
     }
 }
 
-bool GpuYuvConverter::convertAndReadback(const uint16_t* raw, int width, int height,
-                                         std::vector<uint16_t>& outPacked) {
-    LogProRes("[GPU] convertAndReadback invoked");
+bool GpuYuvConverter::convertToFrame(const uint16_t* raw, int width, int height,
+                                     AVFrame* frame,
+                                     const float wbGains[3], const float rgb2yuv[9]) {
+    LogProRes("[GPU] convertToFrame invoked");
     VkDeviceSize rawSize = static_cast<VkDeviceSize>(width) * height * sizeof(uint16_t);
-    VkDeviceSize outSize = static_cast<VkDeviceSize>(width) * height * 4;
+    VkDeviceSize ySize = static_cast<VkDeviceSize>(width) * height * sizeof(uint16_t);
+    VkDeviceSize cSize = static_cast<VkDeviceSize>((width / 2)) * height * sizeof(uint16_t);
 
     VkBuffer stagingBuf = VK_NULL_HANDLE;
     VmaAllocation stagingAlloc = VK_NULL_HANDLE;
@@ -268,18 +279,20 @@ bool GpuYuvConverter::convertAndReadback(const uint16_t* raw, int width, int hei
     memcpy(sbAllocInfo.pMappedData, raw, rawSize);
     vmaFlushAllocation(m_renderer->m_allocator_p, stagingAlloc, 0, rawSize);
 
-    VkBuffer readbackBuf = VK_NULL_HANDLE;
-    VmaAllocation readbackAlloc = VK_NULL_HANDLE;
-    VkBufferCreateInfo rbInfo{ VK_STRUCTURE_TYPE_BUFFER_CREATE_INFO };
-    rbInfo.size = outSize;
-    rbInfo.usage = VK_BUFFER_USAGE_TRANSFER_DST_BIT;
-    VmaAllocationCreateInfo rbAlloc{};
-    rbAlloc.usage = VMA_MEMORY_USAGE_AUTO_PREFER_HOST;
-    rbAlloc.flags = VMA_ALLOCATION_CREATE_HOST_ACCESS_RANDOM_BIT |
-                    VMA_ALLOCATION_CREATE_MAPPED_BIT;
-    VmaAllocationInfo rbAllocInfo{};
-    VK_CHECK_RENDERER(vmaCreateBuffer(m_renderer->m_allocator_p, &rbInfo, &rbAlloc,
-                                      &readbackBuf, &readbackAlloc, &rbAllocInfo));
+    VkBuffer readbackBuf[3]{VK_NULL_HANDLE, VK_NULL_HANDLE, VK_NULL_HANDLE};
+    VmaAllocation readbackAlloc[3]{VK_NULL_HANDLE, VK_NULL_HANDLE, VK_NULL_HANDLE};
+    VmaAllocationInfo rbAllocInfo[3]{};
+    for (int i = 0; i < 3; ++i) {
+        VkBufferCreateInfo rbInfo{ VK_STRUCTURE_TYPE_BUFFER_CREATE_INFO };
+        rbInfo.size = (i == 0 ? ySize : cSize);
+        rbInfo.usage = VK_BUFFER_USAGE_TRANSFER_DST_BIT;
+        VmaAllocationCreateInfo rbAlloc{};
+        rbAlloc.usage = VMA_MEMORY_USAGE_AUTO_PREFER_HOST;
+        rbAlloc.flags = VMA_ALLOCATION_CREATE_HOST_ACCESS_RANDOM_BIT |
+                        VMA_ALLOCATION_CREATE_MAPPED_BIT;
+        VK_CHECK_RENDERER(vmaCreateBuffer(m_renderer->m_allocator_p, &rbInfo, &rbAlloc,
+                                          &readbackBuf[i], &readbackAlloc[i], &rbAllocInfo[i]));
+    }
 
     VkCommandBuffer cmd = VulkanHelpers::beginSingleTimeCommands(m_renderer->m_device_p,
                                                                 m_cmdPool);
@@ -343,97 +356,123 @@ bool GpuYuvConverter::convertAndReadback(const uint16_t* raw, int width, int hei
     inputInfo.imageView = m_rawView;
     inputInfo.imageLayout = VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL;
 
-    VkDescriptorImageInfo outInfo{};
-    outInfo.imageView = m_yuvView;
-    outInfo.imageLayout = VK_IMAGE_LAYOUT_GENERAL;
+    VkDescriptorImageInfo outInfos[3]{};
+    for(int i=0;i<3;++i){
+        outInfos[i].imageView = m_planeViews[i];
+        outInfos[i].imageLayout = VK_IMAGE_LAYOUT_GENERAL;
+    }
 
-    VkWriteDescriptorSet writes[2]{};
+    VkWriteDescriptorSet writes[4]{};
     writes[0].sType = VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET;
     writes[0].dstSet = m_descSet;
     writes[0].dstBinding = 0;
     writes[0].descriptorCount = 1;
     writes[0].descriptorType = VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER;
     writes[0].pImageInfo = &inputInfo;
-    writes[1].sType = VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET;
-    writes[1].dstSet = m_descSet;
-    writes[1].dstBinding = 1;
-    writes[1].descriptorCount = 1;
-    writes[1].descriptorType = VK_DESCRIPTOR_TYPE_STORAGE_IMAGE;
-    writes[1].pImageInfo = &outInfo;
-    vkUpdateDescriptorSets(m_renderer->m_device_p, 2, writes, 0, nullptr);
+    for(int i=0;i<3;++i){
+        writes[1+i].sType = VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET;
+        writes[1+i].dstSet = m_descSet;
+        writes[1+i].dstBinding = 1 + i;
+        writes[1+i].descriptorCount = 1;
+        writes[1+i].descriptorType = VK_DESCRIPTOR_TYPE_STORAGE_IMAGE;
+        writes[1+i].pImageInfo = &outInfos[i];
+    }
+    vkUpdateDescriptorSets(m_renderer->m_device_p, 4, writes, 0, nullptr);
 
     vkCmdBindPipeline(cmd, VK_PIPELINE_BIND_POINT_COMPUTE, m_pipeline);
     vkCmdBindDescriptorSets(cmd, VK_PIPELINE_BIND_POINT_COMPUTE, m_pipelineLayout, 0, 1, &m_descSet, 0, nullptr);
 
-    struct Push { int w; int h; } push{ width, height };
+    struct Push {
+        int w; int h;
+        float gains[3];
+        float mtx[9];
+    } push{};
+    push.w = width; push.h = height;
+    for(int i=0;i<3;++i) push.gains[i] = wbGains[i];
+    for(int i=0;i<9;++i) push.mtx[i] = rgb2yuv[i];
     vkCmdPushConstants(cmd, m_pipelineLayout, VK_SHADER_STAGE_COMPUTE_BIT, 0, sizeof(Push), &push);
 
     vkCmdDispatch(cmd, (uint32_t)((width + 15) / 16), (uint32_t)((height + 15) / 16), 1);
     LogProRes("[GPU] compute dispatched");
 
-    VkImageMemoryBarrier bar3{ VK_STRUCTURE_TYPE_IMAGE_MEMORY_BARRIER };
-    bar3.oldLayout = VK_IMAGE_LAYOUT_GENERAL;
-    bar3.newLayout = VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL;
-    bar3.srcQueueFamilyIndex = VK_QUEUE_FAMILY_IGNORED;
-    bar3.dstQueueFamilyIndex = VK_QUEUE_FAMILY_IGNORED;
-    bar3.image = m_yuvImage;
-    bar3.subresourceRange.aspectMask = VK_IMAGE_ASPECT_COLOR_BIT;
-    bar3.subresourceRange.baseMipLevel = 0;
-    bar3.subresourceRange.levelCount = 1;
-    bar3.subresourceRange.baseArrayLayer = 0;
-    bar3.subresourceRange.layerCount = 1;
-    bar3.srcAccessMask = VK_ACCESS_SHADER_WRITE_BIT;
-    bar3.dstAccessMask = VK_ACCESS_TRANSFER_READ_BIT;
-    vkCmdPipelineBarrier(cmd,
-        VK_PIPELINE_STAGE_COMPUTE_SHADER_BIT,
-        VK_PIPELINE_STAGE_TRANSFER_BIT,
-        0,
-        0, nullptr,
-        0, nullptr,
-        1, &bar3);
+    for(int i=0;i<3;++i){
+        VkImageMemoryBarrier bar{ VK_STRUCTURE_TYPE_IMAGE_MEMORY_BARRIER };
+        bar.oldLayout = VK_IMAGE_LAYOUT_GENERAL;
+        bar.newLayout = VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL;
+        bar.srcQueueFamilyIndex = VK_QUEUE_FAMILY_IGNORED;
+        bar.dstQueueFamilyIndex = VK_QUEUE_FAMILY_IGNORED;
+        bar.image = m_planeImages[i];
+        bar.subresourceRange.aspectMask = VK_IMAGE_ASPECT_COLOR_BIT;
+        bar.subresourceRange.baseMipLevel = 0;
+        bar.subresourceRange.levelCount = 1;
+        bar.subresourceRange.baseArrayLayer = 0;
+        bar.subresourceRange.layerCount = 1;
+        bar.srcAccessMask = VK_ACCESS_SHADER_WRITE_BIT;
+        bar.dstAccessMask = VK_ACCESS_TRANSFER_READ_BIT;
+        vkCmdPipelineBarrier(cmd,
+            VK_PIPELINE_STAGE_COMPUTE_SHADER_BIT,
+            VK_PIPELINE_STAGE_TRANSFER_BIT,
+            0,
+            0, nullptr,
+            0, nullptr,
+            1, &bar);
 
-    VkBufferImageCopy rbRegion{};
-    rbRegion.bufferOffset = 0;
-    rbRegion.bufferRowLength = 0;
-    rbRegion.bufferImageHeight = 0;
-    rbRegion.imageSubresource.aspectMask = VK_IMAGE_ASPECT_COLOR_BIT;
-    rbRegion.imageSubresource.mipLevel = 0;
-    rbRegion.imageSubresource.baseArrayLayer = 0;
-    rbRegion.imageSubresource.layerCount = 1;
-    rbRegion.imageOffset = {0,0,0};
-    rbRegion.imageExtent = { static_cast<uint32_t>((width + 1) / 2), static_cast<uint32_t>(height), 1 };
-    vkCmdCopyImageToBuffer(cmd, m_yuvImage, VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL,
-                           readbackBuf, 1, &rbRegion);
+        VkBufferImageCopy rbRegion{};
+        rbRegion.bufferOffset = 0;
+        rbRegion.bufferRowLength = 0;
+        rbRegion.bufferImageHeight = 0;
+        rbRegion.imageSubresource.aspectMask = VK_IMAGE_ASPECT_COLOR_BIT;
+        rbRegion.imageSubresource.mipLevel = 0;
+        rbRegion.imageSubresource.baseArrayLayer = 0;
+        rbRegion.imageSubresource.layerCount = 1;
+        rbRegion.imageOffset = {0,0,0};
+        rbRegion.imageExtent = { static_cast<uint32_t>(i==0?width:(width+1)/2), static_cast<uint32_t>(height), 1 };
+        vkCmdCopyImageToBuffer(cmd, m_planeImages[i], VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL,
+                               readbackBuf[i], 1, &rbRegion);
 
-    VkImageMemoryBarrier bar4{ VK_STRUCTURE_TYPE_IMAGE_MEMORY_BARRIER };
-    bar4.oldLayout = VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL;
-    bar4.newLayout = VK_IMAGE_LAYOUT_GENERAL;
-    bar4.srcQueueFamilyIndex = VK_QUEUE_FAMILY_IGNORED;
-    bar4.dstQueueFamilyIndex = VK_QUEUE_FAMILY_IGNORED;
-    bar4.image = m_yuvImage;
-    bar4.subresourceRange.aspectMask = VK_IMAGE_ASPECT_COLOR_BIT;
-    bar4.subresourceRange.baseMipLevel = 0;
-    bar4.subresourceRange.levelCount = 1;
-    bar4.subresourceRange.baseArrayLayer = 0;
-    bar4.subresourceRange.layerCount = 1;
-    bar4.srcAccessMask = VK_ACCESS_TRANSFER_READ_BIT;
-    bar4.dstAccessMask = VK_ACCESS_SHADER_READ_BIT | VK_ACCESS_SHADER_WRITE_BIT;
-    vkCmdPipelineBarrier(cmd,
-        VK_PIPELINE_STAGE_TRANSFER_BIT,
-        VK_PIPELINE_STAGE_COMPUTE_SHADER_BIT,
-        0,
-        0, nullptr,
-        0, nullptr,
-        1, &bar4);
+        bar.oldLayout = VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL;
+        bar.newLayout = VK_IMAGE_LAYOUT_GENERAL;
+        bar.srcAccessMask = VK_ACCESS_TRANSFER_READ_BIT;
+        bar.dstAccessMask = VK_ACCESS_SHADER_READ_BIT | VK_ACCESS_SHADER_WRITE_BIT;
+        vkCmdPipelineBarrier(cmd,
+            VK_PIPELINE_STAGE_TRANSFER_BIT,
+            VK_PIPELINE_STAGE_COMPUTE_SHADER_BIT,
+            0,
+            0, nullptr,
+            0, nullptr,
+            1, &bar);
+    }
     VulkanHelpers::endSingleTimeCommands(m_renderer->m_device_p, m_cmdPool,
         m_renderer->m_graphicsQueue_p, cmd);
 
-    vmaInvalidateAllocation(m_renderer->m_allocator_p, readbackAlloc, 0, outSize);
-    outPacked.resize(static_cast<size_t>(outSize / sizeof(uint16_t)));
-    memcpy(outPacked.data(), rbAllocInfo.pMappedData, outSize);
+    for(int i=0;i<3;++i){
+        VkDeviceSize size = (i==0? ySize : cSize);
+        vmaInvalidateAllocation(m_renderer->m_allocator_p, readbackAlloc[i], 0, size);
+    }
+
+    for(int y=0;y<height;++y){
+        const uint8_t* srcY = reinterpret_cast<const uint8_t*>(rbAllocInfo[0].pMappedData) + y*width*2;
+        uint8_t* dstY = frame->data[0] + y*frame->linesize[0];
+        memcpy(dstY, srcY, width*2);
+        const uint8_t* srcU = reinterpret_cast<const uint8_t*>(rbAllocInfo[1].pMappedData) + y*width;
+        const uint8_t* srcV = reinterpret_cast<const uint8_t*>(rbAllocInfo[2].pMappedData) + y*width;
+        uint8_t* dstU = frame->data[1] + y*frame->linesize[1];
+        uint8_t* dstV = frame->data[2] + y*frame->linesize[2];
+        memcpy(dstU, srcU, width);
+        memcpy(dstV, srcV, width);
+        if(y==0){
+            uint16_t y0 = *reinterpret_cast<const uint16_t*>(dstY);
+            uint16_t u0 = *reinterpret_cast<const uint16_t*>(dstU);
+            uint16_t v0 = *reinterpret_cast<const uint16_t*>(dstV);
+            std::ostringstream oss; oss << "[GPU-CHECK] first macropixel  Y=" << y0 << "  U=" << u0 << "  V=" << v0; LogProRes(oss.str());
+        }
+    }
+
     LogProRes("[GPU] readback complete");
 
     vmaDestroyBuffer(m_renderer->m_allocator_p, stagingBuf, stagingAlloc);
-    vmaDestroyBuffer(m_renderer->m_allocator_p, readbackBuf, readbackAlloc);
+    for(int i=0;i<3;++i){
+        vmaDestroyBuffer(m_renderer->m_allocator_p, readbackBuf[i], readbackAlloc[i]);
+    }
     return true;
 }


### PR DESCRIPTION
## Summary
- add GPU conversion API that writes planar YUV422P10LE
- rewrite compute shader to output three separate R16 planes
- allocate Y/U/V images in `GpuYuvConverter`
- copy GPU output rows directly into AVFrame
- simplify export path to call new GPU converter

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6871fd54f0648327a813559511e74b5d