### PR TITLE
Stub GPU DNxHR export

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -98,6 +98,7 @@ set(SHADER_FILES
     "${APP_SHADERS_SRC_DIR}/fullscreen_quad.vert"
     "${APP_SHADERS_SRC_DIR}/image_process.frag"
     "${APP_SHADERS_SRC_DIR}/raw_to_yuv422.comp"
+    "${APP_SHADERS_SRC_DIR}/dct_quant.comp"
 )
 set(COMPILED_SHADER_OUTPUTS "")
 foreach(SHADER_INPUT_FILE ${SHADER_FILES})
@@ -184,6 +185,7 @@ target_compile_definitions(${PROJECT_NAME} PRIVATE SDL_MAIN_HANDLED)
 target_compile_definitions(${PROJECT_NAME} PRIVATE GLFW_INCLUDE_NONE)
 if(HAVE_FFMPEG)
     target_compile_definitions(${PROJECT_NAME} PRIVATE ENABLE_PRORES_EXPORT)
+    target_compile_definitions(${PROJECT_NAME} PRIVATE ENABLE_DNXHR_EXPORT)
 endif()
 if(MSVC AND CMAKE_SYSTEM_NAME STREQUAL "Windows")
     set_target_properties(${PROJECT_NAME} PROPERTIES LINK_FLAGS "/ENTRY:mainCRTStartup")

--- a/include/App/App.h
+++ b/include/App/App.h
@@ -113,6 +113,8 @@ public:
     void convertCurrentFileToDngs();
     void exportCurrentClipToProRes();
     void convertCurrentClipToProRes();
+    void exportCurrentClipToDnxhr();
+    void convertCurrentClipToDnxhr();
     void performSeek(size_t new_frame_index);
     void triggerOpenFileViaDialog();
 	void setPlaybackMode(PlaybackController::PlaybackMode mode);
@@ -228,6 +230,15 @@ private:
     } m_proResStatus;
     std::atomic<bool> m_showExportProgressPopup{ false };
     std::thread m_proResThread;
+
+    struct DnxhrExportStatus {
+        std::atomic<bool> active{ false };
+        std::atomic<int> currentFrame{ 0 };
+        int totalFrames{ 0 };
+        std::string errorMsg;
+    } m_dnxhrStatus;
+    std::atomic<bool> m_showDnxhrProgressPopup{ false };
+    std::thread m_dnxhrThread;
 #endif
 
 

--- a/include/Utils/DebugLog.h
+++ b/include/Utils/DebugLog.h
@@ -6,6 +6,7 @@
 // Simple file logger declaration
 void LogToFile(const std::string& message);
 void LogProRes(const std::string& message);
+void LogDnxhr(const std::string& message);
 // Logs whether FFmpeg/ProRes support is available at runtime
 void LogFFmpegStatus();
 

--- a/shaders/dct_quant.comp
+++ b/shaders/dct_quant.comp
@@ -1,0 +1,8 @@
+#version 460
+// Placeholder shader for DNxHR DCT + quantization
+
+layout(local_size_x = 8, local_size_y = 8, local_size_z = 1) in;
+
+void main() {
+    // TODO: implement DCT and quantization
+}

--- a/src/App/AppIO.cpp
+++ b/src/App/AppIO.cpp
@@ -39,6 +39,7 @@ namespace fs = std::filesystem;
 
 #ifdef ENABLE_PRORES_EXPORT
 static bool g_useGpuProRes = false;
+static bool g_useGpuDnxhr = false;
 #endif
 namespace {
     bool writeDngInternal(
@@ -1677,6 +1678,26 @@ void App::convertCurrentClipToProRes() {
     showActionMessage("FFmpeg support not built");
 #endif
 }
+
+#ifdef ENABLE_DNXHR_EXPORT
+void App::exportCurrentClipToDnxhr() {
+    showActionMessage("DNxHR export not implemented");
+    LogDnxhr("[DNxHRExport] Feature not implemented");
+}
+
+void App::convertCurrentClipToDnxhr() {
+    LogDnxhr("[App] convertCurrentClipToDnxhr invoked");
+    g_useGpuDnxhr = true;
+    exportCurrentClipToDnxhr();
+}
+#else
+void App::exportCurrentClipToDnxhr() {
+    showActionMessage("FFmpeg support not built");
+}
+void App::convertCurrentClipToDnxhr() {
+    showActionMessage("FFmpeg support not built");
+}
+#endif
 
 void App::setPlaybackMode(PlaybackController::PlaybackMode mode) {
     if (!m_playbackController_ptr) return;

--- a/src/Gui/GuiRender.cpp
+++ b/src/Gui/GuiRender.cpp
@@ -245,6 +245,9 @@ namespace GuiOverlay {
             if (ImGui::MenuItem("Convert to ProRes (GPU)", nullptr, false, canOperateOnCurrentFile)) {
                 if (appInstance) appInstance->convertCurrentClipToProRes();
             }
+            if (ImGui::MenuItem("Export to DNxHR (GPU)", nullptr, false, canOperateOnCurrentFile)) {
+                if (appInstance) appInstance->convertCurrentClipToDnxhr();
+            }
 #else
             ImGui::MenuItem("Export to ProRes", nullptr, false, false);
 #endif
@@ -687,10 +690,30 @@ namespace GuiOverlay {
                     ImGui::CloseCurrentPopup();
                     appInstance->m_showExportProgressPopup.store(false);
                 }
+        }
+        ImGui::EndPopup();
+    }
+#endif
+        if (appInstance->m_showDnxhrProgressPopup.load()) {
+            ImGui::OpenPopup("DNXHR_PROGRESS");
+        }
+        if (ImGui::BeginPopupModal("DNXHR_PROGRESS", nullptr, ImGuiWindowFlags_AlwaysAutoResize)) {
+            int cur = appInstance->m_dnxhrStatus.currentFrame.load();
+            int total = appInstance->m_dnxhrStatus.totalFrames;
+            float progress = total > 0 ? static_cast<float>(cur) / static_cast<float>(total) : 0.0f;
+            ImGui::Text("Exporting to DNxHR %d / %d", cur, total);
+            ImGui::ProgressBar(progress, ImVec2(200, 0));
+            if (!appInstance->m_dnxhrStatus.errorMsg.empty()) {
+                ImGui::TextColored(ImVec4(1,0,0,1), "%s", appInstance->m_dnxhrStatus.errorMsg.c_str());
+            }
+            if (!appInstance->m_dnxhrStatus.active.load()) {
+                if (ImGui::Button("Close")) {
+                    ImGui::CloseCurrentPopup();
+                    appInstance->m_showDnxhrProgressPopup.store(false);
+                }
             }
             ImGui::EndPopup();
         }
-#endif
         ImGui::PopStyleVar();
     }
 

--- a/src/Utils/DebugLog.cpp
+++ b/src/Utils/DebugLog.cpp
@@ -88,6 +88,21 @@ static std::ofstream& get_prores_log_file() {
     return log_file;
 }
 
+// Separate log file for DNxHR export diagnostics
+static std::ofstream& get_dnxhr_log_file() {
+    static std::ofstream log_file;
+    static bool initialized = false;
+    if (!initialized) {
+        std::filesystem::path logDir = getLogDirectory();
+        std::error_code ec;
+        std::filesystem::create_directories(logDir, ec);
+        std::filesystem::path logPath = logDir / "dnxhr_export_log.txt";
+        log_file.open(logPath, std::ios_base::app | std::ios_base::out);
+        initialized = true;
+    }
+    return log_file;
+}
+
 void LogToFile(const std::string& message) {
     std::lock_guard<std::mutex> lock(g_log_mutex); // Lock for thread safety
 
@@ -118,6 +133,15 @@ void LogProRes(const std::string& message) {
     std::lock_guard<std::mutex> lock(g_log_mutex);
 
     std::ofstream& log_file = get_prores_log_file();
+    if (log_file.is_open()) {
+        log_file << "[" << make_timestamp() << "] " << message << std::endl;
+    }
+}
+
+void LogDnxhr(const std::string& message) {
+    std::lock_guard<std::mutex> lock(g_log_mutex);
+
+    std::ofstream& log_file = get_dnxhr_log_file();
     if (log_file.is_open()) {
         log_file << "[" << make_timestamp() << "] " << message << std::endl;
     }


### PR DESCRIPTION
## Summary
- create placeholder shader for DNxHR GPU stages
- hook up DNxHR logging facilities
- stub App methods for DNxHR export
- expose DNxHR option in GUI
- adjust CMake for new shader and compile-time flag

## Testing
- `cmake -S . -B build` *(fails: could not find FFMPEG)*

------
https://chatgpt.com/codex/tasks/task_e_68734c8a30048327880614508b97c9d5