### PR TITLE
Replace ProRes export with DNxHR

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ This project builds a desktop player for MotionCam `.mcraw` files.
     cmake --build build --config Release
     ```
 
-FFmpeg is required for the "Export to ProRes" feature. When detected, the build
+FFmpeg is required for the "Export to DNxHR" feature. When detected, the build
 system defines the `ENABLE_PRORES_EXPORT` flag. It will link using the
 `FFMPEG::` imported targets provided by vcpkg when they are available, falling
 back to the `${FFMPEG_LIBRARIES}` list otherwise. The CMake configuration will
@@ -34,19 +34,19 @@ approach is to copy them from
 `avfilter-10.dll`) to the output directory next to the executable. The
 `avfilter-10.pdb` file may also be copied for debugging symbols.
 
-If the **Export to ProRes** option is grayed out in the application, it means
+If the **Export to DNxHR** option is grayed out in the application, it means
 the binary was built without FFmpeg support. Re-run CMake and check that the
 configure step prints "FFmpeg found via vcpkg, enabling ProRes export". When
 this message appears, the `ENABLE_PRORES_EXPORT` definition is added and the
 runtime DLLs will be copied automatically.
 
-## ProRes Export
+## DNxHR Export
 
 - Right-click anywhere in the player window to open the context menu.
-- Choose **Export to ProRes** and select a `.mov` file path.
+- Choose **Export to DNxHR** and select a `.mov` file path.
 - Encoding uses FFmpeg linked via vcpkg. Make sure the libraries are installed in your vcpkg instance.
  - Progress is shown in a modal popup while the encoding thread runs.
- - The export uses the `prores_ks` encoder with frame threading and sets
+- The export uses the `dnxhd` encoder with the `dnxhr_hq` profile and frame threading. `slice_count` is set
    `slice_count` to the number of CPU cores. The conversion and scaling stages
    run on the same thread count via libswscale. The log records all thread
    counts and prints progress every 50 frames with elapsed time. A timing
@@ -68,9 +68,9 @@ runtime DLLs will be copied automatically.
 - You can override the detected CFA pattern at runtime by pressing the number
   keys `1`‑`4` which map to **BGGR**, **RGGB**, **GBRG**, and **GRBG** respectively.
 
-### GPU ProRes Conversion
+### GPU DNxHR Conversion
 
-- Choose **Convert to ProRes (GPU)** from the context menu to run the RAW→YUV conversion on the GPU.
+- Choose **Convert to DNxHR (GPU)** from the context menu to run the RAW→YUV conversion on the GPU.
 - The log prints `MODE = GPU (Vulkan hw_frames)` when this path is used.
 - If initialization of Vulkan hardware frames fails it falls back to the CPU path automatically.
 - When GPU processing is active additional `[GPU]` log lines confirm the compute pipeline ran.

--- a/src/App/AppIO.cpp
+++ b/src/App/AppIO.cpp
@@ -1273,14 +1273,14 @@ void App::exportCurrentClipToProRes() {
                 std::chrono::steady_clock::now() - allocStart).count();
         LogProRes("[ProResExport] Output context created in " + std::to_string(allocMs) + "ms");
 
-        const AVCodec* vcodec = avcodec_find_encoder_by_name("prores_ks");
+        const AVCodec* vcodec = avcodec_find_encoder_by_name("dnxhd");
         if (!vcodec) {
-            m_proResStatus.errorMsg = "ProRes encoder not found";
+            m_proResStatus.errorMsg = "DNxHR encoder not found";
             m_proResStatus.active.store(false);
             avformat_free_context(fmt);
             return;
         }
-        LogProRes(std::string("[ProResExport] ProRes encoder: ") + avcodec_get_name(vcodec->id));
+        LogProRes(std::string("[ProResExport] DNxHR encoder: ") + avcodec_get_name(vcodec->id));
 
         AVStream* vstream = avformat_new_stream(fmt, nullptr);
         if (!vstream) {
@@ -1308,6 +1308,7 @@ void App::exportCurrentClipToProRes() {
             vctx->flags |= AV_CODEC_FLAG_GLOBAL_HEADER;
         AVDictionary* encOpts = nullptr;
         av_dict_set(&encOpts, "slice_count", std::to_string(threads).c_str(), 0);
+        av_dict_set(&encOpts, "profile", "dnxhr_hq", 0);
         LogProRes(std::string("[ProResExport] Slice count: ") + std::to_string(threads));
         auto openVStart = std::chrono::steady_clock::now();
         if (avcodec_open2(vctx, vcodec, &encOpts) < 0) {

--- a/src/Gui/GuiRender.cpp
+++ b/src/Gui/GuiRender.cpp
@@ -239,14 +239,14 @@ namespace GuiOverlay {
             }
             ImGui::Separator();
 #ifdef ENABLE_PRORES_EXPORT
-            if (ImGui::MenuItem("Export to ProRes", nullptr, false, canOperateOnCurrentFile)) {
+            if (ImGui::MenuItem("Export to DNxHR", nullptr, false, canOperateOnCurrentFile)) {
                 if (appInstance) appInstance->exportCurrentClipToProRes();
             }
-            if (ImGui::MenuItem("Convert to ProRes (GPU)", nullptr, false, canOperateOnCurrentFile)) {
+            if (ImGui::MenuItem("Convert to DNxHR (GPU)", nullptr, false, canOperateOnCurrentFile)) {
                 if (appInstance) appInstance->convertCurrentClipToProRes();
             }
 #else
-            ImGui::MenuItem("Export to ProRes", nullptr, false, false);
+            ImGui::MenuItem("Export to DNxHR", nullptr, false, false);
 #endif
             ImGui::EndPopup();
         }
@@ -677,7 +677,7 @@ namespace GuiOverlay {
             int cur = appInstance->m_proResStatus.currentFrame.load();
             int total = appInstance->m_proResStatus.totalFrames;
             float progress = total > 0 ? static_cast<float>(cur) / static_cast<float>(total) : 0.0f;
-            ImGui::Text("Exporting to ProRes %d / %d", cur, total);
+            ImGui::Text("Exporting to DNxHR %d / %d", cur, total);
             ImGui::ProgressBar(progress, ImVec2(200, 0));
             if (!appInstance->m_proResStatus.errorMsg.empty()) {
                 ImGui::TextColored(ImVec4(1,0,0,1), "%s", appInstance->m_proResStatus.errorMsg.c_str());


### PR DESCRIPTION
## Summary
- switch the export codec from `prores_ks` to `dnxhd`
- add DNxHR HQ profile option
- update UI text for DNxHR export
- document DNxHR export in README

## Testing
- `cmake -S . -B build` *(fails: Could not find package configuration file provided by "FFMPEG")*

------
https://chatgpt.com/codex/tasks/task_e_687355123b6c8327b7250fb95daf79ae