### PR TITLE
Fix GPU YUV path and note license

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,3 +74,7 @@ runtime DLLs will be copied automatically.
 - The log prints `MODE = GPU (Vulkan hw_frames)` when this path is used.
 - If initialization of Vulkan hardware frames fails it falls back to the CPU path automatically.
 - When GPU processing is active additional `[GPU]` log lines confirm the compute pipeline ran.
+
+## License
+MotionCam Player is distributed under the Apache License 2.0. The full license text is available in [motioncam-decoder/LICENSE](motioncam-decoder/LICENSE).
+

--- a/cmake/FindFFMPEG.cmake
+++ b/cmake/FindFFMPEG.cmake
@@ -1,0 +1,11 @@
+# Minimal FindFFMPEG using pkg-config
+find_package(PkgConfig)
+if(PKG_CONFIG_FOUND)
+    pkg_check_modules(FFMPEG libavcodec libavformat libavutil libswscale libswresample)
+endif()
+if(FFMPEG_FOUND)
+    set(FFMPEG_LIBRARIES ${FFMPEG_LIBRARIES})
+    set(FFMPEG_INCLUDE_DIRS ${FFMPEG_INCLUDE_DIRS})
+endif()
+include(FindPackageHandleStandardArgs)
+find_package_handle_standard_args(FFMPEG DEFAULT_MSG FFMPEG_LIBRARIES FFMPEG_INCLUDE_DIRS)

--- a/include/Graphics/GpuYuvConverter.h
+++ b/include/Graphics/GpuYuvConverter.h
@@ -18,7 +18,7 @@ public:
     void cleanup();
 
     bool convertToFrame(const uint16_t* raw, int width, int height, AVFrame* frame,
-                        const float wbGains[3], const float rgb2yuv[9]);
+                        const float wbGains[3], const float colourMatrix[9]);
 private:
     Renderer_VK* m_renderer;
 

--- a/shaders/raw_to_yuv422.comp
+++ b/shaders/raw_to_yuv422.comp
@@ -11,18 +11,14 @@ layout(push_constant) uniform PushConsts {
     int width;
     int height;
     vec3 wbGains;
-    mat3 rgb2yuv;
+    mat3 colourMatrix;
 } pc;
 
+const vec3 kLuma = vec3(0.2126, 0.7152, 0.0722);
 const float kYmul = 876.0;
 const float kCmul = 896.0;
 const float kYoff = 64.0;
-const float kCoff = 512.0;
-const mat3 kRGB2YUV = mat3(
-    0.183,  0.614,  0.062,
-   -0.101, -0.339,  0.439,
-    0.439, -0.399, -0.040
-);
+const float kCoff = 64.0;
 
 uint readU16(int x, int y) {
     x = clamp(x, 0, pc.width - 1);
@@ -65,23 +61,25 @@ void main() {
     if (x0 >= pc.width || y >= pc.height) return;
     int x1 = min(x0 + 1, pc.width - 1);
 
-    vec3 rgb0 = demosaic(x0, y);
-    vec3 rgb1 = demosaic(x1, y);
+    vec3 rgb0 = pc.colourMatrix * demosaic(x0, y);
+    vec3 rgb1 = pc.colourMatrix * demosaic(x1, y);
 
-    vec3 yuv0 = (pc.rgb2yuv * rgb0) * kRGB2YUV;
-    vec3 yuv1 = (pc.rgb2yuv * rgb1) * kRGB2YUV;
+    float Y0 = dot(rgb0, kLuma);
+    float Y1 = dot(rgb1, kLuma);
+    float U0 = (rgb0.b - Y0) * 0.5389 + 0.5;
+    float V0 = (rgb0.r - Y0) * 0.6350 + 0.5;
+    float U1 = (rgb1.b - Y1) * 0.5389 + 0.5;
+    float V1 = (rgb1.r - Y1) * 0.6350 + 0.5;
 
-    float Y0 = yuv0.x * kYmul + kYoff;
-    float U0 = yuv0.y * kCmul + kCoff;
-    float V0 = yuv0.z * kCmul + kCoff;
-    float Y1 = yuv1.x * kYmul + kYoff;
-    float U1 = yuv1.y * kCmul + kCoff;
-    float V1 = yuv1.z * kCmul + kCoff;
+    int y0i = int(clamp(Y0 * kYmul + kYoff + 0.5, 0.0, 1023.0));
+    int y1i = int(clamp(Y1 * kYmul + kYoff + 0.5, 0.0, 1023.0));
+    int ui  = int(clamp(((U0 + U1) * 0.5) * kCmul + kCoff + 0.5, 0.0, 1023.0));
+    int vi  = int(clamp(((V0 + V1) * 0.5) * kCmul + kCoff + 0.5, 0.0, 1023.0));
 
-    uint y0 = uint(clamp(round(Y0), 0.0, 1023.0)) << 6;
-    uint y1 = uint(clamp(round(Y1), 0.0, 1023.0)) << 6;
-    uint uVal = uint(clamp(round((U0+U1)*0.5), 0.0, 1023.0)) << 6;
-    uint vVal = uint(clamp(round((V0+V1)*0.5), 0.0, 1023.0)) << 6;
+    uint y0 = uint(y0i) << 6;
+    uint y1 = uint(y1i) << 6;
+    uint uVal = uint(ui) << 6;
+    uint vVal = uint(vi) << 6;
 
     imageStore(yPlane, ivec2(x0, y), uvec4(y0,0,0,0));
     imageStore(yPlane, ivec2(x1, y), uvec4(y1,0,0,0));

--- a/src/App/AppIO.cpp
+++ b/src/App/AppIO.cpp
@@ -1443,13 +1443,13 @@ void App::exportCurrentClipToProRes() {
         cpParams.saturation = 1.0f;
 
         float wb[3] = { cpParams.gainR, cpParams.gainG, cpParams.gainB };
-        const float rgb2yuvBase[9] = {
+        const float colourBase[9] = {
             0.183f, 0.614f, 0.062f,
            -0.101f,-0.339f, 0.439f,
             0.439f,-0.399f,-0.040f
         };
-        float rgb2yuv[9];
-        for(int i=0;i<9;++i) rgb2yuv[i] = rgb2yuvBase[i];
+        float colourMatrix[9];
+        for(int i=0;i<9;++i) colourMatrix[i] = colourBase[i];
 
         {
             std::ostringstream oss;
@@ -1489,7 +1489,7 @@ void App::exportCurrentClipToProRes() {
             t0 = t1;
             if (gpuActive) {
                 if (av_frame_make_writable(frame) < 0) { m_proResStatus.errorMsg = "frame not writable"; break; }
-                converter.convertToFrame(asU16(raw), width, height, frame, wb, rgb2yuv);
+                converter.convertToFrame(asU16(raw), width, height, frame, wb, colourMatrix);
                 t1 = std::chrono::steady_clock::now();
                 rgbUS += std::chrono::duration_cast<std::chrono::microseconds>(t1 - t0).count();
             } else {
@@ -1503,6 +1503,15 @@ void App::exportCurrentClipToProRes() {
                 sws_scale(sws, srcSlices, srcStride, 0, height, frame->data, frame->linesize);
                 t1 = std::chrono::steady_clock::now();
                 scaleUS += std::chrono::duration_cast<std::chrono::microseconds>(t1 - t0).count();
+#ifdef DEBUG_YUV_VALIDATE
+                if(idx==0){
+                    uint16_t y0 = *reinterpret_cast<const uint16_t*>(frame->data[0]);
+                    uint16_t y1 = *reinterpret_cast<const uint16_t*>(frame->data[0] + 2);
+                    uint16_t u0 = *reinterpret_cast<const uint16_t*>(frame->data[1]);
+                    uint16_t v0 = *reinterpret_cast<const uint16_t*>(frame->data[2]);
+                    std::ostringstream oss; oss << "[CPU-CHECK] (0,0) Y0=" << y0 << " U=" << u0 << " Y1=" << y1 << " V=" << v0; LogProRes(oss.str());
+                }
+#endif
             }
 
             frame->pts = pts;

--- a/src/Graphics/GpuYuvConverter.cpp
+++ b/src/Graphics/GpuYuvConverter.cpp
@@ -258,7 +258,7 @@ void GpuYuvConverter::cleanup() {
 
 bool GpuYuvConverter::convertToFrame(const uint16_t* raw, int width, int height,
                                      AVFrame* frame,
-                                     const float wbGains[3], const float rgb2yuv[9]) {
+                                     const float wbGains[3], const float colourMatrix[9]) {
     LogProRes("[GPU] convertToFrame invoked");
     VkDeviceSize rawSize = static_cast<VkDeviceSize>(width) * height * sizeof(uint16_t);
     VkDeviceSize ySize = static_cast<VkDeviceSize>(width) * height * sizeof(uint16_t);
@@ -389,7 +389,7 @@ bool GpuYuvConverter::convertToFrame(const uint16_t* raw, int width, int height,
     } push{};
     push.w = width; push.h = height;
     for(int i=0;i<3;++i) push.gains[i] = wbGains[i];
-    for(int i=0;i<9;++i) push.mtx[i] = rgb2yuv[i];
+    for(int i=0;i<9;++i) push.mtx[i] = colourMatrix[i];
     vkCmdPushConstants(cmd, m_pipelineLayout, VK_SHADER_STAGE_COMPUTE_BIT, 0, sizeof(Push), &push);
 
     vkCmdDispatch(cmd, (uint32_t)((width + 15) / 16), (uint32_t)((height + 15) / 16), 1);
@@ -450,22 +450,27 @@ bool GpuYuvConverter::convertToFrame(const uint16_t* raw, int width, int height,
         vmaInvalidateAllocation(m_renderer->m_allocator_p, readbackAlloc[i], 0, size);
     }
 
+    size_t rowPitchY = width * 2;
+    size_t rowPitchC = (width / 2) * 2;
     for(int y=0;y<height;++y){
-        const uint8_t* srcY = reinterpret_cast<const uint8_t*>(rbAllocInfo[0].pMappedData) + y*width*2;
+        const uint8_t* srcY = reinterpret_cast<const uint8_t*>(rbAllocInfo[0].pMappedData) + y*rowPitchY;
+        const uint8_t* srcU = reinterpret_cast<const uint8_t*>(rbAllocInfo[1].pMappedData) + y*rowPitchC;
+        const uint8_t* srcV = reinterpret_cast<const uint8_t*>(rbAllocInfo[2].pMappedData) + y*rowPitchC;
         uint8_t* dstY = frame->data[0] + y*frame->linesize[0];
-        memcpy(dstY, srcY, width*2);
-        const uint8_t* srcU = reinterpret_cast<const uint8_t*>(rbAllocInfo[1].pMappedData) + y*width;
-        const uint8_t* srcV = reinterpret_cast<const uint8_t*>(rbAllocInfo[2].pMappedData) + y*width;
         uint8_t* dstU = frame->data[1] + y*frame->linesize[1];
         uint8_t* dstV = frame->data[2] + y*frame->linesize[2];
-        memcpy(dstU, srcU, width);
-        memcpy(dstV, srcV, width);
+        memcpy(dstY, srcY, rowPitchY);
+        memcpy(dstU, srcU, rowPitchC);
+        memcpy(dstV, srcV, rowPitchC);
+#ifdef DEBUG_YUV_VALIDATE
         if(y==0){
             uint16_t y0 = *reinterpret_cast<const uint16_t*>(dstY);
+            uint16_t y1 = *reinterpret_cast<const uint16_t*>(dstY + 2);
             uint16_t u0 = *reinterpret_cast<const uint16_t*>(dstU);
             uint16_t v0 = *reinterpret_cast<const uint16_t*>(dstV);
-            std::ostringstream oss; oss << "[GPU-CHECK] first macropixel  Y=" << y0 << "  U=" << u0 << "  V=" << v0; LogProRes(oss.str());
+            std::ostringstream oss; oss << "[GPU-CHECK] (0,0) Y0=" << y0 << " U=" << u0 << " Y1=" << y1 << " V=" << v0; LogProRes(oss.str());
         }
+#endif
     }
 
     LogProRes("[GPU] readback complete");

--- a/src/Utils/DebugLog.cpp
+++ b/src/Utils/DebugLog.cpp
@@ -160,7 +160,9 @@ void LogFFmpegStatus() {
         LogProRes("[FFmpeg] Some FFmpeg DLLs could not be loaded; export may fail.");
     }
 #   else
+#if LIBAVFORMAT_VERSION_MAJOR < 58
     av_register_all();
+#endif
     int version = avcodec_version();
     LogToFile(std::string("[FFmpeg] avcodec version ") + std::to_string(version));
     LogProRes(std::string("[FFmpeg] avcodec version ") + std::to_string(version));


### PR DESCRIPTION
## Summary
- correct chroma conversion in `raw_to_yuv422.comp`
- pass colour matrix to GPU converter
- log first macropixel for CPU/GPU comparison when `DEBUG_YUV_VALIDATE` is set
- add minimal FindFFMPEG.cmake for pkg-config builds
- document Apache 2.0 license in README

## Testing
- `cmake -B build -DCMAKE_MODULE_PATH=$PWD/cmake -DENABLE_GPU=ON` *(fails: could not link Windows-only libs)*
- `cmake --build build -j16` *(fails: linking errors with provided prebuilt libraries)*

------
https://chatgpt.com/codex/tasks/task_e_68720b33ca3483279c309b2c1ed70cdd