### PR TITLE
Implement GPU-based ProRes color pipeline

### DIFF
--- a/include/Graphics/GpuColorParams.h
+++ b/include/Graphics/GpuColorParams.h
@@ -1,0 +1,10 @@
+#pragma once
+#include <array>
+
+struct GpuColorParams {
+    int black{0};
+    int white{65535};
+    std::array<float,3> asShotNeutral{1.0f,1.0f,1.0f};
+    std::array<float,9> colorMatrix{1,0,0,0,1,0,0,0,1};
+    int cfaType{0}; // 0 BGGR,1 RGGB,2 GBRG,3 GRBG
+};

--- a/include/Graphics/GpuYuvConverter.h
+++ b/include/Graphics/GpuYuvConverter.h
@@ -6,6 +6,7 @@
 #include <cstdint>
 #include <libavutil/frame.h>
 #include "Utils/vma_usage.h"
+#include "Graphics/GpuColorParams.h"
 
 class Renderer_VK;
 
@@ -18,7 +19,7 @@ public:
     void cleanup();
 
     bool convertToFrame(const uint16_t* raw, int width, int height, AVFrame* frame,
-                        const float wbGains[3], const float rgb2yuv[9]);
+                        const GpuColorParams& params);
 private:
     Renderer_VK* m_renderer;
 

--- a/shaders/raw_to_yuv422.comp
+++ b/shaders/raw_to_yuv422.comp
@@ -10,8 +10,11 @@ layout(binding = 3, r16ui) writeonly uniform uimage2D vPlane;
 layout(push_constant) uniform PushConsts {
     int width;
     int height;
-    vec3 wbGains;
-    mat3 rgb2yuv;
+    int black;
+    int white;
+    vec3 asShotNeutral;
+    mat3 colorMatrix;
+    int cfaType;
 } pc;
 
 const float kYmul = 876.0;
@@ -24,38 +27,77 @@ const mat3 kRGB2YUV = mat3(
     0.439, -0.399, -0.040
 );
 
-uint readU16(int x, int y) {
-    x = clamp(x, 0, pc.width - 1);
-    y = clamp(y, 0, pc.height - 1);
-    return texelFetch(rawImage, ivec2(x, y), 0).r;
+float linFromRaw(uint v){
+    float t = (float(v) - float(pc.black)) / max(float(pc.white - pc.black), 1.0);
+    return clamp(t, 0.0, 1.0);
 }
+
+float srgb_eotf(float v){
+    v = clamp(v,0.0,1.0);
+    return (v <= 0.0031308) ? v*12.92 : 1.055*pow(v,1.0/2.4) - 0.055;
+}
+
+float readLin(int x,int y){
+    x = clamp(x,0,pc.width-1);
+    y = clamp(y,0,pc.height-1);
+    return linFromRaw(texelFetch(rawImage, ivec2(x,y),0).r);
+}
+
+float interpG(int x,int y){ return 0.25*(readLin(x+1,y)+readLin(x-1,y)+readLin(x,y+1)+readLin(x,y-1)); }
+float interpH(int x,int y){ return 0.5*(readLin(x+1,y)+readLin(x-1,y)); }
+float interpV(int x,int y){ return 0.5*(readLin(x,y+1)+readLin(x,y-1)); }
+float interpD(int x,int y){ return 0.25*(readLin(x+1,y+1)+readLin(x-1,y+1)+readLin(x+1,y-1)+readLin(x-1,y-1)); }
 
 vec3 demosaic(int x, int y) {
     bool ye = (y & 1) == 0;
     bool xe = (x & 1) == 0;
     float r = 0.0, g = 0.0, b = 0.0;
-    if (ye) {
-        if (xe) { // B
-            b = float(readU16(x, y));
-            g = 0.25 * (float(readU16(x+1,y)) + float(readU16(x-1,y)) + float(readU16(x,y+1)) + float(readU16(x,y-1)));
-            r = 0.25 * (float(readU16(x+1,y+1)) + float(readU16(x-1,y+1)) + float(readU16(x+1,y-1)) + float(readU16(x-1,y-1)));
-        } else { // G
-            g = float(readU16(x,y));
-            r = 0.5 * (float(readU16(x+1,y)) + float(readU16(x-1,y)));
-            b = 0.5 * (float(readU16(x,y+1)) + float(readU16(x,y-1)));
-        }
-    } else {
-        if (xe) { // G
-            g = float(readU16(x,y));
-            r = 0.5 * (float(readU16(x,y+1)) + float(readU16(x,y-1)));
-            b = 0.5 * (float(readU16(x+1,y)) + float(readU16(x-1,y)));
-        } else { // R
-            r = float(readU16(x,y));
-            g = 0.25 * (float(readU16(x+1,y)) + float(readU16(x-1,y)) + float(readU16(x,y+1)) + float(readU16(x,y-1)));
-            b = 0.25 * (float(readU16(x+1,y+1)) + float(readU16(x-1,y+1)) + float(readU16(x+1,y-1)) + float(readU16(x-1,y-1)));
-        }
+    switch(pc.cfaType){
+        case 0: // BGGR
+            if(ye){
+                if(xe){ b=readLin(x,y); g=interpG(x,y); r=interpD(x,y); }
+                else { g=readLin(x,y); r=interpV(x,y); b=interpH(x,y); }
+            }else{
+                if(xe){ g=readLin(x,y); r=interpH(x,y); b=interpV(x,y); }
+                else { r=readLin(x,y); g=interpG(x,y); b=interpD(x,y); }
+            }
+            break;
+        case 1: // RGGB
+            if(ye){
+                if(xe){ r=readLin(x,y); g=interpG(x,y); b=interpD(x,y); }
+                else { g=readLin(x,y); r=interpH(x,y); b=interpV(x,y); }
+            }else{
+                if(xe){ g=readLin(x,y); r=interpV(x,y); b=interpH(x,y); }
+                else { b=readLin(x,y); g=interpG(x,y); r=interpD(x,y); }
+            }
+            break;
+        case 2: // GBRG
+            if(ye){
+                if(xe){ g=readLin(x,y); r=interpV(x,y); b=interpH(x,y); }
+                else { b=readLin(x,y); g=interpG(x,y); r=interpD(x,y); }
+            }else{
+                if(xe){ r=readLin(x,y); g=interpG(x,y); b=interpD(x,y); }
+                else { g=readLin(x,y); r=interpH(x,y); b=interpV(x,y); }
+            }
+            break;
+        default: // GRBG
+            if(ye){
+                if(xe){ g=readLin(x,y); r=interpH(x,y); b=interpV(x,y); }
+                else { r=readLin(x,y); g=interpG(x,y); b=interpD(x,y); }
+            }else{
+                if(xe){ b=readLin(x,y); g=interpG(x,y); r=interpD(x,y); }
+                else { g=readLin(x,y); r=interpV(x,y); b=interpH(x,y); }
+            }
+            break;
     }
-    return vec3(r,g,b) * pc.wbGains / 1023.0; // assume 10-bit raw
+
+    float gainR = (pc.asShotNeutral.y > 1e-6 && pc.asShotNeutral.x > 1e-6) ? pc.asShotNeutral.y/pc.asShotNeutral.x : 1.0;
+    float gainB = (pc.asShotNeutral.y > 1e-6 && pc.asShotNeutral.z > 1e-6) ? pc.asShotNeutral.y/pc.asShotNeutral.z : 1.0;
+    vec3 wb = vec3(gainR,1.0,gainB);
+    vec3 rgb = clamp(vec3(r,g,b)*wb, 0.0,1.0);
+    rgb = clamp(pc.colorMatrix * rgb, 0.0,1.0);
+    rgb = vec3(srgb_eotf(rgb.r), srgb_eotf(rgb.g), srgb_eotf(rgb.b));
+    return rgb;
 }
 
 void main() {
@@ -68,8 +110,8 @@ void main() {
     vec3 rgb0 = demosaic(x0, y);
     vec3 rgb1 = demosaic(x1, y);
 
-    vec3 yuv0 = (pc.rgb2yuv * rgb0) * kRGB2YUV;
-    vec3 yuv1 = (pc.rgb2yuv * rgb1) * kRGB2YUV;
+    vec3 yuv0 = kRGB2YUV * rgb0;
+    vec3 yuv1 = kRGB2YUV * rgb1;
 
     float Y0 = yuv0.x * kYmul + kYoff;
     float U0 = yuv0.y * kCmul + kCoff;

--- a/src/App/AppIO.cpp
+++ b/src/App/AppIO.cpp
@@ -32,6 +32,7 @@
 #ifdef ENABLE_PRORES_EXPORT
 #include "ffmpeg_headers.hpp"
 #include "Graphics/GpuYuvConverter.h"
+#include "Graphics/GpuColorParams.h"
 #endif
 #include "Utils/ColorPipelineCPU.h"
 
@@ -1442,14 +1443,13 @@ void App::exportCurrentClipToProRes() {
         }
         cpParams.saturation = 1.0f;
 
-        float wb[3] = { cpParams.gainR, cpParams.gainG, cpParams.gainB };
-        const float rgb2yuvBase[9] = {
-            0.183f, 0.614f, 0.062f,
-           -0.101f,-0.339f, 0.439f,
-            0.439f,-0.399f,-0.040f
-        };
-        float rgb2yuv[9];
-        for(int i=0;i<9;++i) rgb2yuv[i] = rgb2yuvBase[i];
+        GpuColorParams gpuParams{};
+        gpuParams.black = static_cast<int>(cpParams.blackLevel);
+        gpuParams.white = static_cast<int>(cpParams.whiteLevel);
+        for(size_t i=0;i<3 && i<asn_json.size();++i)
+            gpuParams.asShotNeutral[i] = static_cast<float>(asn_json[i]);
+        for(int i=0;i<9;++i) gpuParams.colorMatrix[i] = cpParams.ccm[i];
+        gpuParams.cfaType = cpParams.cfaType;
 
         {
             std::ostringstream oss;
@@ -1489,7 +1489,7 @@ void App::exportCurrentClipToProRes() {
             t0 = t1;
             if (gpuActive) {
                 if (av_frame_make_writable(frame) < 0) { m_proResStatus.errorMsg = "frame not writable"; break; }
-                converter.convertToFrame(asU16(raw), width, height, frame, wb, rgb2yuv);
+                converter.convertToFrame(asU16(raw), width, height, frame, gpuParams);
                 t1 = std::chrono::steady_clock::now();
                 rgbUS += std::chrono::duration_cast<std::chrono::microseconds>(t1 - t0).count();
             } else {

--- a/src/Graphics/GpuYuvConverter.cpp
+++ b/src/Graphics/GpuYuvConverter.cpp
@@ -59,7 +59,7 @@ bool GpuYuvConverter::init(int width, int height) {
     VkPushConstantRange pcRange{};
     pcRange.stageFlags = VK_SHADER_STAGE_COMPUTE_BIT;
     pcRange.offset = 0;
-    pcRange.size = sizeof(int) * 2 + sizeof(float) * 3 + sizeof(float) * 9;
+    pcRange.size = sizeof(int) * 5 + sizeof(float) * 3 + sizeof(float) * 9;
 
     VkPipelineLayoutCreateInfo pli{};
     pli.sType = VK_STRUCTURE_TYPE_PIPELINE_LAYOUT_CREATE_INFO;
@@ -258,7 +258,7 @@ void GpuYuvConverter::cleanup() {
 
 bool GpuYuvConverter::convertToFrame(const uint16_t* raw, int width, int height,
                                      AVFrame* frame,
-                                     const float wbGains[3], const float rgb2yuv[9]) {
+                                     const GpuColorParams& params) {
     LogProRes("[GPU] convertToFrame invoked");
     VkDeviceSize rawSize = static_cast<VkDeviceSize>(width) * height * sizeof(uint16_t);
     VkDeviceSize ySize = static_cast<VkDeviceSize>(width) * height * sizeof(uint16_t);
@@ -383,13 +383,17 @@ bool GpuYuvConverter::convertToFrame(const uint16_t* raw, int width, int height,
     vkCmdBindDescriptorSets(cmd, VK_PIPELINE_BIND_POINT_COMPUTE, m_pipelineLayout, 0, 1, &m_descSet, 0, nullptr);
 
     struct Push {
-        int w; int h;
-        float gains[3];
-        float mtx[9];
+        int width; int height;
+        int black; int white;
+        float asn[3];
+        float ccm[9];
+        int cfaType;
     } push{};
-    push.w = width; push.h = height;
-    for(int i=0;i<3;++i) push.gains[i] = wbGains[i];
-    for(int i=0;i<9;++i) push.mtx[i] = rgb2yuv[i];
+    push.width = width; push.height = height;
+    push.black = params.black; push.white = params.white;
+    for(int i=0;i<3;++i) push.asn[i] = params.asShotNeutral[i];
+    for(int i=0;i<9;++i) push.ccm[i] = params.colorMatrix[i];
+    push.cfaType = params.cfaType;
     vkCmdPushConstants(cmd, m_pipelineLayout, VK_SHADER_STAGE_COMPUTE_BIT, 0, sizeof(Push), &push);
 
     vkCmdDispatch(cmd, (uint32_t)((width + 15) / 16), (uint32_t)((height + 15) / 16), 1);
@@ -450,22 +454,34 @@ bool GpuYuvConverter::convertToFrame(const uint16_t* raw, int width, int height,
         vmaInvalidateAllocation(m_renderer->m_allocator_p, readbackAlloc[i], 0, size);
     }
 
-    for(int y=0;y<height;++y){
-        const uint8_t* srcY = reinterpret_cast<const uint8_t*>(rbAllocInfo[0].pMappedData) + y*width*2;
-        uint8_t* dstY = frame->data[0] + y*frame->linesize[0];
-        memcpy(dstY, srcY, width*2);
-        const uint8_t* srcU = reinterpret_cast<const uint8_t*>(rbAllocInfo[1].pMappedData) + y*width;
-        const uint8_t* srcV = reinterpret_cast<const uint8_t*>(rbAllocInfo[2].pMappedData) + y*width;
-        uint8_t* dstU = frame->data[1] + y*frame->linesize[1];
-        uint8_t* dstV = frame->data[2] + y*frame->linesize[2];
-        memcpy(dstU, srcU, width);
-        memcpy(dstV, srcV, width);
-        if(y==0){
-            uint16_t y0 = *reinterpret_cast<const uint16_t*>(dstY);
-            uint16_t u0 = *reinterpret_cast<const uint16_t*>(dstU);
-            uint16_t v0 = *reinterpret_cast<const uint16_t*>(dstV);
-            std::ostringstream oss; oss << "[GPU-CHECK] first macropixel  Y=" << y0 << "  U=" << u0 << "  V=" << v0; LogProRes(oss.str());
+    size_t srcYPitch = width * 2;
+    size_t srcCPitch = width;
+    const uint8_t* srcYBase = reinterpret_cast<const uint8_t*>(rbAllocInfo[0].pMappedData);
+    const uint8_t* srcUBase = reinterpret_cast<const uint8_t*>(rbAllocInfo[1].pMappedData);
+    const uint8_t* srcVBase = reinterpret_cast<const uint8_t*>(rbAllocInfo[2].pMappedData);
+
+    if(frame->linesize[0] == static_cast<int>(srcYPitch) &&
+       frame->linesize[1] == static_cast<int>(srcCPitch) &&
+       frame->linesize[2] == static_cast<int>(srcCPitch)){
+        memcpy(frame->data[0], srcYBase, srcYPitch * height);
+        memcpy(frame->data[1], srcUBase, srcCPitch * height);
+        memcpy(frame->data[2], srcVBase, srcCPitch * height);
+    }else{
+        for(int y=0;y<height;++y){
+            memcpy(frame->data[0] + y*frame->linesize[0], srcYBase + y*srcYPitch, srcYPitch);
+            memcpy(frame->data[1] + y*frame->linesize[1], srcUBase + y*srcCPitch, srcCPitch);
+            memcpy(frame->data[2] + y*frame->linesize[2], srcVBase + y*srcCPitch, srcCPitch);
         }
+    }
+
+    uint16_t Y0 = *reinterpret_cast<const uint16_t*>(frame->data[0]);
+    uint16_t Y1 = *(reinterpret_cast<const uint16_t*>(frame->data[0]) + 1);
+    uint16_t U0 = *reinterpret_cast<const uint16_t*>(frame->data[1]);
+    uint16_t V0 = *reinterpret_cast<const uint16_t*>(frame->data[2]);
+    {
+        std::ostringstream oss;
+        oss << "[GPU-CHECK] first macropixel  Y0=" << Y0 << " U=" << U0 << " Y1=" << Y1 << " V=" << V0;
+        LogProRes(oss.str());
     }
 
     LogProRes("[GPU] readback complete");


### PR DESCRIPTION
## Summary
- add `GpuColorParams` struct for compute shader
- extend compute shader to apply black/white levels, white balance and color matrix
- push new color parameters to GPU pipeline
- handle row pitch correctly during readback and restore macropixel logging
- adjust ProRes export code to supply new GPU parameters

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687211e5cddc8327b59de92aeb633b3f