### PR TITLE
Add stubbed GPU DNxHR export components

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -98,6 +98,7 @@ set(SHADER_FILES
     "${APP_SHADERS_SRC_DIR}/fullscreen_quad.vert"
     "${APP_SHADERS_SRC_DIR}/image_process.frag"
     "${APP_SHADERS_SRC_DIR}/raw_to_yuv422.comp"
+    "${APP_SHADERS_SRC_DIR}/dct_quant.comp"
 )
 set(COMPILED_SHADER_OUTPUTS "")
 foreach(SHADER_INPUT_FILE ${SHADER_FILES})
@@ -151,6 +152,10 @@ set(APP_SOURCES
   src/Graphics/Pipeline.cpp
   src/Graphics/Descriptor.cpp
 
+  src/export/DnxhrBackend.cpp
+  src/export/GpuSliceTransfer.cpp
+  src/export/gpuDnxhrExport.cpp
+
   src/Gui/GuiSetup.cpp
   src/Gui/GuiRender.cpp
   src/Gui/GuiUtils.cpp
@@ -185,6 +190,7 @@ target_compile_definitions(${PROJECT_NAME} PRIVATE GLFW_INCLUDE_NONE)
 if(HAVE_FFMPEG)
     target_compile_definitions(${PROJECT_NAME} PRIVATE ENABLE_PRORES_EXPORT)
 endif()
+target_compile_definitions(${PROJECT_NAME} PRIVATE ENABLE_DNXHR_EXPORT)
 if(MSVC AND CMAKE_SYSTEM_NAME STREQUAL "Windows")
     set_target_properties(${PROJECT_NAME} PROPERTIES LINK_FLAGS "/ENTRY:mainCRTStartup")
     message(STATUS "MSVC: Setting LINK_FLAGS /ENTRY:mainCRTStartup for ${PROJECT_NAME}")
@@ -199,6 +205,7 @@ target_include_directories(${PROJECT_NAME} PRIVATE
   "${PROJECT_SOURCE_DIR}/include/Gui"
   "${PROJECT_SOURCE_DIR}/include/Playback"
   "${PROJECT_SOURCE_DIR}/include/Utils"
+  "${PROJECT_SOURCE_DIR}/include/Export"
 
   "${VMA_INCLUDE_DIR}"
   "${Vulkan_INCLUDE_DIRS}"

--- a/include/App/App.h
+++ b/include/App/App.h
@@ -113,6 +113,8 @@ public:
     void convertCurrentFileToDngs();
     void exportCurrentClipToProRes();
     void convertCurrentClipToProRes();
+    void exportCurrentClipToDnxhr();
+    void convertCurrentClipToDnxhr();
     void performSeek(size_t new_frame_index);
     void triggerOpenFileViaDialog();
 	void setPlaybackMode(PlaybackController::PlaybackMode mode);
@@ -228,6 +230,15 @@ private:
     } m_proResStatus;
     std::atomic<bool> m_showExportProgressPopup{ false };
     std::thread m_proResThread;
+#endif
+#ifdef ENABLE_DNXHR_EXPORT
+    struct DnxhrExportStatus {
+        std::atomic<bool> active{ false };
+        std::atomic<int> currentFrame{ 0 };
+        int totalFrames{ 0 };
+        std::string errorMsg;
+    } m_dnxhrStatus;
+    std::thread m_dnxhrThread;
 #endif
 
 

--- a/include/Export/DnxhrBackend.h
+++ b/include/Export/DnxhrBackend.h
@@ -1,0 +1,15 @@
+#ifndef DNXHR_BACKEND_H
+#define DNXHR_BACKEND_H
+
+#include <string>
+#include "Export/SliceBuffer.h"
+
+class DnxhrBackend {
+public:
+    bool initialize(const std::string& path, int width, int height,
+                    int fpsNum, int fpsDen);
+    bool writeSlice(const SliceBuffer& slice);
+    void finalize();
+};
+
+#endif // DNXHR_BACKEND_H

--- a/include/Export/ExportFormat.h
+++ b/include/Export/ExportFormat.h
@@ -1,0 +1,9 @@
+#ifndef EXPORT_FORMAT_H
+#define EXPORT_FORMAT_H
+
+enum class ExportFormat {
+    ProResGPU,
+    DnxhrGPU
+};
+
+#endif // EXPORT_FORMAT_H

--- a/include/Export/GpuSliceTransfer.h
+++ b/include/Export/GpuSliceTransfer.h
@@ -1,0 +1,16 @@
+#ifndef GPU_SLICE_TRANSFER_H
+#define GPU_SLICE_TRANSFER_H
+
+#include <vector>
+#include "Export/SliceBuffer.h"
+
+class GpuSliceTransfer {
+public:
+    bool mapSlices(void* buffer, size_t size);
+    bool unmap();
+    const std::vector<SliceBuffer>& getSlices() const { return m_slices; }
+private:
+    std::vector<SliceBuffer> m_slices;
+};
+
+#endif // GPU_SLICE_TRANSFER_H

--- a/include/Export/SliceBuffer.h
+++ b/include/Export/SliceBuffer.h
@@ -1,0 +1,13 @@
+#ifndef SLICE_BUFFER_H
+#define SLICE_BUFFER_H
+
+#include <cstdint>
+#include <vector>
+
+struct SliceBuffer {
+    std::vector<int16_t> lumaBlocks;
+    std::vector<int16_t> chromaUBlocks;
+    std::vector<int16_t> chromaVBlocks;
+};
+
+#endif // SLICE_BUFFER_H

--- a/shaders/dct_quant.comp
+++ b/shaders/dct_quant.comp
@@ -1,0 +1,7 @@
+#version 450
+
+// Placeholder compute shader for DNxHR DCT and quantization
+
+void main() {
+    // TODO: implement DCT, quantization and block packing
+}

--- a/src/App/AppIO.cpp
+++ b/src/App/AppIO.cpp
@@ -40,6 +40,9 @@ namespace fs = std::filesystem;
 #ifdef ENABLE_PRORES_EXPORT
 static bool g_useGpuProRes = false;
 #endif
+#ifdef ENABLE_DNXHR_EXPORT
+static bool g_useGpuDnxhr = false;
+#endif
 namespace {
     bool writeDngInternal(
         const std::string& outputPath,
@@ -1677,6 +1680,23 @@ void App::convertCurrentClipToProRes() {
     showActionMessage("FFmpeg support not built");
 #endif
 }
+
+#ifdef ENABLE_DNXHR_EXPORT
+void App::exportCurrentClipToDnxhr() {
+    showActionMessage("DNxHR export not implemented");
+}
+
+void App::convertCurrentClipToDnxhr() {
+    showActionMessage("DNxHR export not implemented");
+}
+#else
+void App::exportCurrentClipToDnxhr() {
+    showActionMessage("DNxHR support not built");
+}
+void App::convertCurrentClipToDnxhr() {
+    showActionMessage("DNxHR support not built");
+}
+#endif
 
 void App::setPlaybackMode(PlaybackController::PlaybackMode mode) {
     if (!m_playbackController_ptr) return;

--- a/src/Gui/GuiRender.cpp
+++ b/src/Gui/GuiRender.cpp
@@ -248,6 +248,11 @@ namespace GuiOverlay {
 #else
             ImGui::MenuItem("Export to ProRes", nullptr, false, false);
 #endif
+#ifdef ENABLE_DNXHR_EXPORT
+            if (ImGui::MenuItem("Export to DNxHR (GPU)", nullptr, false, canOperateOnCurrentFile)) {
+                if (appInstance) appInstance->convertCurrentClipToDnxhr();
+            }
+#endif
             ImGui::EndPopup();
         }
 

--- a/src/Utils/DebugLog.cpp
+++ b/src/Utils/DebugLog.cpp
@@ -169,4 +169,7 @@ void LogFFmpegStatus() {
     LogToFile("[FFmpeg] FFmpeg support not built; ProRes export unavailable.");
     LogProRes("[FFmpeg] FFmpeg support not built; ProRes export unavailable.");
 #endif
+#ifdef ENABLE_DNXHR_EXPORT
+    LogToFile("[DNxHR] GPU exporter compiled in.");
+#endif
 }

--- a/src/export/DnxhrBackend.cpp
+++ b/src/export/DnxhrBackend.cpp
@@ -1,0 +1,18 @@
+#include "Export/DnxhrBackend.h"
+#include "Utils/DebugLog.h"
+
+bool DnxhrBackend::initialize(const std::string& path, int width, int height,
+                             int fpsNum, int fpsDen) {
+    LogToFile("[DNxHR] initialize stub");
+    (void)path; (void)width; (void)height; (void)fpsNum; (void)fpsDen;
+    return true;
+}
+
+bool DnxhrBackend::writeSlice(const SliceBuffer& slice) {
+    (void)slice;
+    return true;
+}
+
+void DnxhrBackend::finalize() {
+    LogToFile("[DNxHR] finalize stub");
+}

--- a/src/export/GpuSliceTransfer.cpp
+++ b/src/export/GpuSliceTransfer.cpp
@@ -1,0 +1,12 @@
+#include "Export/GpuSliceTransfer.h"
+
+bool GpuSliceTransfer::mapSlices(void* buffer, size_t size) {
+    (void)buffer;
+    (void)size;
+    // Stub implementation
+    return true;
+}
+
+bool GpuSliceTransfer::unmap() {
+    return true;
+}

--- a/src/export/gpuDnxhrExport.cpp
+++ b/src/export/gpuDnxhrExport.cpp
@@ -1,0 +1,9 @@
+#include "Export/DnxhrBackend.h"
+#include "Export/GpuSliceTransfer.h"
+#include "Utils/DebugLog.h"
+
+bool gpuDnxhrExport(const uint16_t* raw, int width, int height) {
+    (void)raw; (void)width; (void)height;
+    LogToFile("[DNxHR] gpuDnxhrExport stub called");
+    return true;
+}

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -202,6 +202,11 @@ int main(int argc, char* argv[]) {
 
     // Force creation of ProRes log at startup
     LogProRes("[Startup] ProRes log initialized");
+#ifdef ENABLE_DNXHR_EXPORT
+    LogToFile("[Startup] DNxHR exporter available: yes");
+#else
+    LogToFile("[Startup] DNxHR exporter available: no");
+#endif
 
     // Record whether FFmpeg support is available
     LogFFmpegStatus();


### PR DESCRIPTION
## Summary
- add preliminary DNxHR export headers and source stubs
- compile new compute shader `dct_quant.comp`
- hook DNxHR exporter into build and GUI
- log DNxHR capability at startup

## Testing
- `cmake -S . -B build` *(fails: Could not find package configuration file provided by "FFMPEG")*

------
https://chatgpt.com/codex/tasks/task_e_68734c8a30048327880614508b97c9d5