### PR TITLE
Add HEVC export for AMD

### DIFF
--- a/include/App/App.h
+++ b/include/App/App.h
@@ -108,6 +108,7 @@ public:
     void toggleHelpPage() { m_showHelpPage = !m_showHelpPage; }
     void saveCurrentFrameAsDng();
     void convertCurrentFileToDngs();
+    void exportCurrentClipToHEVC_AMD();
     void performSeek(size_t new_frame_index);
     void triggerOpenFileViaDialog();
 

--- a/include/Utils/DebugLog.h
+++ b/include/Utils/DebugLog.h
@@ -5,5 +5,6 @@
 
 // Simple file logger declaration
 void LogToFile(const std::string& message);
+void LogHevc(const std::string& message);
 
 #endif // DEBUG_LOG_H

--- a/src/App/AppIO.cpp
+++ b/src/App/AppIO.cpp
@@ -23,7 +23,8 @@
 #include <algorithm>
 #include <cmath>
 #include <cstdio>
-#include <sstream> 
+#include <sstream>
+#include <cstdlib>
 
 namespace fs = std::filesystem;
 
@@ -1148,4 +1149,54 @@ void App::sendAllPlaylistFilesToMotionCamFS()
 
     LogToFile(std::string("[App::sendAllToMotionCamFS] Done. Success: ")
         + std::to_string(ok) + ", Fail: " + std::to_string(fail));
+}
+
+namespace {
+    bool ffmpegSupportsHevcAmf() {
+        FILE* pipe = popen("ffmpeg -encoders 2>&1", "r");
+        if (!pipe) return false;
+        std::string output;
+        char buffer[256];
+        while (fgets(buffer, sizeof(buffer), pipe)) {
+            output += buffer;
+        }
+        pclose(pipe);
+        return output.find("hevc_amf") != std::string::npos;
+    }
+}
+
+void App::exportCurrentClipToHEVC_AMD()
+{
+    if (m_fileList.empty() || m_currentFileIndex < 0 || static_cast<size_t>(m_currentFileIndex) >= m_fileList.size())
+    {
+        LogHevc("[HEVCExport] No valid file selected.");
+        return;
+    }
+
+    if (!ffmpegSupportsHevcAmf()) {
+        LogHevc("[HEVCExport] AMD hardware encoder not available. Aborting export.");
+        return;
+    }
+
+    std::string inputPath = m_fileList[m_currentFileIndex];
+    fs::path inPath(inputPath);
+    fs::path outPath = inPath.parent_path() / (inPath.stem().string() + "_HEVC_AMD_HQ.mp4");
+
+    std::ostringstream cmd;
+    cmd << "ffmpeg -y -i \"" << inputPath << "\" "
+        << "-c:v hevc_amf "
+        << "-pix_fmt p010le "
+        << "-quality quality "
+        << "-rc cqp "
+        << "-cqp_i 20 -cqp_p 23 -cqp_b 25 "
+        << "\"" << outPath.string() << "\"";
+
+    LogHevc(std::string("[HEVCExport] Command: ") + cmd.str());
+
+    int ret = system(cmd.str().c_str());
+    if (ret == 0) {
+        LogHevc(std::string("[HEVCExport] Export completed: ") + outPath.string());
+    } else {
+        LogHevc(std::string("[HEVCExport] Export failed with code ") + std::to_string(ret));
+    }
 }

--- a/src/Gui/GuiRender.cpp
+++ b/src/Gui/GuiRender.cpp
@@ -211,6 +211,9 @@ namespace GuiOverlay {
             if (ImGui::MenuItem("Send All in Playlist to motioncam-fs", nullptr, false, playlistNotEmpty)) {
                 if (appInstance) appInstance->sendAllPlaylistFilesToMotionCamFS();
             }
+            if (ImGui::MenuItem("Convert to HEVC (GPU, AMD 10-bit HQ)", nullptr, false, canOperateOnCurrentFile)) {
+                if (appInstance) appInstance->exportCurrentClipToHEVC_AMD();
+            }
             ImGui::EndPopup();
         }
 

--- a/src/Utils/DebugLog.cpp
+++ b/src/Utils/DebugLog.cpp
@@ -9,6 +9,11 @@
 
 static std::mutex g_log_mutex; // Mutex to protect file access
 
+static std::ofstream& hevc_log_file() {
+    static std::ofstream file("hevc_export_log.txt", std::ios_base::app | std::ios_base::out);
+    return file;
+}
+
 void LogToFile(const std::string& message) {
     std::lock_guard<std::mutex> lock(g_log_mutex); // Lock for thread safety
 
@@ -32,5 +37,28 @@ void LogToFile(const std::string& message) {
 
         log_file << "[" << oss.str() << "] " << message << std::endl;
         // log_file.flush(); // Optional: flush immediately, impacts performance
+    }
+}
+
+void LogHevc(const std::string& message) {
+    std::lock_guard<std::mutex> lock(g_log_mutex);
+
+    auto& file = hevc_log_file();
+    if (file.is_open()) {
+        auto now = std::chrono::system_clock::now();
+        auto ms = std::chrono::duration_cast<std::chrono::milliseconds>(now.time_since_epoch()) % 1000;
+        std::time_t time_now = std::chrono::system_clock::to_time_t(now);
+
+        std::tm timeinfo{};
+#ifdef _WIN32
+        localtime_s(&timeinfo, &time_now);
+#else
+        localtime_r(&time_now, &timeinfo);
+#endif
+        std::ostringstream oss;
+        oss << std::put_time(&timeinfo, "%Y-%m-%d %H:%M:%S");
+        oss << '.' << std::setfill('0') << std::setw(3) << ms.count();
+
+        file << "[" << oss.str() << "] " << message << std::endl;
     }
 }


### PR DESCRIPTION
## Summary
- add LogHevc for separate HEVC export logging
- support exporting current clip with `hevc_amf`
- expose new export option in the context menu

## Testing
- `cmake -S . -B build` *(fails: Threads::Threads target not found)*
- `cmake --build build -j$(nproc)` *(fails: build errors in motioncam-decoder)*

------
https://chatgpt.com/codex/tasks/task_e_6874fd3482a8832796eac4b3fc7f3623