### PR TITLE
Fix limited-range YUV packing for GPU ProRes

### DIFF
--- a/shaders/raw_to_yuv422.comp
+++ b/shaders/raw_to_yuv422.comp
@@ -101,8 +101,8 @@ vec3 processPixel(int x,int y){
 
 vec3 rgbToYUV(vec3 rgb){
     float Y = dot(rgb, vec3(0.299,0.587,0.114));
-    float U = dot(rgb, vec3(-0.169, -0.331, 0.500)) + 0.5;
-    float V = dot(rgb, vec3(0.500, -0.419, -0.081)) + 0.5;
+    float U = dot(rgb, vec3(-0.169, -0.331, 0.500));
+    float V = dot(rgb, vec3(0.500, -0.419, -0.081));
     return vec3(Y,U,V);
 }
 
@@ -125,10 +125,15 @@ void main(){
     float U = (yuv0.y + yuv1.y) * 0.5;
     float V = (yuv0.z + yuv1.z) * 0.5;
 
-    uint y0 = uint(clamp(round(Y0*1023.0),0.0,1023.0));
-    uint y1 = uint(clamp(round(Y1*1023.0),0.0,1023.0));
-    uint uVal = uint(clamp(round(U*1023.0),0.0,1023.0));
-    uint vVal = uint(clamp(round(V*1023.0),0.0,1023.0));
+    const float kYRange  = 940.0;
+    const float kUVRange = 896.0;
+
+    uint y0 = clamp(int(round(Y0 * kYRange)) + 64, 0, 1023);
+    uint y1 = clamp(int(round(Y1 * kYRange)) + 64, 0, 1023);
+    uint uVal = clamp(int(round((U + 0.5) * kUVRange)) + 512, 0, 1023);
+    uint vVal = clamp(int(round((V + 0.5) * kUVRange)) + 512, 0, 1023);
+
+    y0 <<= 6; y1 <<= 6; uVal <<= 6; vVal <<= 6;
 
     imageStore(yPlane, ivec2(x0,y), uvec4(y0,0,0,0));
     imageStore(yPlane, ivec2(x1,y), uvec4(y1,0,0,0));

--- a/src/Graphics/GpuYuvConverter.cpp
+++ b/src/Graphics/GpuYuvConverter.cpp
@@ -473,11 +473,20 @@ bool GpuYuvConverter::convertToFrame(const uint16_t* raw, int width, int height,
         }
     }
 
-    uint16_t y0 = *reinterpret_cast<const uint16_t*>(frame->data[0]);
-    uint16_t y1 = *reinterpret_cast<const uint16_t*>(frame->data[0] + 2);
-    uint16_t u0 = *reinterpret_cast<const uint16_t*>(frame->data[1]);
-    uint16_t v0 = *reinterpret_cast<const uint16_t*>(frame->data[2]);
-    std::ostringstream oss; oss << "[GPU-CHECK] first macropixel Y0=" << y0 << " U=" << u0 << " Y1=" << y1 << " V=" << v0; LogProRes(oss.str());
+    static bool firstDump = false;
+    if(!firstDump){
+        std::ostringstream oss;
+        oss << "[GPU-CHECK] macropixels:";
+        for(int i=0;i<16;++i){
+            uint16_t y0 = *reinterpret_cast<const uint16_t*>(frame->data[0] + i*4);
+            uint16_t y1 = *reinterpret_cast<const uint16_t*>(frame->data[0] + i*4 + 2);
+            uint16_t u0 = *reinterpret_cast<const uint16_t*>(frame->data[1] + i*2);
+            uint16_t v0 = *reinterpret_cast<const uint16_t*>(frame->data[2] + i*2);
+            oss << " [" << i << "]Y0=" << y0 << " U=" << u0 << " Y1=" << y1 << " V=" << v0;
+        }
+        LogProRes(oss.str());
+        firstDump = true;
+    }
 
     LogProRes("[GPU] readback complete");
 


### PR DESCRIPTION
## Summary
- correct RGB→YUV conversion and 10‑bit limited‑range packing
- dump the first sixteen macropixels once for debugging

## Testing
- `cmake -B build -DENABLE_GPU=ON` *(fails: could not find package `FFMPEG`)*

------
https://chatgpt.com/codex/tasks/task_e_687255994a7c8327948b7e144095eff8