### PR TITLE
Fix chroma maths & packing in GPU YUV converter

### DIFF
--- a/shaders/raw_to_yuv422.comp
+++ b/shaders/raw_to_yuv422.comp
@@ -11,18 +11,13 @@ layout(push_constant) uniform PushConsts {
     int width;
     int height;
     vec3 wbGains;
-    mat3 rgb2yuv;
+    mat3 colorMatrix;
 } pc;
 
 const float kYmul = 876.0;
 const float kCmul = 896.0;
 const float kYoff = 64.0;
 const float kCoff = 512.0;
-const mat3 kRGB2YUV = mat3(
-    0.183,  0.614,  0.062,
-   -0.101, -0.339,  0.439,
-    0.439, -0.399, -0.040
-);
 
 uint readU16(int x, int y) {
     x = clamp(x, 0, pc.width - 1);
@@ -55,7 +50,7 @@ vec3 demosaic(int x, int y) {
             b = 0.25 * (float(readU16(x+1,y+1)) + float(readU16(x-1,y+1)) + float(readU16(x+1,y-1)) + float(readU16(x-1,y-1)));
         }
     }
-    return vec3(r,g,b) * pc.wbGains / 1023.0; // assume 10-bit raw
+    return (vec3(r, g, b) / 1023.0) * pc.wbGains; // apply white balance
 }
 
 void main() {
@@ -65,23 +60,18 @@ void main() {
     if (x0 >= pc.width || y >= pc.height) return;
     int x1 = min(x0 + 1, pc.width - 1);
 
-    vec3 rgb0 = demosaic(x0, y);
-    vec3 rgb1 = demosaic(x1, y);
+    vec3 rgb0 = pc.colorMatrix * demosaic(x0, y);
+    vec3 rgb1 = pc.colorMatrix * demosaic(x1, y);
 
-    vec3 yuv0 = (pc.rgb2yuv * rgb0) * kRGB2YUV;
-    vec3 yuv1 = (pc.rgb2yuv * rgb1) * kRGB2YUV;
+    float Y0f = dot(rgb0, vec3(0.2126, 0.7152, 0.0722));
+    float Y1f = dot(rgb1, vec3(0.2126, 0.7152, 0.0722));
+    float U = ((rgb0.b - Y0f) * 0.5389 + 0.5 + (rgb1.b - Y1f) * 0.5389 + 0.5) * 0.5;
+    float V = ((rgb0.r - Y0f) * 0.6350 + 0.5 + (rgb1.r - Y1f) * 0.6350 + 0.5) * 0.5;
 
-    float Y0 = yuv0.x * kYmul + kYoff;
-    float U0 = yuv0.y * kCmul + kCoff;
-    float V0 = yuv0.z * kCmul + kCoff;
-    float Y1 = yuv1.x * kYmul + kYoff;
-    float U1 = yuv1.y * kCmul + kCoff;
-    float V1 = yuv1.z * kCmul + kCoff;
-
-    uint y0 = uint(clamp(round(Y0), 0.0, 1023.0)) << 6;
-    uint y1 = uint(clamp(round(Y1), 0.0, 1023.0)) << 6;
-    uint uVal = uint(clamp(round((U0+U1)*0.5), 0.0, 1023.0)) << 6;
-    uint vVal = uint(clamp(round((V0+V1)*0.5), 0.0, 1023.0)) << 6;
+    uint y0 = uint(clamp(int(Y0f * kYmul + kYoff + 0.5), 0, 1023));
+    uint y1 = uint(clamp(int(Y1f * kYmul + kYoff + 0.5), 0, 1023));
+    uint uVal = uint(clamp(int(U * kCmul + kCoff + 0.5), 0, 1023));
+    uint vVal = uint(clamp(int(V * kCmul + kCoff + 0.5), 0, 1023));
 
     imageStore(yPlane, ivec2(x0, y), uvec4(y0,0,0,0));
     imageStore(yPlane, ivec2(x1, y), uvec4(y1,0,0,0));

--- a/src/App/AppIO.cpp
+++ b/src/App/AppIO.cpp
@@ -1503,6 +1503,15 @@ void App::exportCurrentClipToProRes() {
                 sws_scale(sws, srcSlices, srcStride, 0, height, frame->data, frame->linesize);
                 t1 = std::chrono::steady_clock::now();
                 scaleUS += std::chrono::duration_cast<std::chrono::microseconds>(t1 - t0).count();
+#ifdef DEBUG_YUV_VALIDATE
+                if(idx==0){
+                    uint16_t y0 = *reinterpret_cast<const uint16_t*>(frame->data[0]);
+                    uint16_t y1 = *reinterpret_cast<const uint16_t*>(frame->data[0] + 2);
+                    uint16_t u0 = *reinterpret_cast<const uint16_t*>(frame->data[1]);
+                    uint16_t v0 = *reinterpret_cast<const uint16_t*>(frame->data[2]);
+                    std::ostringstream oss; oss << "[CPU-CHECK] (0,0) Y0=" << y0 << " U=" << u0 << " Y1=" << y1 << " V=" << v0; LogProRes(oss.str());
+                }
+#endif
             }
 
             frame->pts = pts;

--- a/src/Graphics/GpuYuvConverter.cpp
+++ b/src/Graphics/GpuYuvConverter.cpp
@@ -461,10 +461,13 @@ bool GpuYuvConverter::convertToFrame(const uint16_t* raw, int width, int height,
         memcpy(dstU, srcU, width);
         memcpy(dstV, srcV, width);
         if(y==0){
+#ifdef DEBUG_YUV_VALIDATE
             uint16_t y0 = *reinterpret_cast<const uint16_t*>(dstY);
+            uint16_t y1 = *reinterpret_cast<const uint16_t*>(dstY + 2);
             uint16_t u0 = *reinterpret_cast<const uint16_t*>(dstU);
             uint16_t v0 = *reinterpret_cast<const uint16_t*>(dstV);
-            std::ostringstream oss; oss << "[GPU-CHECK] first macropixel  Y=" << y0 << "  U=" << u0 << "  V=" << v0; LogProRes(oss.str());
+            std::ostringstream oss; oss << "[GPU-CHECK] (0,0) Y0=" << y0 << " U=" << u0 << " Y1=" << y1 << " V=" << v0; LogProRes(oss.str());
+#endif
         }
     }
 


### PR DESCRIPTION
## Summary
- adjust compute shader for correct YUV conversion
- add CPU/GPU validation logging

## Testing
- `cmake -B build -DENABLE_GPU=ON` *(fails: FFMPEG not found)*

------
https://chatgpt.com/codex/tasks/task_e_68720b33ca3483279c309b2c1ed70cdd