### PR TITLE
Fix GPU RAW->YUV422 converter magenta bias

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ build/
 motioncam-player-codex.zip
 23_codex_vertical_fix.zip
 24_codex_renameMotionCamFuse.zip
+shaders_spv/

--- a/include/Graphics/GpuColorParams.h
+++ b/include/Graphics/GpuColorParams.h
@@ -8,6 +8,8 @@ struct GpuColorParams {
     float colorMatrix[9]{1,0,0,0,1,0,0,0,1};
     int   cfaType{0};   // 0 BGGR,1 RGGB,2 GBRG,3 GRBG
     int   fullSwing{0}; // 0 studio, 1 full
+    unsigned int black{64};
+    unsigned int white{1023};
 };
 
 #endif // GPU_COLOR_PARAMS_H

--- a/shaders/raw_to_yuv422.comp
+++ b/shaders/raw_to_yuv422.comp
@@ -16,10 +16,26 @@ layout(push_constant, scalar) uniform PC {
     uint   fullSwing;            // 0=studio 64-940  1=full 0-1023
     float  wbR, wbG, wbB;        // white-balance gains
     mat3   colMat;               // sensor→BT.709 matrix
+    uint   black;                // black level
+    uint   white;                // white level
 } pc;
 
 // ---------- helper macros ----------
-#define RAW(xx,yy) ( float(imageLoad(rawImg, ivec2(int(xx), int(yy))).r) / 1023.0 )
+#define READ_RAW(xx,yy) uint(imageLoad(rawImg, ivec2(int(xx), int(yy))).r)
+
+float linFromRaw(uint v)
+{
+    return clamp((float(v) - float(pc.black)) /
+                 float(pc.white - pc.black), 0.0, 1.0);
+}
+
+#define RAW(xx,yy) linFromRaw(READ_RAW(xx,yy))
+
+float toDisplay(float x)
+{
+    return (x <= 0.04045) ? x/12.92
+                          : pow((x+0.055)/1.055, 2.4);
+}
 
 // ---------- functions ----------
 vec3 bayerToRGB(uint x, uint y)
@@ -95,7 +111,11 @@ vec3 bayerToRGB(uint x, uint y)
     // colour matrix
     rgb = pc.colMat * rgb;
 
-    return clamp(rgb, 0.0, 1.0);
+    rgb = clamp(rgb, 0.0, 1.0);
+
+    rgb = vec3(toDisplay(rgb.r), toDisplay(rgb.g), toDisplay(rgb.b));
+
+    return rgb;
 }
 
 uvec4 packYUV(vec3 rgb0, vec3 rgb1)
@@ -108,25 +128,27 @@ uvec4 packYUV(vec3 rgb0, vec3 rgb1)
     float y0 = dot(rgb0, vec3(kr.x, kg.x, kb.x));
     float y1 = dot(rgb1, vec3(kr.x, kg.x, kb.x));
 
-    float u  = 0.5389 * ((rgb0.b + rgb1.b) - (y0 + y1));
-    float v  = 0.6350 * ((rgb0.r + rgb1.r) - (y0 + y1));
+    float cb = (rgb0.b - y0) * 0.5389 + (rgb1.b - y1) * 0.5389;
+    float cr = (rgb0.r - y0) * 0.6350 + (rgb1.r - y1) * 0.6350;
+    cb = cb * 0.5 + 0.5;
+    cr = cr * 0.5 + 0.5;
 
     if (pc.fullSwing == 0u) {          // studio swing
         y0 = y0 * 876.0 + 64.0;
         y1 = y1 * 876.0 + 64.0;
-        u  = u  * 448.0 + 512.0;
-        v  = v  * 448.0 + 512.0;
+        cb = cb * 896.0 + 64.0;
+        cr = cr * 896.0 + 64.0;
     } else {                           // full swing
         y0 *= 1023.0;
         y1 *= 1023.0;
-        u   = u * 511.5 + 512.0;
-        v   = v * 511.5 + 512.0;
+        cb *= 1023.0;
+        cr *= 1023.0;
     }
 
     return uvec4(uint(y0 + 0.5),
-                 uint(u  + 0.5),
+                 uint(cb + 0.5),
                  uint(y1 + 0.5),
-                 uint(v  + 0.5));
+                 uint(cr + 0.5));
 }
 
 // ---------- work-group size ----------
@@ -153,6 +175,10 @@ void main()
 #ifdef GL_EXT_debug_print
     if (gid.x == 0u && gid.y == 0u) {
         debugPrintfEXT("GPU first macro-pixel: Y0=%u U=%u Y1=%u V=%u\n",
+                       macropixel.x, macropixel.y, macropixel.z, macropixel.w);
+    }
+    if (gid.x == 500u && gid.y == 500u) {
+        debugPrintfEXT("MP500 y0=%u u=%u y1=%u v=%u\n",
                        macropixel.x, macropixel.y, macropixel.z, macropixel.w);
     }
 #endif

--- a/src/App/AppIO.cpp
+++ b/src/App/AppIO.cpp
@@ -1435,6 +1435,8 @@ void App::exportCurrentClipToProRes() {
         GpuColorParams gpuParams{};
         gpuParams.cfaType = m_cfaTypeFromMetadata;
         gpuParams.fullSwing = 0;
+        gpuParams.black = static_cast<unsigned int>(m_staticBlack);
+        gpuParams.white = static_cast<unsigned int>(m_staticWhite);
 
         auto asn_json = meta.value("asShotNeutral", std::vector<double>{1.0,1.0,1.0});
         if (asn_json.size() >= 3) {

--- a/src/Graphics/GpuYuvConverter.cpp
+++ b/src/Graphics/GpuYuvConverter.cpp
@@ -58,7 +58,7 @@ bool GpuYuvConverter::init(int width, int height) {
     VkPushConstantRange pcRange{};
     pcRange.stageFlags = VK_SHADER_STAGE_COMPUTE_BIT;
     pcRange.offset = 0;
-    pcRange.size = 64;
+    pcRange.size = 72;
 
     VkPipelineLayoutCreateInfo pli{};
     pli.sType = VK_STRUCTURE_TYPE_PIPELINE_LAYOUT_CREATE_INFO;
@@ -350,6 +350,7 @@ bool GpuYuvConverter::convertToFrame(const uint16_t* raw, int width, int height,
         uint32_t width, height, cfaType, fullSwing;
         float wbR, wbG, wbB;
         float colMat[9];
+        uint32_t black, white;
     } push{};
     push.width = width;
     push.height = height;
@@ -359,6 +360,8 @@ bool GpuYuvConverter::convertToFrame(const uint16_t* raw, int width, int height,
     push.wbG = params.wbG;
     push.wbB = params.wbB;
     for(int i=0;i<9;++i) push.colMat[i] = params.colorMatrix[i];
+    push.black = params.black;
+    push.white = params.white;
     vkCmdPushConstants(cmd, m_pipelineLayout, VK_SHADER_STAGE_COMPUTE_BIT, 0, sizeof(Push), &push);
 
     vkCmdDispatch(cmd, (uint32_t)((width + 31) / 32), (uint32_t)((height + 15) / 16), 1);


### PR DESCRIPTION
## Summary
- add black/white levels and gamma correction to shader
- update BT.709 chroma equations and debug print
- extend GPU color params with black/white
- upload push constant changes and pass black/white
- remove compiled SPIR-V from repo

## Testing
- `glslangValidator -DVK_KHR_shader_subgroup_basic -V shaders/raw_to_yuv422.comp -o shaders_spv/raw_to_yuv422.comp.spv`
- `cmake -B build -DENABLE_GPU=ON` *(fails: FindFFMPEG.cmake not found)*
- `cmake --build build -j$(nproc)` *(fails: no Makefile)*
- `./build/tests/GpuCopyTest` *(fails: file not found)*
- `./build/bin/MotionCam\ Player sample.mcraw --export=gpu.mov --export-cpu=cpu.mov` *(fails: file not found)*


------
https://chatgpt.com/codex/tasks/task_e_6872a6d6db2c8327970fdae0a11f7bd2