### PR TITLE
Fix chroma offset in GPU YUV conversion

### DIFF
--- a/shaders/raw_to_yuv422.comp
+++ b/shaders/raw_to_yuv422.comp
@@ -106,6 +106,9 @@ vec3 rgbToYUV(vec3 rgb){
     return vec3(Y,U,V);
 }
 
+const float kYRange  = 940.0;   // 235×4
+const float kUVRange = 896.0;   // 224×4
+
 void main(){
     ivec2 gid = ivec2(gl_GlobalInvocationID.xy);
     int x0 = gid.x * 2;
@@ -125,10 +128,10 @@ void main(){
     float U = (yuv0.y + yuv1.y) * 0.5;
     float V = (yuv0.z + yuv1.z) * 0.5;
 
-    uint y0 = uint(clamp(round(Y0*1023.0),0.0,1023.0));
-    uint y1 = uint(clamp(round(Y1*1023.0),0.0,1023.0));
-    uint uVal = uint(clamp(round(U*1023.0),0.0,1023.0));
-    uint vVal = uint(clamp(round(V*1023.0),0.0,1023.0));
+    uint y0 = uint(clamp(int(round(Y0 * kYRange))  + 64,  0, 1023));
+    uint y1 = uint(clamp(int(round(Y1 * kYRange))  + 64,  0, 1023));
+    uint uVal = uint(clamp(int(round(U * kUVRange)) + 512, 0, 1023));
+    uint vVal = uint(clamp(int(round(V * kUVRange)) + 512, 0, 1023));
 
     imageStore(yPlane, ivec2(x0,y), uvec4(y0,0,0,0));
     imageStore(yPlane, ivec2(x1,y), uvec4(y1,0,0,0));

--- a/src/Graphics/GpuYuvConverter.cpp
+++ b/src/Graphics/GpuYuvConverter.cpp
@@ -473,11 +473,16 @@ bool GpuYuvConverter::convertToFrame(const uint16_t* raw, int width, int height,
         }
     }
 
-    uint16_t y0 = *reinterpret_cast<const uint16_t*>(frame->data[0]);
-    uint16_t y1 = *reinterpret_cast<const uint16_t*>(frame->data[0] + 2);
-    uint16_t u0 = *reinterpret_cast<const uint16_t*>(frame->data[1]);
-    uint16_t v0 = *reinterpret_cast<const uint16_t*>(frame->data[2]);
-    std::ostringstream oss; oss << "[GPU-CHECK] first macropixel Y0=" << y0 << " U=" << u0 << " Y1=" << y1 << " V=" << v0; LogProRes(oss.str());
+    int dump = std::min(16, width/2);
+    std::ostringstream oss; oss << "[GPU-CHECK] first macropixels";
+    for(int i=0;i<dump;++i){
+        uint16_t y0 = *reinterpret_cast<const uint16_t*>(frame->data[0] + i*4);
+        uint16_t y1 = *reinterpret_cast<const uint16_t*>(frame->data[0] + i*4 + 2);
+        uint16_t u0 = *reinterpret_cast<const uint16_t*>(frame->data[1] + i*2);
+        uint16_t v0 = *reinterpret_cast<const uint16_t*>(frame->data[2] + i*2);
+        oss << (i?"; ":" ") << "Y0="<<y0<<" U="<<u0<<" Y1="<<y1<<" V="<<v0;
+    }
+    LogProRes(oss.str());
 
     LogProRes("[GPU] readback complete");
 


### PR DESCRIPTION
## Summary
- adjust compute shader to output limited-range 10‑bit YUV
- log the first 16 macropixels after GPU readback for debugging

## Testing
- `cmake -B build -DENABLE_GPU=ON` *(fails: Could not find package configuration file provided by "FFMPEG" )*

------
https://chatgpt.com/codex/tasks/task_e_687255994a7c8327948b7e144095eff8