### PR TITLE
Add skeleton GPU DNxHR export framework

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -98,6 +98,7 @@ set(SHADER_FILES
     "${APP_SHADERS_SRC_DIR}/fullscreen_quad.vert"
     "${APP_SHADERS_SRC_DIR}/image_process.frag"
     "${APP_SHADERS_SRC_DIR}/raw_to_yuv422.comp"
+    "${APP_SHADERS_SRC_DIR}/dct_quant.comp"
 )
 set(COMPILED_SHADER_OUTPUTS "")
 foreach(SHADER_INPUT_FILE ${SHADER_FILES})
@@ -151,6 +152,10 @@ set(APP_SOURCES
   src/Graphics/Pipeline.cpp
   src/Graphics/Descriptor.cpp
 
+  src/export/gpuDnxhrExport.cpp
+  src/export/DnxhrBackend.cpp
+  src/export/GpuSliceTransfer.cpp
+
   src/Gui/GuiSetup.cpp
   src/Gui/GuiRender.cpp
   src/Gui/GuiUtils.cpp
@@ -185,6 +190,7 @@ target_compile_definitions(${PROJECT_NAME} PRIVATE GLFW_INCLUDE_NONE)
 if(HAVE_FFMPEG)
     target_compile_definitions(${PROJECT_NAME} PRIVATE ENABLE_PRORES_EXPORT)
 endif()
+target_compile_definitions(${PROJECT_NAME} PRIVATE ENABLE_DNXHR_EXPORT)
 if(MSVC AND CMAKE_SYSTEM_NAME STREQUAL "Windows")
     set_target_properties(${PROJECT_NAME} PROPERTIES LINK_FLAGS "/ENTRY:mainCRTStartup")
     message(STATUS "MSVC: Setting LINK_FLAGS /ENTRY:mainCRTStartup for ${PROJECT_NAME}")
@@ -199,6 +205,7 @@ target_include_directories(${PROJECT_NAME} PRIVATE
   "${PROJECT_SOURCE_DIR}/include/Gui"
   "${PROJECT_SOURCE_DIR}/include/Playback"
   "${PROJECT_SOURCE_DIR}/include/Utils"
+  "${PROJECT_SOURCE_DIR}/include/Export"
 
   "${VMA_INCLUDE_DIR}"
   "${Vulkan_INCLUDE_DIRS}"

--- a/include/App/App.h
+++ b/include/App/App.h
@@ -113,6 +113,7 @@ public:
     void convertCurrentFileToDngs();
     void exportCurrentClipToProRes();
     void convertCurrentClipToProRes();
+    void exportCurrentClipToDnxhr();
     void performSeek(size_t new_frame_index);
     void triggerOpenFileViaDialog();
 	void setPlaybackMode(PlaybackController::PlaybackMode mode);
@@ -228,6 +229,16 @@ private:
     } m_proResStatus;
     std::atomic<bool> m_showExportProgressPopup{ false };
     std::thread m_proResThread;
+#endif
+#ifdef ENABLE_DNXHR_EXPORT
+    struct DnxhrExportStatus {
+        std::atomic<bool> active{ false };
+        std::atomic<int> currentFrame{ 0 };
+        int totalFrames{ 0 };
+        std::string errorMsg;
+    } m_dnxhrStatus;
+    std::atomic<bool> m_showDnxhrProgressPopup{ false };
+    std::thread m_dnxhrThread;
 #endif
 
 

--- a/include/Export/DnxhrExporter.h
+++ b/include/Export/DnxhrExporter.h
@@ -1,0 +1,26 @@
+#ifndef DNXHR_EXPORTER_H
+#define DNXHR_EXPORTER_H
+
+#include <string>
+#include <vector>
+#include <cstdint>
+
+class DnxhrExporter {
+public:
+    struct SliceBuffer {
+        std::vector<int16_t> lumaBlocks;
+        std::vector<int16_t> chromaUBlocks;
+        std::vector<int16_t> chromaVBlocks;
+    };
+
+    explicit DnxhrExporter(const std::string& outputPath);
+    ~DnxhrExporter();
+
+    bool addFrame(const SliceBuffer& slice);
+    bool finalize();
+
+private:
+    std::string m_outputPath;
+};
+
+#endif // DNXHR_EXPORTER_H

--- a/include/Export/GpuExport.h
+++ b/include/Export/GpuExport.h
@@ -1,0 +1,8 @@
+#ifndef GPU_EXPORT_H
+#define GPU_EXPORT_H
+
+#include <string>
+
+bool gpuDnxhrExport(const std::string& outputPath);
+
+#endif // GPU_EXPORT_H

--- a/include/Utils/DebugLog.h
+++ b/include/Utils/DebugLog.h
@@ -6,6 +6,7 @@
 // Simple file logger declaration
 void LogToFile(const std::string& message);
 void LogProRes(const std::string& message);
+void LogDnxhr(const std::string& message);
 // Logs whether FFmpeg/ProRes support is available at runtime
 void LogFFmpegStatus();
 

--- a/shaders/dct_quant.comp
+++ b/shaders/dct_quant.comp
@@ -1,0 +1,9 @@
+// Placeholder compute shader performing DCT and quantization for DNxHR.
+// This GLSL compute shader divides the frame into 8x8 blocks and would
+// output quantized coefficients. The real implementation is GPU specific.
+#version 450
+layout(local_size_x = 8, local_size_y = 8) in;
+
+void main() {
+    // TODO: Implement DCT and quantization on GPU
+}

--- a/src/App/AppIO.cpp
+++ b/src/App/AppIO.cpp
@@ -33,6 +33,9 @@
 #include "ffmpeg_headers.hpp"
 #include "Graphics/GpuYuvConverter.h"
 #endif
+#ifdef ENABLE_DNXHR_EXPORT
+#include "Export/GpuExport.h"
+#endif
 #include "Utils/ColorPipelineCPU.h"
 
 namespace fs = std::filesystem;
@@ -1675,6 +1678,34 @@ void App::convertCurrentClipToProRes() {
     exportCurrentClipToProRes();
 #else
     showActionMessage("FFmpeg support not built");
+#endif
+}
+
+void App::exportCurrentClipToDnxhr() {
+#ifdef ENABLE_DNXHR_EXPORT
+    LogDnxhr("[App] exportCurrentClipToDnxhr invoked");
+    if (m_dnxhrStatus.active.load()) {
+        showActionMessage("Export already running");
+        return;
+    }
+    std::string outputPath = openSaveMovDialog();
+    if (outputPath.empty()) return;
+    if (outputPath.size() < 4 || outputPath.substr(outputPath.size() - 4) != ".mxf") {
+        outputPath += ".mxf";
+    }
+    m_dnxhrStatus.currentFrame.store(0);
+    m_dnxhrStatus.totalFrames = 0;
+    m_dnxhrStatus.errorMsg.clear();
+    m_dnxhrStatus.active.store(true);
+    m_showDnxhrProgressPopup.store(true);
+    if (m_dnxhrThread.joinable()) m_dnxhrThread.join();
+    m_dnxhrThread = std::thread([this, outputPath]() {
+        LogDnxhr("[DNxHR] export thread stub running");
+        gpuDnxhrExport(outputPath);
+        m_dnxhrStatus.active.store(false);
+    });
+#else
+    showActionMessage("DNxHR support not built");
 #endif
 }
 

--- a/src/App/AppInit.cpp
+++ b/src/App/AppInit.cpp
@@ -150,6 +150,10 @@ App::App(const std::string& filePath) :
     , m_showExportProgressPopup(false)
     , m_proResStatus()
 #endif
+#ifdef ENABLE_DNXHR_EXPORT
+    , m_showDnxhrProgressPopup(false)
+    , m_dnxhrStatus()
+#endif
 {
     LogToFile(std::string("App::App Constructor called for file: ") + this->m_filePath);
 #ifndef NDEBUG

--- a/src/Gui/GuiRender.cpp
+++ b/src/Gui/GuiRender.cpp
@@ -248,6 +248,11 @@ namespace GuiOverlay {
 #else
             ImGui::MenuItem("Export to ProRes", nullptr, false, false);
 #endif
+#ifdef ENABLE_DNXHR_EXPORT
+            if (ImGui::MenuItem("Export to DNxHR (GPU)", nullptr, false, canOperateOnCurrentFile)) {
+                if (appInstance) appInstance->exportCurrentClipToDnxhr();
+            }
+#endif
             ImGui::EndPopup();
         }
 
@@ -686,6 +691,28 @@ namespace GuiOverlay {
                 if (ImGui::Button("Close")) {
                     ImGui::CloseCurrentPopup();
                     appInstance->m_showExportProgressPopup.store(false);
+                }
+            }
+            ImGui::EndPopup();
+        }
+#endif
+#ifdef ENABLE_DNXHR_EXPORT
+        if (appInstance->m_showDnxhrProgressPopup.load()) {
+            ImGui::OpenPopup("DNXHR_PROGRESS");
+        }
+        if (ImGui::BeginPopupModal("DNXHR_PROGRESS", nullptr, ImGuiWindowFlags_AlwaysAutoResize)) {
+            int cur = appInstance->m_dnxhrStatus.currentFrame.load();
+            int total = appInstance->m_dnxhrStatus.totalFrames;
+            float progress = total > 0 ? static_cast<float>(cur) / static_cast<float>(total) : 0.0f;
+            ImGui::Text("Exporting to DNxHR %d / %d", cur, total);
+            ImGui::ProgressBar(progress, ImVec2(200, 0));
+            if (!appInstance->m_dnxhrStatus.errorMsg.empty()) {
+                ImGui::TextColored(ImVec4(1,0,0,1), "%s", appInstance->m_dnxhrStatus.errorMsg.c_str());
+            }
+            if (!appInstance->m_dnxhrStatus.active.load()) {
+                if (ImGui::Button("Close")) {
+                    ImGui::CloseCurrentPopup();
+                    appInstance->m_showDnxhrProgressPopup.store(false);
                 }
             }
             ImGui::EndPopup();

--- a/src/Utils/DebugLog.cpp
+++ b/src/Utils/DebugLog.cpp
@@ -88,6 +88,21 @@ static std::ofstream& get_prores_log_file() {
     return log_file;
 }
 
+// Separate log file for DNxHR export diagnostics
+static std::ofstream& get_dnxhr_log_file() {
+    static std::ofstream log_file;
+    static bool initialized = false;
+    if (!initialized) {
+        std::filesystem::path logDir = getLogDirectory();
+        std::error_code ec;
+        std::filesystem::create_directories(logDir, ec);
+        std::filesystem::path logPath = logDir / "dnxhr_export_log.txt";
+        log_file.open(logPath, std::ios_base::app | std::ios_base::out);
+        initialized = true;
+    }
+    return log_file;
+}
+
 void LogToFile(const std::string& message) {
     std::lock_guard<std::mutex> lock(g_log_mutex); // Lock for thread safety
 
@@ -118,6 +133,15 @@ void LogProRes(const std::string& message) {
     std::lock_guard<std::mutex> lock(g_log_mutex);
 
     std::ofstream& log_file = get_prores_log_file();
+    if (log_file.is_open()) {
+        log_file << "[" << make_timestamp() << "] " << message << std::endl;
+    }
+}
+
+void LogDnxhr(const std::string& message) {
+    std::lock_guard<std::mutex> lock(g_log_mutex);
+
+    std::ofstream& log_file = get_dnxhr_log_file();
     if (log_file.is_open()) {
         log_file << "[" << make_timestamp() << "] " << message << std::endl;
     }

--- a/src/export/DnxhrBackend.cpp
+++ b/src/export/DnxhrBackend.cpp
@@ -1,0 +1,19 @@
+#include "Export/DnxhrExporter.h"
+#include "Utils/DebugLog.h"
+
+DnxhrExporter::DnxhrExporter(const std::string& outputPath)
+    : m_outputPath(outputPath) {
+    LogToFile("[DNxHR] exporter created for " + outputPath);
+}
+
+DnxhrExporter::~DnxhrExporter() = default;
+
+bool DnxhrExporter::addFrame(const SliceBuffer& /*slice*/) {
+    LogToFile("[DNxHR] addFrame stub called");
+    return true;
+}
+
+bool DnxhrExporter::finalize() {
+    LogToFile("[DNxHR] finalize stub called");
+    return true;
+}

--- a/src/export/GpuSliceTransfer.cpp
+++ b/src/export/GpuSliceTransfer.cpp
@@ -1,0 +1,14 @@
+#include "Export/DnxhrExporter.h"
+#include "Utils/DebugLog.h"
+
+// Placeholder for GPU to CPU slice transfer implementation.
+// In the real implementation this would map the SSBO and copy
+// the quantized DCT blocks to CPU memory.
+
+bool transferSliceBuffer(int /*frameIdx*/, DnxhrExporter::SliceBuffer& outSlice) {
+    LogToFile("[DNxHR] transferSliceBuffer stub");
+    outSlice.lumaBlocks.clear();
+    outSlice.chromaUBlocks.clear();
+    outSlice.chromaVBlocks.clear();
+    return true;
+}

--- a/src/export/gpuDnxhrExport.cpp
+++ b/src/export/gpuDnxhrExport.cpp
@@ -1,0 +1,16 @@
+#include "Export/DnxhrExporter.h"
+#include "Export/GpuExport.h"
+#include "Utils/DebugLog.h"
+
+// Entry point for GPU accelerated DNxHR export. This is currently a stub
+// implementation that only logs the invocation.
+
+bool gpuDnxhrExport(const std::string& outputPath) {
+    LogToFile("[DNxHR] gpuDnxhrExport invoked for " + outputPath);
+    DnxhrExporter exporter(outputPath);
+    DnxhrExporter::SliceBuffer slice{};
+    // In a real implementation frames would be processed here
+    exporter.addFrame(slice);
+    exporter.finalize();
+    return true;
+}


### PR DESCRIPTION
## Summary
- introduce new DNxHR export headers and stub implementation
- add logging helpers for DNxHR
- wire GUI option and popup to stub DNxHR export
- add placeholder compute shader for future DNxHR DCT/quantization
- extend CMake to build new files and shader

## Testing
- `cmake -S . -B build` *(fails: could not find FFMPEG)*

------
https://chatgpt.com/codex/tasks/task_e_68734c8a30048327880614508b97c9d5