### PR TITLE
Fix GPU YUV pipeline

### DIFF
--- a/include/Graphics/GpuColorParams.h
+++ b/include/Graphics/GpuColorParams.h
@@ -1,0 +1,12 @@
+#ifndef GPU_COLOR_PARAMS_H
+#define GPU_COLOR_PARAMS_H
+
+struct GpuColorParams {
+    int black{0};
+    int white{1023};
+    float asShotNeutral[3]{1.0f,1.0f,1.0f};
+    float colorMatrix[9]{1,0,0,0,1,0,0,0,1};
+    int cfaType{0}; // 0 BGGR,1 RGGB,2 GBRG,3 GRBG
+};
+
+#endif // GPU_COLOR_PARAMS_H

--- a/include/Graphics/GpuYuvConverter.h
+++ b/include/Graphics/GpuYuvConverter.h
@@ -6,6 +6,7 @@
 #include <cstdint>
 #include <libavutil/frame.h>
 #include "Utils/vma_usage.h"
+#include "Graphics/GpuColorParams.h"
 
 class Renderer_VK;
 
@@ -18,7 +19,7 @@ public:
     void cleanup();
 
     bool convertToFrame(const uint16_t* raw, int width, int height, AVFrame* frame,
-                        const float wbGains[3], const float rgb2yuv[9]);
+                        const GpuColorParams& params);
 private:
     Renderer_VK* m_renderer;
 

--- a/shaders/raw_to_yuv422.comp
+++ b/shaders/raw_to_yuv422.comp
@@ -10,8 +10,11 @@ layout(binding = 3, r16ui) writeonly uniform uimage2D vPlane;
 layout(push_constant) uniform PushConsts {
     int width;
     int height;
-    vec3 wbGains;
-    mat3 rgb2yuv;
+    int black;
+    int white;
+    int cfaType;
+    vec3 asShotNeutral;
+    float colorMatrix[9];
 } pc;
 
 const float kYmul = 876.0;
@@ -24,52 +27,100 @@ const mat3 kRGB2YUV = mat3(
     0.439, -0.399, -0.040
 );
 
-uint readU16(int x, int y) {
-    x = clamp(x, 0, pc.width - 1);
-    y = clamp(y, 0, pc.height - 1);
-    return texelFetch(rawImage, ivec2(x, y), 0).r;
+float srgb_eotf(float v){
+    v = clamp(v,0.0,1.0);
+    return (v <= 0.0031308) ? v*12.92 : 1.055*pow(v,1.0/2.4) - 0.055;
 }
 
-vec3 demosaic(int x, int y) {
-    bool ye = (y & 1) == 0;
-    bool xe = (x & 1) == 0;
-    float r = 0.0, g = 0.0, b = 0.0;
-    if (ye) {
-        if (xe) { // B
-            b = float(readU16(x, y));
-            g = 0.25 * (float(readU16(x+1,y)) + float(readU16(x-1,y)) + float(readU16(x,y+1)) + float(readU16(x,y-1)));
-            r = 0.25 * (float(readU16(x+1,y+1)) + float(readU16(x-1,y+1)) + float(readU16(x+1,y-1)) + float(readU16(x-1,y-1)));
-        } else { // G
-            g = float(readU16(x,y));
-            r = 0.5 * (float(readU16(x+1,y)) + float(readU16(x-1,y)));
-            b = 0.5 * (float(readU16(x,y+1)) + float(readU16(x,y-1)));
+uint readU16(int x,int y){
+    x = clamp(x,0,pc.width-1);
+    y = clamp(y,0,pc.height-1);
+    return texelFetch(rawImage, ivec2(x,y),0).r;
+}
+
+float linearise(uint v){
+    float t = (float(v) - float(pc.black)) / float(pc.white - pc.black);
+    return clamp(t,0.0,1.0);
+}
+
+float interpG(int x,int y){return 0.25*(linearise(readU16(x+1,y))+linearise(readU16(x-1,y))+linearise(readU16(x,y+1))+linearise(readU16(x,y-1)));}
+float interpH(int x,int y){return 0.5*(linearise(readU16(x+1,y))+linearise(readU16(x-1,y)));}
+float interpV(int x,int y){return 0.5*(linearise(readU16(x,y+1))+linearise(readU16(x,y-1)));}
+float interpD(int x,int y){return 0.25*(linearise(readU16(x+1,y+1))+linearise(readU16(x-1,y+1))+linearise(readU16(x+1,y-1))+linearise(readU16(x-1,y-1)));}
+
+vec3 demosaic(int x,int y){
+    bool ye = (y&1)==0;
+    bool xe = (x&1)==0;
+    float r=0.0,g=0.0,b=0.0;
+    int cfa = pc.cfaType;
+    if(cfa==0){
+        if(ye){
+            if(xe){ b=linearise(readU16(x,y)); g=interpG(x,y); r=interpD(x,y); }
+            else { g=linearise(readU16(x,y)); r=interpV(x,y); b=interpH(x,y); }
+        }else{
+            if(xe){ g=linearise(readU16(x,y)); r=interpH(x,y); b=interpV(x,y); }
+            else { r=linearise(readU16(x,y)); g=interpG(x,y); b=interpD(x,y); }
         }
-    } else {
-        if (xe) { // G
-            g = float(readU16(x,y));
-            r = 0.5 * (float(readU16(x,y+1)) + float(readU16(x,y-1)));
-            b = 0.5 * (float(readU16(x+1,y)) + float(readU16(x-1,y)));
-        } else { // R
-            r = float(readU16(x,y));
-            g = 0.25 * (float(readU16(x+1,y)) + float(readU16(x-1,y)) + float(readU16(x,y+1)) + float(readU16(x,y-1)));
-            b = 0.25 * (float(readU16(x+1,y+1)) + float(readU16(x-1,y+1)) + float(readU16(x+1,y-1)) + float(readU16(x-1,y-1)));
+    }else if(cfa==1){
+        if(ye){
+            if(xe){ r=linearise(readU16(x,y)); g=interpG(x,y); b=interpD(x,y); }
+            else { g=linearise(readU16(x,y)); r=interpH(x,y); b=interpV(x,y); }
+        }else{
+            if(xe){ g=linearise(readU16(x,y)); r=interpV(x,y); b=interpH(x,y); }
+            else { b=linearise(readU16(x,y)); g=interpG(x,y); r=interpD(x,y); }
+        }
+    }else if(cfa==2){
+        if(ye){
+            if(xe){ g=linearise(readU16(x,y)); r=interpV(x,y); b=interpH(x,y); }
+            else { b=linearise(readU16(x,y)); g=interpG(x,y); r=interpD(x,y); }
+        }else{
+            if(xe){ r=linearise(readU16(x,y)); g=interpG(x,y); b=interpD(x,y); }
+            else { g=linearise(readU16(x,y)); r=interpH(x,y); b=interpV(x,y); }
+        }
+    }else{
+        if(ye){
+            if(xe){ g=linearise(readU16(x,y)); r=interpH(x,y); b=interpV(x,y); }
+            else { r=linearise(readU16(x,y)); g=interpG(x,y); b=interpD(x,y); }
+        }else{
+            if(xe){ b=linearise(readU16(x,y)); g=interpG(x,y); r=interpD(x,y); }
+            else { g=linearise(readU16(x,y)); r=interpV(x,y); b=interpH(x,y); }
         }
     }
-    return vec3(r,g,b) * pc.wbGains / 1023.0; // assume 10-bit raw
+    return vec3(r,g,b);
 }
 
-void main() {
+void main(){
     ivec2 gid = ivec2(gl_GlobalInvocationID.xy);
     int x0 = gid.x * 2;
     int y = gid.y;
-    if (x0 >= pc.width || y >= pc.height) return;
-    int x1 = min(x0 + 1, pc.width - 1);
+    if(x0 >= pc.width || y >= pc.height) return;
+    int x1 = min(x0+1, pc.width-1);
 
-    vec3 rgb0 = demosaic(x0, y);
-    vec3 rgb1 = demosaic(x1, y);
+    vec3 rgb0 = demosaic(x0,y);
+    vec3 rgb1 = demosaic(x1,y);
 
-    vec3 yuv0 = (pc.rgb2yuv * rgb0) * kRGB2YUV;
-    vec3 yuv1 = (pc.rgb2yuv * rgb1) * kRGB2YUV;
+    float gainR = (pc.asShotNeutral.y > 1e-6 && pc.asShotNeutral.x > 1e-6) ? pc.asShotNeutral.y / pc.asShotNeutral.x : 1.0;
+    float gainB = (pc.asShotNeutral.y > 1e-6 && pc.asShotNeutral.z > 1e-6) ? pc.asShotNeutral.y / pc.asShotNeutral.z : 1.0;
+
+    rgb0 = vec3(rgb0.r * gainR, rgb0.g, rgb0.b * gainB);
+    rgb1 = vec3(rgb1.r * gainR, rgb1.g, rgb1.b * gainB);
+
+    mat3 ccm = mat3(
+        pc.colorMatrix[0], pc.colorMatrix[3], pc.colorMatrix[6],
+        pc.colorMatrix[1], pc.colorMatrix[4], pc.colorMatrix[7],
+        pc.colorMatrix[2], pc.colorMatrix[5], pc.colorMatrix[8]
+    );
+    rgb0 = ccm * rgb0;
+    rgb1 = ccm * rgb1;
+
+    rgb0 = clamp(rgb0,0.0,1.0);
+    rgb1 = clamp(rgb1,0.0,1.0);
+
+    rgb0 = vec3(srgb_eotf(rgb0.r), srgb_eotf(rgb0.g), srgb_eotf(rgb0.b));
+    rgb1 = vec3(srgb_eotf(rgb1.r), srgb_eotf(rgb1.g), srgb_eotf(rgb1.b));
+
+    vec3 yuv0 = kRGB2YUV * rgb0;
+    vec3 yuv1 = kRGB2YUV * rgb1;
 
     float Y0 = yuv0.x * kYmul + kYoff;
     float U0 = yuv0.y * kCmul + kCoff;
@@ -78,13 +129,13 @@ void main() {
     float U1 = yuv1.y * kCmul + kCoff;
     float V1 = yuv1.z * kCmul + kCoff;
 
-    uint y0 = uint(clamp(round(Y0), 0.0, 1023.0)) << 6;
-    uint y1 = uint(clamp(round(Y1), 0.0, 1023.0)) << 6;
-    uint uVal = uint(clamp(round((U0+U1)*0.5), 0.0, 1023.0)) << 6;
-    uint vVal = uint(clamp(round((V0+V1)*0.5), 0.0, 1023.0)) << 6;
+    uint y0 = uint(clamp(round(Y0),0.0,1023.0));
+    uint y1 = uint(clamp(round(Y1),0.0,1023.0));
+    uint uVal = uint(clamp(round((U0+U1)*0.5),0.0,1023.0));
+    uint vVal = uint(clamp(round((V0+V1)*0.5),0.0,1023.0));
 
-    imageStore(yPlane, ivec2(x0, y), uvec4(y0,0,0,0));
-    imageStore(yPlane, ivec2(x1, y), uvec4(y1,0,0,0));
-    imageStore(uPlane, ivec2(x0/2, y), uvec4(uVal,0,0,0));
-    imageStore(vPlane, ivec2(x0/2, y), uvec4(vVal,0,0,0));
+    imageStore(yPlane, ivec2(x0,y), uvec4(y0,0,0,0));
+    imageStore(yPlane, ivec2(x1,y), uvec4(y1,0,0,0));
+    imageStore(uPlane, ivec2(x0/2,y), uvec4(uVal,0,0,0));
+    imageStore(vPlane, ivec2(x0/2,y), uvec4(vVal,0,0,0));
 }

--- a/src/App/AppIO.cpp
+++ b/src/App/AppIO.cpp
@@ -1431,25 +1431,29 @@ void App::exportCurrentClipToProRes() {
         cpParams.cfaType = m_cfaTypeFromMetadata;
         cpParams.blackLevel = m_staticBlack;
         cpParams.whiteLevel = m_staticWhite;
+
+        GpuColorParams gpuParams{};
+        gpuParams.black = m_staticBlack;
+        gpuParams.white = m_staticWhite;
+        gpuParams.cfaType = m_cfaTypeFromMetadata;
+
         auto asn_json = meta.value("asShotNeutral", std::vector<double>{1.0,1.0,1.0});
         if (asn_json.size() >= 3) {
             cpParams.gainR = (asn_json[1] > 1e-6 && asn_json[0] > 1e-6) ? (float)(asn_json[1]/asn_json[0]) : 1.0f;
             cpParams.gainB = (asn_json[1] > 1e-6 && asn_json[2] > 1e-6) ? (float)(asn_json[1]/asn_json[2]) : 1.0f;
+            gpuParams.asShotNeutral[0] = static_cast<float>(asn_json[0]);
+            gpuParams.asShotNeutral[1] = static_cast<float>(asn_json[1]);
+            gpuParams.asShotNeutral[2] = static_cast<float>(asn_json[2]);
         }
         auto ccm_json = meta.value("ColorMatrix2", meta.value("ColorMatrix", std::vector<float>{1,0,0,0,1,0,0,0,1}));
         if (ccm_json.size() == 9) {
-            for(int i=0;i<9;++i) cpParams.ccm[i] = ccm_json[i];
+            for(int i=0;i<9;++i){
+                cpParams.ccm[i] = ccm_json[i];
+                gpuParams.colorMatrix[i] = ccm_json[i];
+            }
         }
         cpParams.saturation = 1.0f;
 
-        float wb[3] = { cpParams.gainR, cpParams.gainG, cpParams.gainB };
-        const float rgb2yuvBase[9] = {
-            0.183f, 0.614f, 0.062f,
-           -0.101f,-0.339f, 0.439f,
-            0.439f,-0.399f,-0.040f
-        };
-        float rgb2yuv[9];
-        for(int i=0;i<9;++i) rgb2yuv[i] = rgb2yuvBase[i];
 
         {
             std::ostringstream oss;
@@ -1489,7 +1493,7 @@ void App::exportCurrentClipToProRes() {
             t0 = t1;
             if (gpuActive) {
                 if (av_frame_make_writable(frame) < 0) { m_proResStatus.errorMsg = "frame not writable"; break; }
-                converter.convertToFrame(asU16(raw), width, height, frame, wb, rgb2yuv);
+                converter.convertToFrame(asU16(raw), width, height, frame, gpuParams);
                 t1 = std::chrono::steady_clock::now();
                 rgbUS += std::chrono::duration_cast<std::chrono::microseconds>(t1 - t0).count();
             } else {

--- a/src/Graphics/GpuYuvConverter.cpp
+++ b/src/Graphics/GpuYuvConverter.cpp
@@ -1,4 +1,5 @@
 #include "Graphics/GpuYuvConverter.h"
+#include "Graphics/GpuColorParams.h"
 #include "Graphics/Renderer_VK.h"
 #include "Graphics/VulkanHelpers.h"
 #include "Graphics/ImageResource.h"
@@ -59,7 +60,7 @@ bool GpuYuvConverter::init(int width, int height) {
     VkPushConstantRange pcRange{};
     pcRange.stageFlags = VK_SHADER_STAGE_COMPUTE_BIT;
     pcRange.offset = 0;
-    pcRange.size = sizeof(int) * 2 + sizeof(float) * 3 + sizeof(float) * 9;
+    pcRange.size = sizeof(int) * 5 + sizeof(float) * 12;
 
     VkPipelineLayoutCreateInfo pli{};
     pli.sType = VK_STRUCTURE_TYPE_PIPELINE_LAYOUT_CREATE_INFO;
@@ -258,7 +259,7 @@ void GpuYuvConverter::cleanup() {
 
 bool GpuYuvConverter::convertToFrame(const uint16_t* raw, int width, int height,
                                      AVFrame* frame,
-                                     const float wbGains[3], const float rgb2yuv[9]) {
+                                     const GpuColorParams& params) {
     LogProRes("[GPU] convertToFrame invoked");
     VkDeviceSize rawSize = static_cast<VkDeviceSize>(width) * height * sizeof(uint16_t);
     VkDeviceSize ySize = static_cast<VkDeviceSize>(width) * height * sizeof(uint16_t);
@@ -383,13 +384,20 @@ bool GpuYuvConverter::convertToFrame(const uint16_t* raw, int width, int height,
     vkCmdBindDescriptorSets(cmd, VK_PIPELINE_BIND_POINT_COMPUTE, m_pipelineLayout, 0, 1, &m_descSet, 0, nullptr);
 
     struct Push {
-        int w; int h;
-        float gains[3];
-        float mtx[9];
+        int w;
+        int h;
+        int black;
+        int white;
+        int cfa;
+        float asn[3];
+        float ccm[9];
     } push{};
     push.w = width; push.h = height;
-    for(int i=0;i<3;++i) push.gains[i] = wbGains[i];
-    for(int i=0;i<9;++i) push.mtx[i] = rgb2yuv[i];
+    push.black = params.black;
+    push.white = params.white;
+    push.cfa = params.cfaType;
+    for(int i=0;i<3;++i) push.asn[i] = params.asShotNeutral[i];
+    for(int i=0;i<9;++i) push.ccm[i] = params.colorMatrix[i];
     vkCmdPushConstants(cmd, m_pipelineLayout, VK_SHADER_STAGE_COMPUTE_BIT, 0, sizeof(Push), &push);
 
     vkCmdDispatch(cmd, (uint32_t)((width + 15) / 16), (uint32_t)((height + 15) / 16), 1);
@@ -450,22 +458,40 @@ bool GpuYuvConverter::convertToFrame(const uint16_t* raw, int width, int height,
         vmaInvalidateAllocation(m_renderer->m_allocator_p, readbackAlloc[i], 0, size);
     }
 
-    for(int y=0;y<height;++y){
-        const uint8_t* srcY = reinterpret_cast<const uint8_t*>(rbAllocInfo[0].pMappedData) + y*width*2;
-        uint8_t* dstY = frame->data[0] + y*frame->linesize[0];
-        memcpy(dstY, srcY, width*2);
-        const uint8_t* srcU = reinterpret_cast<const uint8_t*>(rbAllocInfo[1].pMappedData) + y*width;
-        const uint8_t* srcV = reinterpret_cast<const uint8_t*>(rbAllocInfo[2].pMappedData) + y*width;
-        uint8_t* dstU = frame->data[1] + y*frame->linesize[1];
-        uint8_t* dstV = frame->data[2] + y*frame->linesize[2];
-        memcpy(dstU, srcU, width);
-        memcpy(dstV, srcV, width);
-        if(y==0){
-            uint16_t y0 = *reinterpret_cast<const uint16_t*>(dstY);
-            uint16_t u0 = *reinterpret_cast<const uint16_t*>(dstU);
-            uint16_t v0 = *reinterpret_cast<const uint16_t*>(dstV);
-            std::ostringstream oss; oss << "[GPU-CHECK] first macropixel  Y=" << y0 << "  U=" << u0 << "  V=" << v0; LogProRes(oss.str());
-        }
+    size_t srcPitchY = width * 2;
+    size_t srcPitchC = (width / 2) * 2;
+    if(frame->linesize[0] == static_cast<int>(srcPitchY))
+        memcpy(frame->data[0], rbAllocInfo[0].pMappedData, srcPitchY * height);
+    else
+        for(int y=0;y<height;++y)
+            memcpy(frame->data[0] + y*frame->linesize[0],
+                   reinterpret_cast<const uint8_t*>(rbAllocInfo[0].pMappedData) + y*srcPitchY,
+                   srcPitchY);
+
+    if(frame->linesize[1] == static_cast<int>(srcPitchC))
+        memcpy(frame->data[1], rbAllocInfo[1].pMappedData, srcPitchC * height);
+    else
+        for(int y=0;y<height;++y)
+            memcpy(frame->data[1] + y*frame->linesize[1],
+                   reinterpret_cast<const uint8_t*>(rbAllocInfo[1].pMappedData) + y*srcPitchC,
+                   srcPitchC);
+
+    if(frame->linesize[2] == static_cast<int>(srcPitchC))
+        memcpy(frame->data[2], rbAllocInfo[2].pMappedData, srcPitchC * height);
+    else
+        for(int y=0;y<height;++y)
+            memcpy(frame->data[2] + y*frame->linesize[2],
+                   reinterpret_cast<const uint8_t*>(rbAllocInfo[2].pMappedData) + y*srcPitchC,
+                   srcPitchC);
+
+    uint16_t y0 = *reinterpret_cast<const uint16_t*>(frame->data[0]);
+    uint16_t u0 = *reinterpret_cast<const uint16_t*>(frame->data[1]);
+    uint16_t y1 = *reinterpret_cast<const uint16_t*>(frame->data[0] + 2);
+    uint16_t v0 = *reinterpret_cast<const uint16_t*>(frame->data[2]);
+    {
+        std::ostringstream oss;
+        oss << "[GPU-CHECK] first macropixel  Y0=" << y0 << " U=" << u0 << " Y1=" << y1 << " V=" << v0;
+        LogProRes(oss.str());
     }
 
     LogProRes("[GPU] readback complete");


### PR DESCRIPTION
## Summary
- add `GpuColorParams` struct to pass colour metadata to compute shader
- handle all conversion parameters via push constants
- implement row-pitch aware readback and restore first macropixel logging
- rework compute shader to match CPU pipeline and output proper YUV422P10

## Testing
- `glslangValidator -V shaders/raw_to_yuv422.comp -o shaders_spv/raw_to_yuv422.comp.spv`
- `cmake -S . -B build` *(fails: FindFFMPEG.cmake missing)*

------
https://chatgpt.com/codex/tasks/task_e_687211e5cddc8327b59de92aeb633b3f