### PR TITLE
Fix chroma scaling for ProRes export

### DIFF
--- a/shaders/raw_to_yuv422.comp
+++ b/shaders/raw_to_yuv422.comp
@@ -18,9 +18,8 @@ layout(push_constant) uniform PushConsts {
 } pc;
 
 const float kYmul = 876.0;
-const float kCmul = 896.0;
+const float kUVRange = 896.0; // 224*4
 const float kYoff = 64.0;
-const float kCoff = 512.0;
 const mat3 kRGB2YUV = mat3(
     0.183,  0.614,  0.062,
    -0.101, -0.339,  0.439,
@@ -123,16 +122,14 @@ void main(){
     vec3 yuv1 = kRGB2YUV * rgb1;
 
     float Y0 = yuv0.x * kYmul + kYoff;
-    float U0 = yuv0.y * kCmul + kCoff;
-    float V0 = yuv0.z * kCmul + kCoff;
     float Y1 = yuv1.x * kYmul + kYoff;
-    float U1 = yuv1.y * kCmul + kCoff;
-    float V1 = yuv1.z * kCmul + kCoff;
+    float Uavg = (yuv0.y + yuv1.y) * 0.5;
+    float Vavg = (yuv0.z + yuv1.z) * 0.5;
 
-    uint y0 = uint(clamp(round(Y0),0.0,1023.0));
-    uint y1 = uint(clamp(round(Y1),0.0,1023.0));
-    uint uVal = uint(clamp(round((U0+U1)*0.5),0.0,1023.0));
-    uint vVal = uint(clamp(round((V0+V1)*0.5),0.0,1023.0));
+    uint y0 = uint(clamp(round(Y0), 0.0, 1023.0));
+    uint y1 = uint(clamp(round(Y1), 0.0, 1023.0));
+    uint uVal = uint(clamp(int(round((Uavg + 0.5) * kUVRange)) + 512, 0, 1023));
+    uint vVal = uint(clamp(int(round((Vavg + 0.5) * kUVRange)) + 512, 0, 1023));
 
     imageStore(yPlane, ivec2(x0,y), uvec4(y0,0,0,0));
     imageStore(yPlane, ivec2(x1,y), uvec4(y1,0,0,0));


### PR DESCRIPTION
## Summary
- adjust GPU shader to scale Cb/Cr using Rec601 limited range

## Testing
- `cmake ..` *(fails: Could not find a package configuration file provided by "FFMPEG")*

------
https://chatgpt.com/codex/tasks/task_e_68724e4786688327869b46aea053a2f6