### PR TITLE
Add AMD HEVC export option

### DIFF
--- a/include/App/App.h
+++ b/include/App/App.h
@@ -108,6 +108,7 @@ public:
     void toggleHelpPage() { m_showHelpPage = !m_showHelpPage; }
     void saveCurrentFrameAsDng();
     void convertCurrentFileToDngs();
+    void exportCurrentClipToHEVC_AMD();
     void performSeek(size_t new_frame_index);
     void triggerOpenFileViaDialog();
 

--- a/include/Utils/DebugLog.h
+++ b/include/Utils/DebugLog.h
@@ -5,5 +5,6 @@
 
 // Simple file logger declaration
 void LogToFile(const std::string& message);
+void LogHevc(const std::string& message);
 
 #endif // DEBUG_LOG_H

--- a/src/App/AppIO.cpp
+++ b/src/App/AppIO.cpp
@@ -983,6 +983,80 @@ void App::convertCurrentFileToDngs() {
     }
 }
 
+void App::exportCurrentClipToHEVC_AMD() {
+    if (m_fileList.empty() || m_currentFileIndex < 0 ||
+        static_cast<size_t>(m_currentFileIndex) >= m_fileList.size()) {
+        LogHevc("[HEVCExport] No valid file to export.");
+        return;
+    }
+
+    std::string inputPathStr = m_fileList[m_currentFileIndex];
+    fs::path inputPath = inputPathStr;
+    fs::path outputPath = inputPath.parent_path() /
+        (inputPath.stem().string() + "_HEVC_AMD_HQ.mp4");
+
+    // Check for hevc_amf encoder
+    bool encoderAvailable = false;
+#ifdef _WIN32
+    const char* checkCmd = "ffmpeg -encoders";
+#else
+    const char* checkCmd = "ffmpeg -encoders 2>&1";
+#endif
+    FILE* pipe = nullptr;
+#ifdef _WIN32
+    pipe = _popen(checkCmd, "r");
+#else
+    pipe = popen(checkCmd, "r");
+#endif
+    if (pipe) {
+        char buf[256];
+        while (fgets(buf, sizeof(buf), pipe)) {
+            std::string line(buf);
+            if (line.find("hevc_amf") != std::string::npos) {
+                encoderAvailable = true;
+            }
+        }
+#ifdef _WIN32
+        _pclose(pipe);
+#else
+        pclose(pipe);
+#endif
+    }
+
+    if (!encoderAvailable) {
+        LogHevc("[HEVCExport] AMD hardware encoder not available. Aborting export.");
+        return;
+    }
+
+    std::stringstream cmd;
+    cmd << "ffmpeg -y -i \"" << inputPathStr << "\" "
+        << "-c:v hevc_amf -pix_fmt p010le -quality quality "
+        << "-rc cqp -cqp_i 20 -cqp_p 23 -cqp_b 25 "
+        << "\"" << outputPath.string() << "\"";
+
+    LogHevc(std::string("[HEVCExport] Command: ") + cmd.str());
+
+#ifdef _WIN32
+    pipe = _popen(cmd.str().c_str(), "r");
+#else
+    pipe = popen((cmd.str() + " 2>&1").c_str(), "r");
+#endif
+    if (!pipe) {
+        LogHevc("[HEVCExport] Failed to launch ffmpeg.");
+        return;
+    }
+    char buf[512];
+    while (fgets(buf, sizeof(buf), pipe)) {
+        LogHevc(std::string(buf));
+    }
+#ifdef _WIN32
+    int ret = _pclose(pipe);
+#else
+    int ret = pclose(pipe);
+#endif
+    LogHevc(std::string("[HEVCExport] ffmpeg exited with code ") + std::to_string(ret));
+}
+
 void App::sendCurrentFileToMotionCamFS()
 {
     if (m_fileList.empty() ||

--- a/src/Gui/GuiRender.cpp
+++ b/src/Gui/GuiRender.cpp
@@ -204,6 +204,9 @@ namespace GuiOverlay {
             if (ImGui::MenuItem("Soft Delete MCRAW", nullptr, false, canOperateOnCurrentFile)) {
                 if (appInstance) appInstance->softDeleteCurrentFile();
             }
+            if (ImGui::MenuItem("Convert to HEVC (GPU, AMD 10-bit HQ)", nullptr, false, canOperateOnCurrentFile)) {
+                if (appInstance) appInstance->exportCurrentClipToHEVC_AMD();
+            }
             ImGui::Separator();
             if (ImGui::MenuItem("Send Current to motioncam-fs", nullptr, false, canOperateOnCurrentFile)) {
                 if (appInstance) appInstance->sendCurrentFileToMotionCamFS();

--- a/src/Utils/DebugLog.cpp
+++ b/src/Utils/DebugLog.cpp
@@ -8,6 +8,7 @@
 #include <mutex> // For thread-safe logging
 
 static std::mutex g_log_mutex; // Mutex to protect file access
+static std::mutex g_hevc_log_mutex;
 
 void LogToFile(const std::string& message) {
     std::lock_guard<std::mutex> lock(g_log_mutex); // Lock for thread safety
@@ -32,5 +33,30 @@ void LogToFile(const std::string& message) {
 
         log_file << "[" << oss.str() << "] " << message << std::endl;
         // log_file.flush(); // Optional: flush immediately, impacts performance
+    }
+}
+
+void LogHevc(const std::string& message) {
+    std::lock_guard<std::mutex> lock(g_hevc_log_mutex);
+
+    static std::ofstream log_file("hevc_export_log.txt", std::ios_base::app | std::ios_base::out);
+
+    if (log_file.is_open()) {
+        auto now = std::chrono::system_clock::now();
+        auto ms = std::chrono::duration_cast<std::chrono::milliseconds>(now.time_since_epoch()) % 1000;
+        std::time_t time_now = std::chrono::system_clock::to_time_t(now);
+
+        std::tm timeinfo{};
+#ifdef _WIN32
+        localtime_s(&timeinfo, &time_now);
+#else
+        localtime_r(&time_now, &timeinfo);
+#endif
+
+        std::ostringstream oss;
+        oss << std::put_time(&timeinfo, "%Y-%m-%d %H:%M:%S");
+        oss << '.' << std::setfill('0') << std::setw(3) << ms.count();
+
+        log_file << "[" << oss.str() << "] " << message << std::endl;
     }
 }


### PR DESCRIPTION
## Summary
- add LogHevc helper for hevc export logging
- implement HEVC export with hevc_amf encoder
- expose export function in App API and context menu

## Testing
- `cmake -S motioncam-player -B motioncam-player/build`
- `cmake --build motioncam-player/build` *(fails: error building motioncam-decoder)*

------
https://chatgpt.com/codex/tasks/task_e_6874fd35c25c832792221341902b67ff