### PR TITLE
Profile & overlap GPU→CPU export; +perf logs

### DIFF
--- a/include/App/ProResExport.h
+++ b/include/App/ProResExport.h
@@ -1,0 +1,7 @@
+#ifndef PRORES_EXPORT_H
+#define PRORES_EXPORT_H
+
+extern bool g_useGpuProRes;
+extern bool g_gpuAsyncExport;
+
+#endif // PRORES_EXPORT_H

--- a/include/Graphics/GpuColorParams.h
+++ b/include/Graphics/GpuColorParams.h
@@ -12,4 +12,13 @@ struct GpuColorParams {
     unsigned int white{1023};
 };
 
+struct PerfStat {
+    double gpuMs = 0;
+    double encMs = 0;
+    double ioMs  = 0;
+    uint32_t frames = 0;
+};
+
+extern PerfStat gPerf;
+
 #endif // GPU_COLOR_PARAMS_H

--- a/include/Graphics/GpuYuvConverter.h
+++ b/include/Graphics/GpuYuvConverter.h
@@ -5,6 +5,7 @@
 #include <vector>
 #include <cstdint>
 #include <libavutil/frame.h>
+#include <chrono>
 #include "Utils/vma_usage.h"
 #include "Graphics/GpuColorParams.h"
 
@@ -20,6 +21,10 @@ public:
 
     bool convertToFrame(const uint16_t* raw, int width, int height, AVFrame* frame,
                         const GpuColorParams& params);
+    bool beginAsync(const uint16_t* raw, const GpuColorParams& params, int& slotIdx);
+    bool completeAsync(int slotIdx, AVFrame* frame);
+
+    static constexpr int kAsyncBuffers = 4;
 private:
     Renderer_VK* m_renderer;
 
@@ -38,6 +43,24 @@ private:
     VkImage m_rawImage{VK_NULL_HANDLE};
     VmaAllocation m_rawAlloc{VK_NULL_HANDLE};
     VkImageView m_rawView{VK_NULL_HANDLE};
+
+    struct Slot {
+        VkBuffer stagingBuf{VK_NULL_HANDLE};
+        VmaAllocation stagingAlloc{VK_NULL_HANDLE};
+        void* stagingMap{nullptr};
+        VkBuffer readbackBuf{VK_NULL_HANDLE};
+        VmaAllocation readbackAlloc{VK_NULL_HANDLE};
+        void* readbackMap{nullptr};
+        VkCommandBuffer cmd{VK_NULL_HANDLE};
+        VkFence fence{VK_NULL_HANDLE};
+        std::chrono::steady_clock::time_point start{};
+    };
+    std::vector<Slot> m_slots;
+    size_t m_nextSlot{0};
+    int m_width{0};
+    int m_height{0};
+    VkDeviceSize m_rawSize{0};
+    VkDeviceSize m_outSize{0};
 };
 
 #endif // GPU_YUV_CONVERTER_H

--- a/src/App/AppIO.cpp
+++ b/src/App/AppIO.cpp
@@ -23,6 +23,10 @@
 #include <chrono>
 #include <iomanip>
 #include <iostream>
+#include <array>
+#include <queue>
+#include <mutex>
+#include <condition_variable>
 #include <fstream>
 #include <numeric>
 #include <algorithm>
@@ -33,13 +37,14 @@
 #include "ffmpeg_headers.hpp"
 #include "Graphics/GpuYuvConverter.h"
 #endif
+#include "App/ProResExport.h"
 #include "Utils/ColorPipelineCPU.h"
 
 namespace fs = std::filesystem;
 
-#ifdef ENABLE_PRORES_EXPORT
-static bool g_useGpuProRes = false;
-#endif
+bool g_useGpuProRes = false;
+bool g_gpuAsyncExport = false;
+
 namespace {
     bool writeDngInternal(
         const std::string& outputPath,
@@ -1212,6 +1217,7 @@ void App::exportCurrentClipToProRes() {
     bool useGpu = g_useGpuProRes;
     m_proResThread = std::thread([this, outputPath, useGpu]() {
         av_log_set_level(AV_LOG_ERROR);
+        gPerf = {};
         LogProRes("[ProResExport] Thread started");
         LogProRes(std::string("[ProResExport] MODE = ") + (useGpu ? "GPU (Vulkan hw_frames)" : "CPU (swscale)"));
 
@@ -1482,6 +1488,57 @@ void App::exportCurrentClipToProRes() {
 
         std::vector<uint8_t> rgbBuf;
         int64_t pts = 0;
+
+        const bool asyncGpu = gpuActive && g_gpuAsyncExport;
+        std::array<AVFrame*, GpuYuvConverter::kAsyncBuffers> asyncFrames{};
+        std::array<int64_t, GpuYuvConverter::kAsyncBuffers> slotPts{};
+        if(asyncGpu){
+            for(int i=0;i<GpuYuvConverter::kAsyncBuffers;++i){
+                asyncFrames[i] = av_frame_alloc();
+                asyncFrames[i]->format = AV_PIX_FMT_YUV422P10LE;
+                asyncFrames[i]->width = width;
+                asyncFrames[i]->height = height;
+                av_frame_get_buffer(asyncFrames[i], 0);
+            }
+        }
+        std::mutex qMutex;
+        std::condition_variable qCv;
+        std::queue<int> q;
+        bool done=false;
+        std::thread worker;
+        if(asyncGpu){
+            worker = std::thread([&](){
+                while(true){
+                    std::unique_lock<std::mutex> lk(qMutex);
+                    qCv.wait(lk,[&]{ return !q.empty() || done; });
+                    if(q.empty() && done) break;
+                    int s = q.front(); q.pop(); lk.unlock();
+                    AVFrame* f = asyncFrames[s];
+                    auto t0 = std::chrono::steady_clock::now();
+                    converter.completeAsync(s,f);
+                    auto t1 = std::chrono::steady_clock::now();
+                    gPerf.gpuMs += std::chrono::duration_cast<std::chrono::microseconds>(t1 - t0).count()/1000.0;
+                    f->pts = slotPts[s];
+                    t0 = std::chrono::steady_clock::now();
+                    if(avcodec_send_frame(vctx,f)>=0){
+                        while(avcodec_receive_packet(vctx,&pkt)==0){
+                            pkt.stream_index = vstream->index;
+                            pkt.duration = 1;
+                            pkt.pts = av_rescale_q(pkt.pts,vctx->time_base,vstream->time_base);
+                            pkt.dts = pkt.pts;
+                            auto ioStart = std::chrono::steady_clock::now();
+                            av_interleaved_write_frame(fmt,&pkt);
+                            auto ioEnd = std::chrono::steady_clock::now();
+                            gPerf.ioMs += std::chrono::duration_cast<std::chrono::microseconds>(ioEnd-ioStart).count()/1000.0;
+                            av_packet_unref(&pkt); gPerf.frames++; ++framesEncoded;
+                        }
+                    }
+                    auto t2 = std::chrono::steady_clock::now();
+                    gPerf.encMs += std::chrono::duration_cast<std::chrono::microseconds>(t2 - t0).count()/1000.0;
+                }
+            });
+        }
+
         for (size_t idx = 0; idx < frames.size(); ++idx) {
             RawBytes raw;
             nlohmann::json metaTmp;
@@ -1493,10 +1550,23 @@ void App::exportCurrentClipToProRes() {
 
             t0 = t1;
             if (gpuActive) {
-                if (av_frame_make_writable(frame) < 0) { m_proResStatus.errorMsg = "frame not writable"; break; }
-                converter.convertToFrame(asU16(raw), width, height, frame, gpuParams);
-                t1 = std::chrono::steady_clock::now();
-                rgbUS += std::chrono::duration_cast<std::chrono::microseconds>(t1 - t0).count();
+                if(asyncGpu){
+                    int slot=0;
+                    converter.beginAsync(asU16(raw), gpuParams, slot);
+                    slotPts[slot]=pts;
+                    {
+                        std::lock_guard<std::mutex> lk(qMutex);
+                        q.push(slot);
+                    }
+                    qCv.notify_one();
+                    t1 = std::chrono::steady_clock::now();
+                    rgbUS += std::chrono::duration_cast<std::chrono::microseconds>(t1 - t0).count();
+                } else {
+                    if (av_frame_make_writable(frame) < 0) { m_proResStatus.errorMsg = "frame not writable"; break; }
+                    converter.convertToFrame(asU16(raw), width, height, frame, gpuParams);
+                    t1 = std::chrono::steady_clock::now();
+                    rgbUS += std::chrono::duration_cast<std::chrono::microseconds>(t1 - t0).count();
+                }
             } else {
                 convertRawToRGB24(asU16(raw), cpParams, rgbBuf, threads);
                 t1 = std::chrono::steady_clock::now();
@@ -1510,23 +1580,30 @@ void App::exportCurrentClipToProRes() {
                 scaleUS += std::chrono::duration_cast<std::chrono::microseconds>(t1 - t0).count();
             }
 
-            frame->pts = pts;
-            pts++;
-
-            t0 = std::chrono::steady_clock::now();
-            if (avcodec_send_frame(vctx, frame) < 0) { m_proResStatus.errorMsg = "send_frame failed"; break; }
-            while (avcodec_receive_packet(vctx, &pkt) == 0) {
-                pkt.stream_index = vstream->index;
-                pkt.duration = 1;
-                pkt.pts = av_rescale_q(pkt.pts, vctx->time_base, vstream->time_base);
-                pkt.dts = pkt.pts;
-                if (av_interleaved_write_frame(fmt, &pkt) < 0) { m_proResStatus.errorMsg = "write_frame failed"; av_packet_unref(&pkt); break; }
-                av_packet_unref(&pkt);
-                ++framesEncoded;
+            if(!asyncGpu){
+                frame->pts = pts;
+                pts++;
+                t0 = std::chrono::steady_clock::now();
+                if (avcodec_send_frame(vctx, frame) < 0) { m_proResStatus.errorMsg = "send_frame failed"; break; }
+                while (avcodec_receive_packet(vctx, &pkt) == 0) {
+                    pkt.stream_index = vstream->index;
+                    pkt.duration = 1;
+                    pkt.pts = av_rescale_q(pkt.pts, vctx->time_base, vstream->time_base);
+                    pkt.dts = pkt.pts;
+                    auto ioStart = std::chrono::steady_clock::now();
+                    if (av_interleaved_write_frame(fmt, &pkt) < 0) { m_proResStatus.errorMsg = "write_frame failed"; av_packet_unref(&pkt); break; }
+                    auto ioEnd = std::chrono::steady_clock::now();
+                    gPerf.ioMs += std::chrono::duration_cast<std::chrono::microseconds>(ioEnd-ioStart).count()/1000.0;
+                    av_packet_unref(&pkt);
+                    ++framesEncoded; gPerf.frames++;
+                }
+                t1 = std::chrono::steady_clock::now();
+                gPerf.encMs += std::chrono::duration_cast<std::chrono::microseconds>(t1 - t0).count()/1000.0;
+                m_proResStatus.currentFrame.store(static_cast<int>(idx + 1));
+            } else {
+                pts++;
+                m_proResStatus.currentFrame.store(static_cast<int>(idx + 1));
             }
-            t1 = std::chrono::steady_clock::now();
-            encodeUS += std::chrono::duration_cast<std::chrono::microseconds>(t1 - t0).count();
-            m_proResStatus.currentFrame.store(static_cast<int>(idx + 1));
             if ((idx + 1) % 50 == 0) {
                 auto now = std::chrono::steady_clock::now();
                 auto ms = std::chrono::duration_cast<std::chrono::milliseconds>(now - encodeStart).count();
@@ -1535,6 +1612,14 @@ void App::exportCurrentClipToProRes() {
                      << " elapsed=" << ms << "ms";
                 LogProRes(prog.str());
             }
+        }
+
+        if(asyncGpu){
+            {
+                std::lock_guard<std::mutex> lk(qMutex); done = true; }
+            qCv.notify_all();
+            worker.join();
+            for(auto* f: asyncFrames) av_frame_free(&f);
         }
 
         // Encode audio
@@ -1649,6 +1734,19 @@ void App::exportCurrentClipToProRes() {
         if (!(fmt->oformat->flags & AVFMT_NOFILE)) avio_closep(&fmt->pb);
         avcodec_free_context(&vctx);
         avformat_free_context(fmt);
+        if(!asyncGpu) av_frame_free(&frame);
+
+        if(gPerf.frames>0){
+            std::ostringstream pmsg;
+            pmsg << "[PERF] gpu=" << std::fixed << std::setprecision(2) << (gPerf.gpuMs/gPerf.frames)
+                 << "ms enc=" << (gPerf.encMs/gPerf.frames)
+                 << "ms io=" << (gPerf.ioMs/gPerf.frames) << "ms";
+            LogProRes(pmsg.str());
+            double totalSec = (encodeEnd - encodeStart).count()/1000.0/1000.0;
+            std::ostringstream fps;
+            fps << "[PERF] avg " << std::fixed << std::setprecision(1) << (gPerf.frames/totalSec) << "fps";
+            LogProRes(fps.str());
+        }
 
         if (m_proResStatus.errorMsg.empty()) {
             showActionMessage("Export Finished");

--- a/src/Graphics/GpuYuvConverter.cpp
+++ b/src/Graphics/GpuYuvConverter.cpp
@@ -10,6 +10,7 @@
 #include <sstream>
 
 extern std::string g_AppBasePath;
+PerfStat gPerf;
 
 GpuYuvConverter::GpuYuvConverter(Renderer_VK* renderer)
     : m_renderer(renderer) {}
@@ -184,6 +185,49 @@ bool GpuYuvConverter::init(int width, int height) {
         VK_IMAGE_LAYOUT_UNDEFINED,
         VK_IMAGE_LAYOUT_GENERAL);
 
+    m_width = width;
+    m_height = height;
+    m_rawSize = static_cast<VkDeviceSize>(width) * height * sizeof(uint16_t);
+    m_outSize = static_cast<VkDeviceSize>(((width + 1) / 2)) * height * sizeof(uint32_t) * 4;
+
+    m_slots.resize(kAsyncBuffers);
+    for(int i=0;i<kAsyncBuffers;++i){
+        VkBufferCreateInfo sbInfo{ VK_STRUCTURE_TYPE_BUFFER_CREATE_INFO };
+        sbInfo.size = m_rawSize;
+        sbInfo.usage = VK_BUFFER_USAGE_TRANSFER_SRC_BIT;
+        VmaAllocationCreateInfo sbAlloc{};
+        sbAlloc.usage = VMA_MEMORY_USAGE_AUTO_PREFER_HOST;
+        sbAlloc.flags = VMA_ALLOCATION_CREATE_HOST_ACCESS_SEQUENTIAL_WRITE_BIT |
+                        VMA_ALLOCATION_CREATE_MAPPED_BIT;
+        VmaAllocationInfo sbInfoOut{};
+        VK_CHECK_RENDERER(vmaCreateBuffer(m_renderer->m_allocator_p, &sbInfo, &sbAlloc,
+                                          &m_slots[i].stagingBuf, &m_slots[i].stagingAlloc, &sbInfoOut));
+        m_slots[i].stagingMap = sbInfoOut.pMappedData;
+
+        VkBufferCreateInfo rbInfo{ VK_STRUCTURE_TYPE_BUFFER_CREATE_INFO };
+        rbInfo.size = m_outSize;
+        rbInfo.usage = VK_BUFFER_USAGE_TRANSFER_DST_BIT;
+        VmaAllocationCreateInfo rbAlloc{};
+        rbAlloc.usage = VMA_MEMORY_USAGE_AUTO_PREFER_HOST;
+        rbAlloc.flags = VMA_ALLOCATION_CREATE_HOST_ACCESS_RANDOM_BIT |
+                        VMA_ALLOCATION_CREATE_MAPPED_BIT;
+        VmaAllocationInfo rbInfoOut{};
+        VK_CHECK_RENDERER(vmaCreateBuffer(m_renderer->m_allocator_p, &rbInfo, &rbAlloc,
+                                          &m_slots[i].readbackBuf, &m_slots[i].readbackAlloc, &rbInfoOut));
+        m_slots[i].readbackMap = rbInfoOut.pMappedData;
+
+        VkCommandBufferAllocateInfo cbai{ VK_STRUCTURE_TYPE_COMMAND_BUFFER_ALLOCATE_INFO };
+        cbai.commandPool = m_cmdPool;
+        cbai.level = VK_COMMAND_BUFFER_LEVEL_PRIMARY;
+        cbai.commandBufferCount = 1;
+        VK_CHECK_RENDERER(vkAllocateCommandBuffers(m_renderer->m_device_p, &cbai, &m_slots[i].cmd));
+
+        VkFenceCreateInfo fi{ VK_STRUCTURE_TYPE_FENCE_CREATE_INFO };
+        fi.flags = VK_FENCE_CREATE_SIGNALED_BIT;
+        VK_CHECK_RENDERER(vkCreateFence(m_renderer->m_device_p, &fi, nullptr, &m_slots[i].fence));
+    }
+    m_nextSlot = 0;
+
     return true;
 }
 
@@ -222,6 +266,13 @@ void GpuYuvConverter::cleanup() {
         vkDestroyDescriptorSetLayout(m_renderer->m_device_p, m_setLayout, nullptr);
         m_setLayout = VK_NULL_HANDLE;
     }
+    for(auto& s : m_slots){
+        if(s.fence) vkDestroyFence(m_renderer->m_device_p, s.fence, nullptr);
+        if(s.cmd) vkFreeCommandBuffers(m_renderer->m_device_p, m_cmdPool, 1, &s.cmd);
+        if(s.stagingBuf) vmaDestroyBuffer(m_renderer->m_allocator_p, s.stagingBuf, s.stagingAlloc);
+        if(s.readbackBuf) vmaDestroyBuffer(m_renderer->m_allocator_p, s.readbackBuf, s.readbackAlloc);
+    }
+    m_slots.clear();
     if (m_cmdPool != VK_NULL_HANDLE) {
         vkDestroyCommandPool(m_renderer->m_device_p, m_cmdPool, nullptr);
         m_cmdPool = VK_NULL_HANDLE;
@@ -448,5 +499,205 @@ bool GpuYuvConverter::convertToFrame(const uint16_t* raw, int width, int height,
 
     vmaDestroyBuffer(m_renderer->m_allocator_p, stagingBuf, stagingAlloc);
     vmaDestroyBuffer(m_renderer->m_allocator_p, readbackBuf, readbackAlloc);
+    return true;
+}
+
+bool GpuYuvConverter::beginAsync(const uint16_t* raw, const GpuColorParams& params, int& slotIdx){
+    Slot& slot = m_slots[m_nextSlot];
+    vkWaitForFences(m_renderer->m_device_p,1,&slot.fence,VK_TRUE,UINT64_MAX);
+    vkResetFences(m_renderer->m_device_p,1,&slot.fence);
+
+    memcpy(slot.stagingMap, raw, m_rawSize);
+    vmaFlushAllocation(m_renderer->m_allocator_p, slot.stagingAlloc, 0, m_rawSize);
+
+    vkResetCommandBuffer(slot.cmd,0);
+    VkCommandBufferBeginInfo bi{VK_STRUCTURE_TYPE_COMMAND_BUFFER_BEGIN_INFO};
+    bi.flags = VK_COMMAND_BUFFER_USAGE_ONE_TIME_SUBMIT_BIT;
+    vkBeginCommandBuffer(slot.cmd,&bi);
+
+    VkImageMemoryBarrier bar1{ VK_STRUCTURE_TYPE_IMAGE_MEMORY_BARRIER };
+    bar1.oldLayout = VK_IMAGE_LAYOUT_GENERAL;
+    bar1.newLayout = VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL;
+    bar1.srcQueueFamilyIndex = VK_QUEUE_FAMILY_IGNORED;
+    bar1.dstQueueFamilyIndex = VK_QUEUE_FAMILY_IGNORED;
+    bar1.image = m_rawImage;
+    bar1.subresourceRange.aspectMask = VK_IMAGE_ASPECT_COLOR_BIT;
+    bar1.subresourceRange.baseMipLevel = 0;
+    bar1.subresourceRange.levelCount = 1;
+    bar1.subresourceRange.baseArrayLayer = 0;
+    bar1.subresourceRange.layerCount = 1;
+    bar1.srcAccessMask = 0;
+    bar1.dstAccessMask = VK_ACCESS_TRANSFER_WRITE_BIT;
+    vkCmdPipelineBarrier(slot.cmd,
+        VK_PIPELINE_STAGE_COMPUTE_SHADER_BIT,
+        VK_PIPELINE_STAGE_TRANSFER_BIT,
+        0,
+        0,nullptr,
+        0,nullptr,
+        1,&bar1);
+
+    VkBufferImageCopy region{};
+    region.bufferOffset = 0;
+    region.bufferRowLength = 0;
+    region.bufferImageHeight = 0;
+    region.imageSubresource.aspectMask = VK_IMAGE_ASPECT_COLOR_BIT;
+    region.imageSubresource.mipLevel = 0;
+    region.imageSubresource.baseArrayLayer = 0;
+    region.imageSubresource.layerCount = 1;
+    region.imageOffset = {0,0,0};
+    region.imageExtent = { static_cast<uint32_t>(m_width), static_cast<uint32_t>(m_height), 1 };
+    vkCmdCopyBufferToImage(slot.cmd, slot.stagingBuf, m_rawImage, VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL, 1, &region);
+
+    VkImageMemoryBarrier bar2{ VK_STRUCTURE_TYPE_IMAGE_MEMORY_BARRIER };
+    bar2.oldLayout = VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL;
+    bar2.newLayout = VK_IMAGE_LAYOUT_GENERAL;
+    bar2.srcQueueFamilyIndex = VK_QUEUE_FAMILY_IGNORED;
+    bar2.dstQueueFamilyIndex = VK_QUEUE_FAMILY_IGNORED;
+    bar2.image = m_rawImage;
+    bar2.subresourceRange.aspectMask = VK_IMAGE_ASPECT_COLOR_BIT;
+    bar2.subresourceRange.baseMipLevel = 0;
+    bar2.subresourceRange.levelCount = 1;
+    bar2.subresourceRange.baseArrayLayer = 0;
+    bar2.subresourceRange.layerCount = 1;
+    bar2.srcAccessMask = VK_ACCESS_TRANSFER_WRITE_BIT;
+    bar2.dstAccessMask = VK_ACCESS_SHADER_READ_BIT;
+    vkCmdPipelineBarrier(slot.cmd,
+        VK_PIPELINE_STAGE_TRANSFER_BIT,
+        VK_PIPELINE_STAGE_COMPUTE_SHADER_BIT,
+        0,
+        0,nullptr,
+        0,nullptr,
+        1,&bar2);
+
+    VkDescriptorImageInfo inputInfo{};
+    inputInfo.imageView = m_rawView;
+    inputInfo.imageLayout = VK_IMAGE_LAYOUT_GENERAL;
+    VkDescriptorImageInfo outInfo{};
+    outInfo.imageView = m_yuvView;
+    outInfo.imageLayout = VK_IMAGE_LAYOUT_GENERAL;
+    VkWriteDescriptorSet writes[2]{};
+    writes[0].sType = VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET;
+    writes[0].dstSet = m_descSet;
+    writes[0].dstBinding = 0;
+    writes[0].descriptorCount = 1;
+    writes[0].descriptorType = VK_DESCRIPTOR_TYPE_STORAGE_IMAGE;
+    writes[0].pImageInfo = &inputInfo;
+    writes[1].sType = VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET;
+    writes[1].dstSet = m_descSet;
+    writes[1].dstBinding = 1;
+    writes[1].descriptorCount = 1;
+    writes[1].descriptorType = VK_DESCRIPTOR_TYPE_STORAGE_IMAGE;
+    writes[1].pImageInfo = &outInfo;
+    vkUpdateDescriptorSets(m_renderer->m_device_p, 2, writes, 0, nullptr);
+
+    vkCmdBindPipeline(slot.cmd, VK_PIPELINE_BIND_POINT_COMPUTE, m_pipeline);
+    vkCmdBindDescriptorSets(slot.cmd, VK_PIPELINE_BIND_POINT_COMPUTE, m_pipelineLayout, 0, 1, &m_descSet, 0, nullptr);
+
+    struct Push {
+        uint32_t width, height, cfaType, fullSwing;
+        float wbR, wbG, wbB;
+        float colMat[9];
+        uint32_t black, white;
+    } push{};
+    push.width = m_width;
+    push.height = m_height;
+    push.cfaType = params.cfaType;
+    push.fullSwing = params.fullSwing;
+    push.wbR = params.wbR;
+    push.wbG = params.wbG;
+    push.wbB = params.wbB;
+    for(int i=0;i<9;++i) push.colMat[i] = params.colorMatrix[i];
+    push.black = params.black;
+    push.white = params.white;
+    vkCmdPushConstants(slot.cmd, m_pipelineLayout, VK_SHADER_STAGE_COMPUTE_BIT, 0, sizeof(Push), &push);
+
+    vkCmdDispatch(slot.cmd, (uint32_t)((m_width + 31) / 32), (uint32_t)((m_height + 15) / 16), 1);
+
+    VkImageMemoryBarrier barOut{ VK_STRUCTURE_TYPE_IMAGE_MEMORY_BARRIER };
+    barOut.oldLayout = VK_IMAGE_LAYOUT_GENERAL;
+    barOut.newLayout = VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL;
+    barOut.srcQueueFamilyIndex = VK_QUEUE_FAMILY_IGNORED;
+    barOut.dstQueueFamilyIndex = VK_QUEUE_FAMILY_IGNORED;
+    barOut.image = m_yuvImage;
+    barOut.subresourceRange.aspectMask = VK_IMAGE_ASPECT_COLOR_BIT;
+    barOut.subresourceRange.baseMipLevel = 0;
+    barOut.subresourceRange.levelCount = 1;
+    barOut.subresourceRange.baseArrayLayer = 0;
+    barOut.subresourceRange.layerCount = 1;
+    barOut.srcAccessMask = VK_ACCESS_SHADER_WRITE_BIT;
+    barOut.dstAccessMask = VK_ACCESS_TRANSFER_READ_BIT;
+    vkCmdPipelineBarrier(slot.cmd,
+        VK_PIPELINE_STAGE_COMPUTE_SHADER_BIT,
+        VK_PIPELINE_STAGE_TRANSFER_BIT,
+        0,
+        0,nullptr,
+        0,nullptr,
+        1,&barOut);
+
+    VkBufferImageCopy rbRegion{};
+    rbRegion.bufferOffset = 0;
+    rbRegion.bufferRowLength = 0;
+    rbRegion.bufferImageHeight = 0;
+    rbRegion.imageSubresource.aspectMask = VK_IMAGE_ASPECT_COLOR_BIT;
+    rbRegion.imageSubresource.mipLevel = 0;
+    rbRegion.imageSubresource.baseArrayLayer = 0;
+    rbRegion.imageSubresource.layerCount = 1;
+    rbRegion.imageOffset = {0,0,0};
+    rbRegion.imageExtent = { static_cast<uint32_t>((m_width + 1) / 2), static_cast<uint32_t>(m_height), 1 };
+    vkCmdCopyImageToBuffer(slot.cmd, m_yuvImage, VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL,
+                           slot.readbackBuf, 1, &rbRegion);
+
+    barOut.oldLayout = VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL;
+    barOut.newLayout = VK_IMAGE_LAYOUT_GENERAL;
+    barOut.srcAccessMask = VK_ACCESS_TRANSFER_READ_BIT;
+    barOut.dstAccessMask = VK_ACCESS_SHADER_READ_BIT | VK_ACCESS_SHADER_WRITE_BIT;
+    vkCmdPipelineBarrier(slot.cmd,
+        VK_PIPELINE_STAGE_TRANSFER_BIT,
+        VK_PIPELINE_STAGE_COMPUTE_SHADER_BIT,
+        0,
+        0,nullptr,
+        0,nullptr,
+        1,&barOut);
+
+    vkEndCommandBuffer(slot.cmd);
+
+    VkSubmitInfo si{ VK_STRUCTURE_TYPE_SUBMIT_INFO };
+    si.commandBufferCount = 1;
+    si.pCommandBuffers = &slot.cmd;
+    VK_CHECK_RENDERER(vkQueueSubmit(m_renderer->m_graphicsQueue_p, 1, &si, slot.fence));
+
+    slot.start = std::chrono::steady_clock::now();
+    slotIdx = static_cast<int>(m_nextSlot);
+    m_nextSlot = (m_nextSlot + 1) % m_slots.size();
+    return true;
+}
+
+bool GpuYuvConverter::completeAsync(int slotIdx, AVFrame* frame){
+    Slot& slot = m_slots[slotIdx];
+    vkWaitForFences(m_renderer->m_device_p,1,&slot.fence,VK_TRUE,UINT64_MAX);
+
+    vmaInvalidateAllocation(m_renderer->m_allocator_p, slot.readbackAlloc, 0, m_outSize);
+
+    const uint32_t* macropix = static_cast<const uint32_t*>(slot.readbackMap);
+    uint32_t macroPitch = ((m_width + 1) / 2) * 4;
+    for(int y=0;y<m_height;++y){
+        const uint32_t* row = macropix + y * macroPitch;
+        uint16_t* dstY = reinterpret_cast<uint16_t*>(frame->data[0] + y*frame->linesize[0]);
+        uint16_t* dstU = reinterpret_cast<uint16_t*>(frame->data[1] + y*frame->linesize[1]);
+        uint16_t* dstV = reinterpret_cast<uint16_t*>(frame->data[2] + y*frame->linesize[2]);
+        for(int x=0;x<(m_width+1)/2;++x){
+            uint32_t y0 = row[x*4];
+            uint32_t u  = row[x*4+1];
+            uint32_t y1 = row[x*4+2];
+            uint32_t v  = row[x*4+3];
+            dstY[x*2]     = static_cast<uint16_t>(y0);
+            dstY[x*2 + 1] = static_cast<uint16_t>(y1);
+            dstU[x] = static_cast<uint16_t>(u);
+            dstV[x] = static_cast<uint16_t>(v);
+        }
+    }
+
+    auto end = std::chrono::steady_clock::now();
+    gPerf.gpuMs += std::chrono::duration_cast<std::chrono::microseconds>(end - slot.start).count()/1000.0;
     return true;
 }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -34,6 +34,7 @@
 #include <SDL.h>
 
 #include "App/App.h"
+#include "App/ProResExport.h"
 #include "Utils/DebugLog.h"
 #ifdef _WIN32
 #include "Utils/SingleInstanceGuard.h"
@@ -269,6 +270,12 @@ int main(int argc, char* argv[]) {
         LogToFile(std::string("[main] Input file from command line: ") + inPath);
     } else {
         LogToFile("[main] No command line argument provided. Starting without file.");
+    }
+
+    for(int i=2;i<argc;i++){
+        std::string a = argv[i];
+        if(a == "-gpu") g_useGpuProRes = true;
+        else if(a == "-gpuAsyncExport") g_gpuAsyncExport = true;
     }
 
     if (!inPath.empty() && (!fs::exists(inPath) || !fs::is_regular_file(inPath))) {


### PR DESCRIPTION
## Summary
- add `PerfStat` struct and global `gPerf`
- expose global export flags and async GPU conversion API
- implement async ring buffers and perf timers in `GpuYuvConverter`
- support async GPU export in ProRes export loop
- parse `-gpu` and `-gpuAsyncExport` flags on startup

## Testing
- `cmake -B build -DENABLE_GPU=ON -DENABLE_TESTS=ON` *(fails: could not find FindFFMPEG)*

------
https://chatgpt.com/codex/tasks/task_e_6872b87bcc8083278583b9fa4133cfab