### PR TITLE
Fix YUV packing in GPU shader

### DIFF
--- a/shaders/raw_to_yuv422.comp
+++ b/shaders/raw_to_yuv422.comp
@@ -125,10 +125,13 @@ void main(){
     float U = (yuv0.y + yuv1.y) * 0.5;
     float V = (yuv0.z + yuv1.z) * 0.5;
 
-    uint y0 = uint(clamp(round(Y0*1023.0),0.0,1023.0));
-    uint y1 = uint(clamp(round(Y1*1023.0),0.0,1023.0));
-    uint uVal = uint(clamp(round(U*1023.0),0.0,1023.0));
-    uint vVal = uint(clamp(round(V*1023.0),0.0,1023.0));
+    const float kYRange  = 940.0;   // 235×4
+    const float kUVRange = 896.0;   // 224×4
+
+    uint y0 = uint(clamp(int(round(Y0 * kYRange)) + 64, 0, 1023));
+    uint y1 = uint(clamp(int(round(Y1 * kYRange)) + 64, 0, 1023));
+    uint uVal = uint(clamp(int(round(U * kUVRange)) + 512, 0, 1023));
+    uint vVal = uint(clamp(int(round(V * kUVRange)) + 512, 0, 1023));
 
     imageStore(yPlane, ivec2(x0,y), uvec4(y0,0,0,0));
     imageStore(yPlane, ivec2(x1,y), uvec4(y1,0,0,0));

--- a/src/Graphics/GpuYuvConverter.cpp
+++ b/src/Graphics/GpuYuvConverter.cpp
@@ -473,11 +473,20 @@ bool GpuYuvConverter::convertToFrame(const uint16_t* raw, int width, int height,
         }
     }
 
-    uint16_t y0 = *reinterpret_cast<const uint16_t*>(frame->data[0]);
-    uint16_t y1 = *reinterpret_cast<const uint16_t*>(frame->data[0] + 2);
-    uint16_t u0 = *reinterpret_cast<const uint16_t*>(frame->data[1]);
-    uint16_t v0 = *reinterpret_cast<const uint16_t*>(frame->data[2]);
-    std::ostringstream oss; oss << "[GPU-CHECK] first macropixel Y0=" << y0 << " U=" << u0 << " Y1=" << y1 << " V=" << v0; LogProRes(oss.str());
+    static bool dumpDone = false;
+    if(!dumpDone){
+        std::ostringstream dump;
+        dump << "[GPU-CHECK] first 16 macropixels";
+        for(int i=0;i<16;++i){
+            uint16_t yy0 = *reinterpret_cast<const uint16_t*>(frame->data[0] + i*4);
+            uint16_t yy1 = *reinterpret_cast<const uint16_t*>(frame->data[0] + i*4 + 2);
+            uint16_t uu  = *reinterpret_cast<const uint16_t*>(frame->data[1] + i*2);
+            uint16_t vv  = *reinterpret_cast<const uint16_t*>(frame->data[2] + i*2);
+            dump << " [" << i << ":" << yy0 << "," << uu << "," << yy1 << "," << vv << "]";
+        }
+        LogProRes(dump.str());
+        dumpDone = true;
+    }
 
     LogProRes("[GPU] readback complete");
 


### PR DESCRIPTION
## Summary
- fix chroma range in `raw_to_yuv422.comp`
- dump first 16 macropixels once in `GpuYuvConverter`

## Testing
- `cmake -B build -DENABLE_GPU=ON` *(fails: FindFFMPEG.cmake not found)*

------
https://chatgpt.com/codex/tasks/task_e_687255994a7c8327948b7e144095eff8