### PR TITLE
Add JSON-based codec settings

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -173,6 +173,7 @@ set(APP_SOURCES
   src/Utils/OrientationUtils.cpp
   src/Utils/ColorPipelineCPU.cpp
   src/Export/DnxhrExporter.cpp
+  src/Export/CodecSettings.cpp
 
   src/main.cpp
 )

--- a/codec_settings.json
+++ b/codec_settings.json
@@ -1,0 +1,16 @@
+{
+  "ProRes": {
+    "enabled": true,
+    "profile": "hq",
+    "threads": 8,
+    "thread_type": "slice",
+    "pix_fmt": "yuv422p10le"
+  },
+  "DNxHR": {
+    "enabled": true,
+    "profile": "hqx",
+    "threads": 6,
+    "thread_type": "frame",
+    "pix_fmt": "yuv422p10le"
+  }
+}

--- a/include/Export/CodecSettings.h
+++ b/include/Export/CodecSettings.h
@@ -1,0 +1,19 @@
+#pragma once
+#include <string>
+#include <vector>
+
+struct SingleCodecSettings {
+    bool enabled = true;
+    std::string profile = "hq";
+    int threads = 0; // 0 = auto
+    std::string thread_type = "frame"; // "frame" or "slice"
+    std::string pix_fmt = "yuv422p10le";
+    std::vector<std::string> flags;
+};
+
+struct CodecSettings {
+    SingleCodecSettings proRes;
+    SingleCodecSettings dnxhr;
+};
+
+CodecSettings loadCodecSettings();

--- a/src/App/AppIO.cpp
+++ b/src/App/AppIO.cpp
@@ -34,6 +34,7 @@
 #include "Graphics/GpuYuvConverter.h"
 #endif
 #include "Utils/ColorPipelineCPU.h"
+#include "Export/CodecSettings.h"
 
 namespace fs = std::filesystem;
 
@@ -1244,6 +1245,12 @@ void App::exportCurrentClipToProRes() {
             return;
         }
 
+        CodecSettings codecCfg = loadCodecSettings();
+        SingleCodecSettings pr = codecCfg.proRes;
+        if(!pr.enabled) {
+            LogProRes("[ProRes] disabled via codec_settings.json");
+        }
+
         GpuYuvConverter converter(m_rendererVk.get());
         bool gpuActive = useGpu;
         if (gpuActive) {
@@ -1300,17 +1307,29 @@ void App::exportCurrentClipToProRes() {
         vctx->framerate = av_inv_q(timeBase);
         unsigned threads = std::thread::hardware_concurrency();
         if (threads == 0) threads = 1;
+        if (pr.enabled && pr.threads > 0) threads = pr.threads;
         int bitrate = (width == 1920) ? 185000000 : 90000000;
         vctx->bit_rate = bitrate;
-        vctx->thread_count = 0; // let FFmpeg decide based on HW
-        vctx->thread_type = FF_THREAD_FRAME;
-        LogProRes(std::string("[ProResExport] Detected CPU threads: ") +
-                  std::to_string(threads));
-        LogProRes(std::string("[ProResExport] Thread type: FRAME"));
+        vctx->thread_count = pr.enabled && pr.threads > 0 ? pr.threads : 0;
+        vctx->thread_type = (pr.thread_type == "slice") ? FF_THREAD_SLICE : FF_THREAD_FRAME;
+        enum AVPixelFormat cfg_pf = av_get_pix_fmt(pr.pix_fmt.c_str());
+        if (pr.enabled && cfg_pf != AV_PIX_FMT_NONE) vctx->pix_fmt = cfg_pf;
+        LogProRes(std::string("[ProRes] Threads = ") + std::to_string(threads) +
+                  ", Mode = " + pr.thread_type + ", PixFmt = " + pr.pix_fmt);
         if (fmt->oformat->flags & AVFMT_GLOBALHEADER)
             vctx->flags |= AV_CODEC_FLAG_GLOBAL_HEADER;
         AVDictionary* encOpts = nullptr;
         av_dict_set(&encOpts, "slice_count", std::to_string(threads).c_str(), 0);
+        if (pr.enabled) {
+            av_dict_set(&encOpts, "profile", pr.profile.c_str(), 0);
+            for(const std::string& f : pr.flags) {
+                auto pos = f.find('=');
+                if(pos != std::string::npos)
+                    av_dict_set(&encOpts, f.substr(0,pos).c_str(), f.substr(pos+1).c_str(), 0);
+                else
+                    av_dict_set(&encOpts, f.c_str(), "1", 0);
+            }
+        }
         LogProRes(std::string("[ProResExport] Slice count: ") + std::to_string(threads));
         auto openVStart = std::chrono::steady_clock::now();
         if (avcodec_open2(vctx, vcodec, &encOpts) < 0) {
@@ -1763,6 +1782,11 @@ void App::exportCurrentClipToDNxHR() {
             m_dnxhrStatus.active.store(false);
             return;
         }
+        CodecSettings codecCfg = loadCodecSettings();
+        SingleCodecSettings dn = codecCfg.dnxhr;
+        if(!dn.enabled) {
+            LogProRes("[DNxHR] disabled via codec_settings.json");
+        }
         bool badDim = (width & 1) || (height & 1);
         if (badDim) {
             LogProRes(std::string("[DNxHRExport] WARN non-even dimensions ") + std::to_string(width) + "x" + std::to_string(height) +
@@ -1820,24 +1844,40 @@ void App::exportCurrentClipToDNxHR() {
         vctx->codec_type = AVMEDIA_TYPE_VIDEO;
         vctx->pix_fmt = AV_PIX_FMT_YUV422P10LE;
         vctx->bits_per_raw_sample = 10;
-        vctx->profile = FF_PROFILE_DNXHR_HQX;
         vctx->width = width;
         vctx->height = height;
         vctx->time_base = timeBase;
         vctx->framerate = av_inv_q(timeBase);
         unsigned threads = std::thread::hardware_concurrency();
         if (threads == 0) threads = 1;
-        vctx->thread_count = 0;
-        vctx->thread_type = FF_THREAD_FRAME;
+        if (dn.enabled && dn.threads > 0) threads = dn.threads;
+        vctx->thread_count = dn.enabled && dn.threads > 0 ? dn.threads : 0;
+        vctx->thread_type = (dn.thread_type == "slice") ? FF_THREAD_SLICE : FF_THREAD_FRAME;
+        enum AVPixelFormat dn_pf = av_get_pix_fmt(dn.pix_fmt.c_str());
+        if (dn.enabled && dn_pf != AV_PIX_FMT_NONE) vctx->pix_fmt = dn_pf;
         int bitrate = (width == 1920) ? 185000000 : 90000000;
         vctx->bit_rate = bitrate;
         LogProRes(std::string("[DNxHRExport] Bitrate: ") + std::to_string(bitrate));
+        LogProRes(std::string("[DNxHR] Threads = ") + std::to_string(threads) +
+                  ", Mode = " + dn.thread_type + ", PixFmt = " + dn.pix_fmt);
         LogProRes(std::string("[DNxHRExport] Detected CPU threads: ") + std::to_string(threads));
-        LogProRes(std::string("[DNxHRExport] Thread type: FRAME"));
+        LogProRes(std::string("[DNxHRExport] Thread type: ") + dn.thread_type);
         if (fmt->oformat->flags & AVFMT_GLOBALHEADER)
             vctx->flags |= AV_CODEC_FLAG_GLOBAL_HEADER;
         AVDictionary* encOpts = nullptr;
-        av_dict_set(&encOpts, "profile", "dnxhr_hqx", 0);
+        if (dn.enabled) {
+            std::string prof = "dnxhr_" + dn.profile;
+            av_dict_set(&encOpts, "profile", prof.c_str(), 0);
+            for(const std::string& f : dn.flags) {
+                auto pos = f.find('=');
+                if(pos != std::string::npos)
+                    av_dict_set(&encOpts, f.substr(0,pos).c_str(), f.substr(pos+1).c_str(), 0);
+                else
+                    av_dict_set(&encOpts, f.c_str(), "1", 0);
+            }
+        } else {
+            av_dict_set(&encOpts, "profile", "dnxhr_hqx", 0);
+        }
         auto openVStart = std::chrono::steady_clock::now();
         if (avcodec_open2(vctx, vcodec, &encOpts) < 0) {
             m_dnxhrStatus.errorMsg = "avcodec_open2 failed";
@@ -1857,7 +1897,8 @@ void App::exportCurrentClipToDNxHR() {
             vinfo << "[DNxHRExport] Video encoder settings: "
                   << avcodec_get_name(vctx->codec_id) << " "
                   << vctx->width << "x" << vctx->height
-                  << " pix_fmt=YUV422P10LE profile=HQX";
+                  << " pix_fmt=" << av_get_pix_fmt_name(vctx->pix_fmt)
+                  << " profile=" << dn.profile;
             LogProRes(vinfo.str());
         }
         avcodec_parameters_from_context(vstream->codecpar, vctx);

--- a/src/Export/CodecSettings.cpp
+++ b/src/Export/CodecSettings.cpp
@@ -1,0 +1,57 @@
+#include "Export/CodecSettings.h"
+#include "Utils/DebugLog.h"
+#include <nlohmann/json.hpp>
+#include <filesystem>
+#include <fstream>
+#include <thread>
+
+extern std::string g_AppBasePath;
+
+CodecSettings loadCodecSettings() {
+    CodecSettings settings;
+    unsigned hwThreads = std::thread::hardware_concurrency();
+    if(hwThreads == 0) hwThreads = 1;
+    settings.proRes.threads = hwThreads;
+    settings.dnxhr.threads = hwThreads;
+
+    std::filesystem::path base = g_AppBasePath.empty() ? std::filesystem::current_path() : std::filesystem::path(g_AppBasePath);
+    std::filesystem::path cfgPath = base / "codec_settings.json";
+    if(!std::filesystem::exists(cfgPath)) {
+        LogProRes("[Warning] codec_settings.json not found. Using default ProRes settings");
+        LogProRes("[Warning] codec_settings.json not found. Using default DNxHR settings");
+        return settings;
+    }
+
+    try {
+        std::ifstream f(cfgPath);
+        nlohmann::json j;
+        f >> j;
+        if(j.contains("ProRes")) {
+            auto &pr = j["ProRes"];
+            settings.proRes.enabled = pr.value("enabled", settings.proRes.enabled);
+            settings.proRes.profile = pr.value("profile", settings.proRes.profile);
+            settings.proRes.threads = pr.value("threads", settings.proRes.threads);
+            settings.proRes.thread_type = pr.value("thread_type", settings.proRes.thread_type);
+            settings.proRes.pix_fmt = pr.value("pix_fmt", settings.proRes.pix_fmt);
+            if(pr.contains("flags") && pr["flags"].is_array()) {
+                settings.proRes.flags.clear();
+                for(auto &v : pr["flags"]) settings.proRes.flags.push_back(v.get<std::string>());
+            }
+        }
+        if(j.contains("DNxHR")) {
+            auto &dn = j["DNxHR"];
+            settings.dnxhr.enabled = dn.value("enabled", settings.dnxhr.enabled);
+            settings.dnxhr.profile = dn.value("profile", settings.dnxhr.profile);
+            settings.dnxhr.threads = dn.value("threads", settings.dnxhr.threads);
+            settings.dnxhr.thread_type = dn.value("thread_type", settings.dnxhr.thread_type);
+            settings.dnxhr.pix_fmt = dn.value("pix_fmt", settings.dnxhr.pix_fmt);
+            if(dn.contains("flags") && dn["flags"].is_array()) {
+                settings.dnxhr.flags.clear();
+                for(auto &v : dn["flags"]) settings.dnxhr.flags.push_back(v.get<std::string>());
+            }
+        }
+    } catch(const std::exception& e) {
+        LogProRes(std::string("[Warning] Failed to parse codec_settings.json: ") + e.what());
+    }
+    return settings;
+}


### PR DESCRIPTION
## Summary
- add `codec_settings.json` for ProRes/DNxHR tuning
- implement loader for configurable codec settings
- hook configurable options into export logic
- include new source file in build

## Testing
- `cmake ..`
- `cmake --build .` *(fails: dangerous relocation errors when linking glfw/SDL2)*

------
https://chatgpt.com/codex/tasks/task_e_6874f72a9740832787fbc97d39a0c2f3