### PR TITLE
Fix chroma scaling in GPU YUV shader

### DIFF
--- a/shaders/raw_to_yuv422.comp
+++ b/shaders/raw_to_yuv422.comp
@@ -18,7 +18,7 @@ layout(push_constant) uniform PushConsts {
 } pc;
 
 const float kYmul = 876.0;
-const float kCmul = 896.0;
+const float kUVRange = 896.0; // Rec 601 limited range for chroma
 const float kYoff = 64.0;
 const float kCoff = 512.0;
 const mat3 kRGB2YUV = mat3(
@@ -123,16 +123,17 @@ void main(){
     vec3 yuv1 = kRGB2YUV * rgb1;
 
     float Y0 = yuv0.x * kYmul + kYoff;
-    float U0 = yuv0.y * kCmul + kCoff;
-    float V0 = yuv0.z * kCmul + kCoff;
     float Y1 = yuv1.x * kYmul + kYoff;
-    float U1 = yuv1.y * kCmul + kCoff;
-    float V1 = yuv1.z * kCmul + kCoff;
+
+    uint u0 = clamp(int(round((yuv0.y + 0.5) * kUVRange)) + 512, 0, 1023);
+    uint v0 = clamp(int(round((yuv0.z + 0.5) * kUVRange)) + 512, 0, 1023);
+    uint u1 = clamp(int(round((yuv1.y + 0.5) * kUVRange)) + 512, 0, 1023);
+    uint v1 = clamp(int(round((yuv1.z + 0.5) * kUVRange)) + 512, 0, 1023);
 
     uint y0 = uint(clamp(round(Y0),0.0,1023.0));
     uint y1 = uint(clamp(round(Y1),0.0,1023.0));
-    uint uVal = uint(clamp(round((U0+U1)*0.5),0.0,1023.0));
-    uint vVal = uint(clamp(round((V0+V1)*0.5),0.0,1023.0));
+    uint uVal = uint((u0 + u1) / 2);
+    uint vVal = uint((v0 + v1) / 2);
 
     imageStore(yPlane, ivec2(x0,y), uvec4(y0,0,0,0));
     imageStore(yPlane, ivec2(x1,y), uvec4(y1,0,0,0));


### PR DESCRIPTION
## Summary
- correct UV scaling for Rec.601 limited range

## Testing
- `glslangValidator -V shaders/raw_to_yuv422.comp -o /tmp/out.spv`

------
https://chatgpt.com/codex/tasks/task_e_68724e4786688327869b46aea053a2f6