### PR TITLE
Fix chroma maths & packing in GPU converter

### DIFF
--- a/include/Graphics/GpuYuvConverter.h
+++ b/include/Graphics/GpuYuvConverter.h
@@ -18,7 +18,8 @@ public:
     void cleanup();
 
     bool convertToFrame(const uint16_t* raw, int width, int height, AVFrame* frame,
-                        const float wbGains[3], const float rgb2yuv[9]);
+                        const float wbGains[3], const float rgb2yuv[9],
+                        float blackLevel, float whiteLevel);
 private:
     Renderer_VK* m_renderer;
 

--- a/shaders/raw_to_yuv422.comp
+++ b/shaders/raw_to_yuv422.comp
@@ -10,52 +10,47 @@ layout(binding = 3, r16ui) writeonly uniform uimage2D vPlane;
 layout(push_constant) uniform PushConsts {
     int width;
     int height;
-    vec3 wbGains;
-    mat3 rgb2yuv;
+    vec3 wb;
+    mat3 colorMtx;
+    float black;
+    float white;
 } pc;
 
-const float kYmul = 876.0;
-const float kCmul = 896.0;
-const float kYoff = 64.0;
-const float kCoff = 512.0;
-const mat3 kRGB2YUV = mat3(
-    0.183,  0.614,  0.062,
-   -0.101, -0.339,  0.439,
-    0.439, -0.399, -0.040
-);
-
-uint readU16(int x, int y) {
-    x = clamp(x, 0, pc.width - 1);
-    y = clamp(y, 0, pc.height - 1);
-    return texelFetch(rawImage, ivec2(x, y), 0).r;
+float rawToLin(uint v) {
+    float t = (float(v) - pc.black) / max(pc.white - pc.black, 0.001);
+    return clamp(t, 0.0, 1.0);
 }
 
 vec3 demosaic(int x, int y) {
     bool ye = (y & 1) == 0;
     bool xe = (x & 1) == 0;
-    float r = 0.0, g = 0.0, b = 0.0;
+    float r=0.0, g=0.0, b=0.0;
     if (ye) {
-        if (xe) { // B
-            b = float(readU16(x, y));
-            g = 0.25 * (float(readU16(x+1,y)) + float(readU16(x-1,y)) + float(readU16(x,y+1)) + float(readU16(x,y-1)));
-            r = 0.25 * (float(readU16(x+1,y+1)) + float(readU16(x-1,y+1)) + float(readU16(x+1,y-1)) + float(readU16(x-1,y-1)));
-        } else { // G
-            g = float(readU16(x,y));
-            r = 0.5 * (float(readU16(x+1,y)) + float(readU16(x-1,y)));
-            b = 0.5 * (float(readU16(x,y+1)) + float(readU16(x,y-1)));
+        if (xe) {
+            b = rawToLin(texelFetch(rawImage, ivec2(x,y),0).r);
+            g = 0.25*(rawToLin(texelFetch(rawImage, ivec2(x+1,y),0).r)+rawToLin(texelFetch(rawImage, ivec2(x-1,y),0).r)
+                     +rawToLin(texelFetch(rawImage, ivec2(x,y+1),0).r)+rawToLin(texelFetch(rawImage, ivec2(x,y-1),0).r));
+            r = 0.25*(rawToLin(texelFetch(rawImage, ivec2(x+1,y+1),0).r)+rawToLin(texelFetch(rawImage, ivec2(x-1,y+1),0).r)
+                     +rawToLin(texelFetch(rawImage, ivec2(x+1,y-1),0).r)+rawToLin(texelFetch(rawImage, ivec2(x-1,y-1),0).r));
+        } else {
+            g = rawToLin(texelFetch(rawImage, ivec2(x,y),0).r);
+            r = 0.5*(rawToLin(texelFetch(rawImage, ivec2(x+1,y),0).r)+rawToLin(texelFetch(rawImage, ivec2(x-1,y),0).r));
+            b = 0.5*(rawToLin(texelFetch(rawImage, ivec2(x,y+1),0).r)+rawToLin(texelFetch(rawImage, ivec2(x,y-1),0).r));
         }
     } else {
-        if (xe) { // G
-            g = float(readU16(x,y));
-            r = 0.5 * (float(readU16(x,y+1)) + float(readU16(x,y-1)));
-            b = 0.5 * (float(readU16(x+1,y)) + float(readU16(x-1,y)));
-        } else { // R
-            r = float(readU16(x,y));
-            g = 0.25 * (float(readU16(x+1,y)) + float(readU16(x-1,y)) + float(readU16(x,y+1)) + float(readU16(x,y-1)));
-            b = 0.25 * (float(readU16(x+1,y+1)) + float(readU16(x-1,y+1)) + float(readU16(x+1,y-1)) + float(readU16(x-1,y-1)));
+        if (xe) {
+            g = rawToLin(texelFetch(rawImage, ivec2(x,y),0).r);
+            r = 0.5*(rawToLin(texelFetch(rawImage, ivec2(x,y+1),0).r)+rawToLin(texelFetch(rawImage, ivec2(x,y-1),0).r));
+            b = 0.5*(rawToLin(texelFetch(rawImage, ivec2(x+1,y),0).r)+rawToLin(texelFetch(rawImage, ivec2(x-1,y),0).r));
+        } else {
+            r = rawToLin(texelFetch(rawImage, ivec2(x,y),0).r);
+            g = 0.25*(rawToLin(texelFetch(rawImage, ivec2(x+1,y),0).r)+rawToLin(texelFetch(rawImage, ivec2(x-1,y),0).r)
+                     +rawToLin(texelFetch(rawImage, ivec2(x,y+1),0).r)+rawToLin(texelFetch(rawImage, ivec2(x,y-1),0).r));
+            b = 0.25*(rawToLin(texelFetch(rawImage, ivec2(x+1,y+1),0).r)+rawToLin(texelFetch(rawImage, ivec2(x-1,y+1),0).r)
+                     +rawToLin(texelFetch(rawImage, ivec2(x+1,y-1),0).r)+rawToLin(texelFetch(rawImage, ivec2(x-1,y-1),0).r));
         }
     }
-    return vec3(r,g,b) * pc.wbGains / 1023.0; // assume 10-bit raw
+    return vec3(r,g,b);
 }
 
 void main() {
@@ -65,23 +60,23 @@ void main() {
     if (x0 >= pc.width || y >= pc.height) return;
     int x1 = min(x0 + 1, pc.width - 1);
 
-    vec3 rgb0 = demosaic(x0, y);
-    vec3 rgb1 = demosaic(x1, y);
+    vec3 rgb0 = demosaic(x0, y) * pc.wb;
+    vec3 rgb1 = demosaic(x1, y) * pc.wb;
 
-    vec3 yuv0 = (pc.rgb2yuv * rgb0) * kRGB2YUV;
-    vec3 yuv1 = (pc.rgb2yuv * rgb1) * kRGB2YUV;
+    rgb0 = pc.colorMtx * rgb0;
+    rgb1 = pc.colorMtx * rgb1;
 
-    float Y0 = yuv0.x * kYmul + kYoff;
-    float U0 = yuv0.y * kCmul + kCoff;
-    float V0 = yuv0.z * kCmul + kCoff;
-    float Y1 = yuv1.x * kYmul + kYoff;
-    float U1 = yuv1.y * kCmul + kCoff;
-    float V1 = yuv1.z * kCmul + kCoff;
+    float Y0 = dot(rgb0, vec3(0.2126,0.7152,0.0722));
+    float Y1 = dot(rgb1, vec3(0.2126,0.7152,0.0722));
+    float U0 = (rgb0.b - Y0) * 0.5389 + 0.5;
+    float V0 = (rgb0.r - Y0) * 0.6350 + 0.5;
+    float U1 = (rgb1.b - Y1) * 0.5389 + 0.5;
+    float V1 = (rgb1.r - Y1) * 0.6350 + 0.5;
 
-    uint y0 = uint(clamp(round(Y0), 0.0, 1023.0)) << 6;
-    uint y1 = uint(clamp(round(Y1), 0.0, 1023.0)) << 6;
-    uint uVal = uint(clamp(round((U0+U1)*0.5), 0.0, 1023.0)) << 6;
-    uint vVal = uint(clamp(round((V0+V1)*0.5), 0.0, 1023.0)) << 6;
+    uint y0 = uint(clamp(int(Y0 * 876.0 + 64.5), 0, 1023));
+    uint y1 = uint(clamp(int(Y1 * 876.0 + 64.5), 0, 1023));
+    uint uVal = uint(clamp(int(((U0+U1)*0.5) * 896.0 + 64.5), 0, 1023));
+    uint vVal = uint(clamp(int(((V0+V1)*0.5) * 896.0 + 64.5), 0, 1023));
 
     imageStore(yPlane, ivec2(x0, y), uvec4(y0,0,0,0));
     imageStore(yPlane, ivec2(x1, y), uvec4(y1,0,0,0));

--- a/src/App/AppIO.cpp
+++ b/src/App/AppIO.cpp
@@ -1489,7 +1489,19 @@ void App::exportCurrentClipToProRes() {
             t0 = t1;
             if (gpuActive) {
                 if (av_frame_make_writable(frame) < 0) { m_proResStatus.errorMsg = "frame not writable"; break; }
-                converter.convertToFrame(asU16(raw), width, height, frame, wb, rgb2yuv);
+                converter.convertToFrame(asU16(raw), width, height, frame, wb, rgb2yuv,
+                                        (float)cpParams.blackLevel, (float)cpParams.whiteLevel);
+#ifdef DEBUG_YUV_VALIDATE
+                if(idx==0){
+                    uint16_t y0 = *reinterpret_cast<uint16_t*>(frame->data[0]);
+                    uint16_t y1 = *reinterpret_cast<uint16_t*>(frame->data[0] + 2);
+                    uint16_t u0 = *reinterpret_cast<uint16_t*>(frame->data[1]);
+                    uint16_t v0 = *reinterpret_cast<uint16_t*>(frame->data[2]);
+                    char buf[128];
+                    snprintf(buf, sizeof(buf), "[GPU-CHECK] (0,0) Y0=%u U=%u Y1=%u V=%u", y0,u0,y1,v0);
+                    LogProRes(buf);
+                }
+#endif
                 t1 = std::chrono::steady_clock::now();
                 rgbUS += std::chrono::duration_cast<std::chrono::microseconds>(t1 - t0).count();
             } else {
@@ -1501,6 +1513,17 @@ void App::exportCurrentClipToProRes() {
                 int srcStride[1] = { width*3 };
                 t0 = std::chrono::steady_clock::now();
                 sws_scale(sws, srcSlices, srcStride, 0, height, frame->data, frame->linesize);
+#ifdef DEBUG_YUV_VALIDATE
+                if(idx==0){
+                    uint16_t y0 = *reinterpret_cast<uint16_t*>(frame->data[0]);
+                    uint16_t y1 = *reinterpret_cast<uint16_t*>(frame->data[0] + 2);
+                    uint16_t u0 = *reinterpret_cast<uint16_t*>(frame->data[1]);
+                    uint16_t v0 = *reinterpret_cast<uint16_t*>(frame->data[2]);
+                    char buf[128];
+                    snprintf(buf, sizeof(buf), "[CPU-CHECK] (0,0) Y0=%u U=%u Y1=%u V=%u", y0,u0,y1,v0);
+                    LogProRes(buf);
+                }
+#endif
                 t1 = std::chrono::steady_clock::now();
                 scaleUS += std::chrono::duration_cast<std::chrono::microseconds>(t1 - t0).count();
             }

--- a/src/Graphics/GpuYuvConverter.cpp
+++ b/src/Graphics/GpuYuvConverter.cpp
@@ -7,6 +7,7 @@
 #include <filesystem>
 #include <chrono>
 #include <sstream>
+#include <cstdio>
 
 extern std::string g_AppBasePath;
 
@@ -59,7 +60,7 @@ bool GpuYuvConverter::init(int width, int height) {
     VkPushConstantRange pcRange{};
     pcRange.stageFlags = VK_SHADER_STAGE_COMPUTE_BIT;
     pcRange.offset = 0;
-    pcRange.size = sizeof(int) * 2 + sizeof(float) * 3 + sizeof(float) * 9;
+    pcRange.size = sizeof(int) * 2 + sizeof(float) * 3 + sizeof(float) * 9 + sizeof(float) * 2;
 
     VkPipelineLayoutCreateInfo pli{};
     pli.sType = VK_STRUCTURE_TYPE_PIPELINE_LAYOUT_CREATE_INFO;
@@ -258,7 +259,8 @@ void GpuYuvConverter::cleanup() {
 
 bool GpuYuvConverter::convertToFrame(const uint16_t* raw, int width, int height,
                                      AVFrame* frame,
-                                     const float wbGains[3], const float rgb2yuv[9]) {
+                                     const float wbGains[3], const float rgb2yuv[9],
+                                     float blackLevel, float whiteLevel) {
     LogProRes("[GPU] convertToFrame invoked");
     VkDeviceSize rawSize = static_cast<VkDeviceSize>(width) * height * sizeof(uint16_t);
     VkDeviceSize ySize = static_cast<VkDeviceSize>(width) * height * sizeof(uint16_t);
@@ -386,10 +388,14 @@ bool GpuYuvConverter::convertToFrame(const uint16_t* raw, int width, int height,
         int w; int h;
         float gains[3];
         float mtx[9];
+        float black;
+        float white;
     } push{};
     push.w = width; push.h = height;
     for(int i=0;i<3;++i) push.gains[i] = wbGains[i];
     for(int i=0;i<9;++i) push.mtx[i] = rgb2yuv[i];
+    push.black = blackLevel;
+    push.white = whiteLevel;
     vkCmdPushConstants(cmd, m_pipelineLayout, VK_SHADER_STAGE_COMPUTE_BIT, 0, sizeof(Push), &push);
 
     vkCmdDispatch(cmd, (uint32_t)((width + 15) / 16), (uint32_t)((height + 15) / 16), 1);
@@ -461,10 +467,15 @@ bool GpuYuvConverter::convertToFrame(const uint16_t* raw, int width, int height,
         memcpy(dstU, srcU, width);
         memcpy(dstV, srcV, width);
         if(y==0){
+#ifdef DEBUG_YUV_VALIDATE
             uint16_t y0 = *reinterpret_cast<const uint16_t*>(dstY);
+            uint16_t y1 = *reinterpret_cast<const uint16_t*>(dstY + 2);
             uint16_t u0 = *reinterpret_cast<const uint16_t*>(dstU);
             uint16_t v0 = *reinterpret_cast<const uint16_t*>(dstV);
-            std::ostringstream oss; oss << "[GPU-CHECK] first macropixel  Y=" << y0 << "  U=" << u0 << "  V=" << v0; LogProRes(oss.str());
+            char buf[128];
+            snprintf(buf, sizeof(buf), "[GPU-CHECK] (0,0) Y0=%u U=%u Y1=%u V=%u", y0, u0, y1, v0);
+            LogProRes(buf);
+#endif
         }
     }
 


### PR DESCRIPTION
## Summary
- update compute shader to correctly convert RGB to YUV
- pass black/white levels to GPU converter
- add debug validation log for CPU and GPU paths

## Testing
- `apt-get install -y libavcodec-dev libavformat-dev libavutil-dev libswscale-dev libswresample-dev`
- `cmake -B build -DENABLE_GPU=ON` *(fails: Could not find a package configuration file provided by "FFMPEG")*

------
https://chatgpt.com/codex/tasks/task_e_68720b33ca3483279c309b2c1ed70cdd