### PR TITLE
Fix GPU ProRes export pipeline

### DIFF
--- a/include/Graphics/GpuYuvConverter.h
+++ b/include/Graphics/GpuYuvConverter.h
@@ -9,6 +9,14 @@
 
 class Renderer_VK;
 
+struct GpuColorParams {
+    int black{0};
+    int white{1023};
+    float asShotNeutral[3]{1.0f,1.0f,1.0f};
+    float colorMatrix[9]{1,0,0,0,1,0,0,0,1};
+    int cfaType{0}; // 0 BGGR,1 RGGB,2 GBRG,3 GRBG
+};
+
 class GpuYuvConverter {
 public:
     explicit GpuYuvConverter(Renderer_VK* renderer);
@@ -18,7 +26,7 @@ public:
     void cleanup();
 
     bool convertToFrame(const uint16_t* raw, int width, int height, AVFrame* frame,
-                        const float wbGains[3], const float rgb2yuv[9]);
+                        const GpuColorParams& params);
 private:
     Renderer_VK* m_renderer;
 

--- a/shaders/raw_to_yuv422.comp
+++ b/shaders/raw_to_yuv422.comp
@@ -7,84 +7,131 @@ layout(binding = 1, r16ui) writeonly uniform uimage2D yPlane;
 layout(binding = 2, r16ui) writeonly uniform uimage2D uPlane;
 layout(binding = 3, r16ui) writeonly uniform uimage2D vPlane;
 
-layout(push_constant) uniform PushConsts {
-    int width;
-    int height;
-    vec3 wbGains;
-    mat3 rgb2yuv;
+layout(push_constant) uniform ColorParams {
+    int black;
+    int white;
+    vec3 asShotNeutral;
+    mat3 colorMatrix;
+    int cfaType;
 } pc;
 
-const float kYmul = 876.0;
-const float kCmul = 896.0;
-const float kYoff = 64.0;
-const float kCoff = 512.0;
-const mat3 kRGB2YUV = mat3(
-    0.183,  0.614,  0.062,
-   -0.101, -0.339,  0.439,
-    0.439, -0.399, -0.040
-);
+float invRange() {
+    return 1.0 / max(float(pc.white - pc.black), 1.0);
+}
 
 uint readU16(int x, int y) {
-    x = clamp(x, 0, pc.width - 1);
-    y = clamp(y, 0, pc.height - 1);
+    ivec2 sz = textureSize(rawImage, 0);
+    x = clamp(x, 0, sz.x - 1);
+    y = clamp(y, 0, sz.y - 1);
     return texelFetch(rawImage, ivec2(x, y), 0).r;
 }
 
-vec3 demosaic(int x, int y) {
-    bool ye = (y & 1) == 0;
-    bool xe = (x & 1) == 0;
-    float r = 0.0, g = 0.0, b = 0.0;
-    if (ye) {
-        if (xe) { // B
-            b = float(readU16(x, y));
-            g = 0.25 * (float(readU16(x+1,y)) + float(readU16(x-1,y)) + float(readU16(x,y+1)) + float(readU16(x,y-1)));
-            r = 0.25 * (float(readU16(x+1,y+1)) + float(readU16(x-1,y+1)) + float(readU16(x+1,y-1)) + float(readU16(x-1,y-1)));
-        } else { // G
-            g = float(readU16(x,y));
-            r = 0.5 * (float(readU16(x+1,y)) + float(readU16(x-1,y)));
-            b = 0.5 * (float(readU16(x,y+1)) + float(readU16(x,y-1)));
-        }
-    } else {
-        if (xe) { // G
-            g = float(readU16(x,y));
-            r = 0.5 * (float(readU16(x,y+1)) + float(readU16(x,y-1)));
-            b = 0.5 * (float(readU16(x+1,y)) + float(readU16(x-1,y)));
-        } else { // R
-            r = float(readU16(x,y));
-            g = 0.25 * (float(readU16(x+1,y)) + float(readU16(x-1,y)) + float(readU16(x,y+1)) + float(readU16(x,y-1)));
-            b = 0.25 * (float(readU16(x+1,y+1)) + float(readU16(x-1,y+1)) + float(readU16(x+1,y-1)) + float(readU16(x-1,y-1)));
-        }
-    }
-    return vec3(r,g,b) * pc.wbGains / 1023.0; // assume 10-bit raw
+float linFromRaw(uint v) {
+    float t = (float(v) - float(pc.black)) * invRange();
+    return clamp(t, 0.0, 1.0);
 }
 
-void main() {
+float lin(int x,int y){ return linFromRaw(readU16(x,y)); }
+float interpG(int x,int y){ return 0.25*(lin(x+1,y)+lin(x-1,y)+lin(x,y+1)+lin(x,y-1)); }
+float interpH(int x,int y){ return 0.5*(lin(x+1,y)+lin(x-1,y)); }
+float interpV(int x,int y){ return 0.5*(lin(x,y+1)+lin(x,y-1)); }
+float interpD(int x,int y){ return 0.25*(lin(x+1,y+1)+lin(x-1,y+1)+lin(x+1,y-1)+lin(x-1,y-1)); }
+
+vec3 demosaic(int x,int y){
+    bool ye = (y & 1) == 0;
+    bool xe = (x & 1) == 0;
+    float r=0.0,g=0.0,b=0.0;
+    switch(pc.cfaType){
+        case 0: // BGGR
+            if(ye){
+                if(xe){ b=lin(x,y); g=interpG(x,y); r=interpD(x,y); }
+                else   { g=lin(x,y); r=interpV(x,y); b=interpH(x,y); }
+            }else{
+                if(xe){ g=lin(x,y); r=interpH(x,y); b=interpV(x,y); }
+                else   { r=lin(x,y); g=interpG(x,y); b=interpD(x,y); }
+            }
+            break;
+        case 1: // RGGB
+            if(ye){
+                if(xe){ r=lin(x,y); g=interpG(x,y); b=interpD(x,y); }
+                else   { g=lin(x,y); r=interpH(x,y); b=interpV(x,y); }
+            }else{
+                if(xe){ g=lin(x,y); r=interpV(x,y); b=interpH(x,y); }
+                else   { b=lin(x,y); g=interpG(x,y); r=interpD(x,y); }
+            }
+            break;
+        case 2: // GBRG
+            if(ye){
+                if(xe){ g=lin(x,y); r=interpV(x,y); b=interpH(x,y); }
+                else   { b=lin(x,y); g=interpG(x,y); r=interpD(x,y); }
+            }else{
+                if(xe){ r=lin(x,y); g=interpG(x,y); b=interpD(x,y); }
+                else   { g=lin(x,y); r=interpH(x,y); b=interpV(x,y); }
+            }
+            break;
+        default: // GRBG
+            if(ye){
+                if(xe){ g=lin(x,y); r=interpH(x,y); b=interpV(x,y); }
+                else   { r=lin(x,y); g=interpG(x,y); b=interpD(x,y); }
+            }else{
+                if(xe){ b=lin(x,y); g=interpG(x,y); r=interpD(x,y); }
+                else   { g=lin(x,y); r=interpV(x,y); b=interpH(x,y); }
+            }
+            break;
+    }
+    return vec3(r,g,b);
+}
+
+float srgb_eotf(float v){
+    v = clamp(v,0.0,1.0);
+    return (v <= 0.0031308) ? v*12.92 : 1.055*pow(v,1.0/2.4) - 0.055;
+}
+
+vec3 processPixel(int x,int y){
+    vec3 rgb = demosaic(x,y);
+    float gR = (pc.asShotNeutral.y > 1e-6 && pc.asShotNeutral.x > 1e-6)
+               ? pc.asShotNeutral.y / pc.asShotNeutral.x : 1.0;
+    float gB = (pc.asShotNeutral.y > 1e-6 && pc.asShotNeutral.z > 1e-6)
+               ? pc.asShotNeutral.y / pc.asShotNeutral.z : 1.0;
+    vec3 wb = rgb * vec3(gR,1.0,gB);
+    vec3 cc = clamp(pc.colorMatrix * wb, 0.0, 1.0);
+    cc = vec3(srgb_eotf(cc.r), srgb_eotf(cc.g), srgb_eotf(cc.b));
+    return cc;
+}
+
+vec3 rgbToYUV(vec3 rgb){
+    float Y = dot(rgb, vec3(0.299,0.587,0.114));
+    float U = dot(rgb, vec3(-0.169, -0.331, 0.500)) + 0.5;
+    float V = dot(rgb, vec3(0.500, -0.419, -0.081)) + 0.5;
+    return vec3(Y,U,V);
+}
+
+void main(){
     ivec2 gid = ivec2(gl_GlobalInvocationID.xy);
     int x0 = gid.x * 2;
-    int y = gid.y;
-    if (x0 >= pc.width || y >= pc.height) return;
-    int x1 = min(x0 + 1, pc.width - 1);
+    int y  = gid.y;
+    ivec2 sz = textureSize(rawImage,0);
+    if(x0 >= sz.x || y >= sz.y) return;
+    int x1 = min(x0 + 1, sz.x-1);
 
-    vec3 rgb0 = demosaic(x0, y);
-    vec3 rgb1 = demosaic(x1, y);
+    vec3 rgb0 = processPixel(x0,y);
+    vec3 rgb1 = processPixel(x1,y);
 
-    vec3 yuv0 = (pc.rgb2yuv * rgb0) * kRGB2YUV;
-    vec3 yuv1 = (pc.rgb2yuv * rgb1) * kRGB2YUV;
+    vec3 yuv0 = rgbToYUV(rgb0);
+    vec3 yuv1 = rgbToYUV(rgb1);
 
-    float Y0 = yuv0.x * kYmul + kYoff;
-    float U0 = yuv0.y * kCmul + kCoff;
-    float V0 = yuv0.z * kCmul + kCoff;
-    float Y1 = yuv1.x * kYmul + kYoff;
-    float U1 = yuv1.y * kCmul + kCoff;
-    float V1 = yuv1.z * kCmul + kCoff;
+    float Y0 = yuv0.x;
+    float Y1 = yuv1.x;
+    float U = (yuv0.y + yuv1.y) * 0.5;
+    float V = (yuv0.z + yuv1.z) * 0.5;
 
-    uint y0 = uint(clamp(round(Y0), 0.0, 1023.0)) << 6;
-    uint y1 = uint(clamp(round(Y1), 0.0, 1023.0)) << 6;
-    uint uVal = uint(clamp(round((U0+U1)*0.5), 0.0, 1023.0)) << 6;
-    uint vVal = uint(clamp(round((V0+V1)*0.5), 0.0, 1023.0)) << 6;
+    uint y0 = uint(clamp(round(Y0*1023.0),0.0,1023.0));
+    uint y1 = uint(clamp(round(Y1*1023.0),0.0,1023.0));
+    uint uVal = uint(clamp(round(U*1023.0),0.0,1023.0));
+    uint vVal = uint(clamp(round(V*1023.0),0.0,1023.0));
 
-    imageStore(yPlane, ivec2(x0, y), uvec4(y0,0,0,0));
-    imageStore(yPlane, ivec2(x1, y), uvec4(y1,0,0,0));
-    imageStore(uPlane, ivec2(x0/2, y), uvec4(uVal,0,0,0));
-    imageStore(vPlane, ivec2(x0/2, y), uvec4(vVal,0,0,0));
+    imageStore(yPlane, ivec2(x0,y), uvec4(y0,0,0,0));
+    imageStore(yPlane, ivec2(x1,y), uvec4(y1,0,0,0));
+    imageStore(uPlane, ivec2(x0/2,y), uvec4(uVal,0,0,0));
+    imageStore(vPlane, ivec2(x0/2,y), uvec4(vVal,0,0,0));
 }

--- a/src/App/AppIO.cpp
+++ b/src/App/AppIO.cpp
@@ -1442,14 +1442,16 @@ void App::exportCurrentClipToProRes() {
         }
         cpParams.saturation = 1.0f;
 
-        float wb[3] = { cpParams.gainR, cpParams.gainG, cpParams.gainB };
-        const float rgb2yuvBase[9] = {
-            0.183f, 0.614f, 0.062f,
-           -0.101f,-0.339f, 0.439f,
-            0.439f,-0.399f,-0.040f
-        };
-        float rgb2yuv[9];
-        for(int i=0;i<9;++i) rgb2yuv[i] = rgb2yuvBase[i];
+        GpuColorParams gpuParams{};
+        gpuParams.black = static_cast<int>(cpParams.blackLevel);
+        gpuParams.white = static_cast<int>(cpParams.whiteLevel);
+        if(asn_json.size() >= 3){
+            gpuParams.asShotNeutral[0] = static_cast<float>(asn_json[0]);
+            gpuParams.asShotNeutral[1] = static_cast<float>(asn_json[1]);
+            gpuParams.asShotNeutral[2] = static_cast<float>(asn_json[2]);
+        }
+        for(int i=0;i<9;++i) gpuParams.colorMatrix[i] = cpParams.ccm[i];
+        gpuParams.cfaType = cpParams.cfaType;
 
         {
             std::ostringstream oss;
@@ -1489,7 +1491,7 @@ void App::exportCurrentClipToProRes() {
             t0 = t1;
             if (gpuActive) {
                 if (av_frame_make_writable(frame) < 0) { m_proResStatus.errorMsg = "frame not writable"; break; }
-                converter.convertToFrame(asU16(raw), width, height, frame, wb, rgb2yuv);
+                converter.convertToFrame(asU16(raw), width, height, frame, gpuParams);
                 t1 = std::chrono::steady_clock::now();
                 rgbUS += std::chrono::duration_cast<std::chrono::microseconds>(t1 - t0).count();
             } else {

--- a/src/Graphics/GpuYuvConverter.cpp
+++ b/src/Graphics/GpuYuvConverter.cpp
@@ -59,7 +59,7 @@ bool GpuYuvConverter::init(int width, int height) {
     VkPushConstantRange pcRange{};
     pcRange.stageFlags = VK_SHADER_STAGE_COMPUTE_BIT;
     pcRange.offset = 0;
-    pcRange.size = sizeof(int) * 2 + sizeof(float) * 3 + sizeof(float) * 9;
+    pcRange.size = sizeof(GpuColorParams);
 
     VkPipelineLayoutCreateInfo pli{};
     pli.sType = VK_STRUCTURE_TYPE_PIPELINE_LAYOUT_CREATE_INFO;
@@ -258,7 +258,7 @@ void GpuYuvConverter::cleanup() {
 
 bool GpuYuvConverter::convertToFrame(const uint16_t* raw, int width, int height,
                                      AVFrame* frame,
-                                     const float wbGains[3], const float rgb2yuv[9]) {
+                                     const GpuColorParams& params) {
     LogProRes("[GPU] convertToFrame invoked");
     VkDeviceSize rawSize = static_cast<VkDeviceSize>(width) * height * sizeof(uint16_t);
     VkDeviceSize ySize = static_cast<VkDeviceSize>(width) * height * sizeof(uint16_t);
@@ -382,15 +382,8 @@ bool GpuYuvConverter::convertToFrame(const uint16_t* raw, int width, int height,
     vkCmdBindPipeline(cmd, VK_PIPELINE_BIND_POINT_COMPUTE, m_pipeline);
     vkCmdBindDescriptorSets(cmd, VK_PIPELINE_BIND_POINT_COMPUTE, m_pipelineLayout, 0, 1, &m_descSet, 0, nullptr);
 
-    struct Push {
-        int w; int h;
-        float gains[3];
-        float mtx[9];
-    } push{};
-    push.w = width; push.h = height;
-    for(int i=0;i<3;++i) push.gains[i] = wbGains[i];
-    for(int i=0;i<9;++i) push.mtx[i] = rgb2yuv[i];
-    vkCmdPushConstants(cmd, m_pipelineLayout, VK_SHADER_STAGE_COMPUTE_BIT, 0, sizeof(Push), &push);
+    vkCmdPushConstants(cmd, m_pipelineLayout, VK_SHADER_STAGE_COMPUTE_BIT, 0,
+                      sizeof(GpuColorParams), &params);
 
     vkCmdDispatch(cmd, (uint32_t)((width + 15) / 16), (uint32_t)((height + 15) / 16), 1);
     LogProRes("[GPU] compute dispatched");
@@ -450,23 +443,41 @@ bool GpuYuvConverter::convertToFrame(const uint16_t* raw, int width, int height,
         vmaInvalidateAllocation(m_renderer->m_allocator_p, readbackAlloc[i], 0, size);
     }
 
-    for(int y=0;y<height;++y){
-        const uint8_t* srcY = reinterpret_cast<const uint8_t*>(rbAllocInfo[0].pMappedData) + y*width*2;
-        uint8_t* dstY = frame->data[0] + y*frame->linesize[0];
-        memcpy(dstY, srcY, width*2);
-        const uint8_t* srcU = reinterpret_cast<const uint8_t*>(rbAllocInfo[1].pMappedData) + y*width;
-        const uint8_t* srcV = reinterpret_cast<const uint8_t*>(rbAllocInfo[2].pMappedData) + y*width;
-        uint8_t* dstU = frame->data[1] + y*frame->linesize[1];
-        uint8_t* dstV = frame->data[2] + y*frame->linesize[2];
-        memcpy(dstU, srcU, width);
-        memcpy(dstV, srcV, width);
-        if(y==0){
-            uint16_t y0 = *reinterpret_cast<const uint16_t*>(dstY);
-            uint16_t u0 = *reinterpret_cast<const uint16_t*>(dstU);
-            uint16_t v0 = *reinterpret_cast<const uint16_t*>(dstV);
-            std::ostringstream oss; oss << "[GPU-CHECK] first macropixel  Y=" << y0 << "  U=" << u0 << "  V=" << v0; LogProRes(oss.str());
+    size_t srcPitchY = width * 2;
+    size_t srcPitchC = width;
+    if(frame->linesize[0] == (int)srcPitchY){
+        memcpy(frame->data[0], rbAllocInfo[0].pMappedData, srcPitchY * height);
+    } else {
+        for(int y=0;y<height;++y){
+            memcpy(frame->data[0] + y*frame->linesize[0],
+                   reinterpret_cast<const uint8_t*>(rbAllocInfo[0].pMappedData) + y*srcPitchY,
+                   srcPitchY);
         }
     }
+    if(frame->linesize[1] == (int)srcPitchC){
+        memcpy(frame->data[1], rbAllocInfo[1].pMappedData, srcPitchC * height);
+    } else {
+        for(int y=0;y<height;++y){
+            memcpy(frame->data[1] + y*frame->linesize[1],
+                   reinterpret_cast<const uint8_t*>(rbAllocInfo[1].pMappedData) + y*srcPitchC,
+                   srcPitchC);
+        }
+    }
+    if(frame->linesize[2] == (int)srcPitchC){
+        memcpy(frame->data[2], rbAllocInfo[2].pMappedData, srcPitchC * height);
+    } else {
+        for(int y=0;y<height;++y){
+            memcpy(frame->data[2] + y*frame->linesize[2],
+                   reinterpret_cast<const uint8_t*>(rbAllocInfo[2].pMappedData) + y*srcPitchC,
+                   srcPitchC);
+        }
+    }
+
+    uint16_t y0 = *reinterpret_cast<const uint16_t*>(frame->data[0]);
+    uint16_t y1 = *reinterpret_cast<const uint16_t*>(frame->data[0] + 2);
+    uint16_t u0 = *reinterpret_cast<const uint16_t*>(frame->data[1]);
+    uint16_t v0 = *reinterpret_cast<const uint16_t*>(frame->data[2]);
+    std::ostringstream oss; oss << "[GPU-CHECK] first macropixel Y0=" << y0 << " U=" << u0 << " Y1=" << y1 << " V=" << v0; LogProRes(oss.str());
 
     LogProRes("[GPU] readback complete");
 


### PR DESCRIPTION
## Summary
- add `GpuColorParams` struct for compute shader push constants
- implement full RAW -> YUV422P10 conversion in shader
- update GPU readback code with row pitch handling and improved macropixel logging
- wire up new parameters in CPU export path

## Testing
- `glslangValidator -V shaders/raw_to_yuv422.comp -o /tmp/raw_to_yuv422.comp.spv`
- `cmake -S . -B build -DCMAKE_BUILD_TYPE=Release` *(fails: FindFFMPEG.cmake not found)*

------
https://chatgpt.com/codex/tasks/task_e_687211e5cddc8327b59de92aeb633b3f