### PR TITLE
Add AMD HEVC export option

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,3 +83,9 @@ runtime DLLs will be copied automatically.
   Non-conforming sizes emit a warning but encoding still proceeds.
 - Uses the DNxHR **HQX** profile (10‑bit 4:2:2) with the MXF container.
 - Progress and error reporting mirror the ProRes export and are written to the same log file.
+
+## HEVC Export (AMD)
+
+- Choose **Convert to HEVC (GPU, AMD 10-bit HQ)** to encode using the `hevc_amf` hardware encoder.
+- Encoding runs in constant quality mode using 10‑bit P010 frames with the `transcoding` usage preset and `slow` quality setting.
+- If the AMD encoder is unavailable the export aborts and logs to `hevc_export_log.txt`.

--- a/include/App/App.h
+++ b/include/App/App.h
@@ -115,6 +115,8 @@ public:
     void convertCurrentClipToProRes();
     void exportCurrentClipToDNxHR();
     void convertCurrentClipToDNxHR();
+    void exportCurrentClipToHEVC_AMD();
+    void convertCurrentClipToHEVC_AMD();
     void performSeek(size_t new_frame_index);
     void triggerOpenFileViaDialog();
 	void setPlaybackMode(PlaybackController::PlaybackMode mode);
@@ -239,6 +241,15 @@ private:
     } m_dnxhrStatus;
     std::atomic<bool> m_showDNxHRExportProgressPopup{ false };
     std::thread m_dnxhrThread;
+
+    struct HevcExportStatus {
+        std::atomic<bool> active{ false };
+        std::atomic<int> currentFrame{ 0 };
+        int totalFrames{ 0 };
+        std::string errorMsg;
+    } m_hevcStatus;
+    std::atomic<bool> m_showHevcExportProgressPopup{ false };
+    std::thread m_hevcThread;
 #endif
 
 
@@ -283,6 +294,7 @@ private:
     std::string openMcrawDialog();
     std::string openSaveMovDialog();
     std::string openSaveMxfDialog();
+    std::string openSaveMp4Dialog();
 
     struct SwapChainSupportDetails {
         VkSurfaceCapabilitiesKHR capabilities;

--- a/include/Utils/DebugLog.h
+++ b/include/Utils/DebugLog.h
@@ -7,6 +7,7 @@
 void LogToFile(const std::string& message);
 void LogProRes(const std::string& message);
 void LogDnxhr(const std::string& message);
+void LogHevc(const std::string& message);
 // Logs whether FFmpeg/ProRes support is available at runtime
 void LogFFmpegStatus();
 

--- a/src/App/AppCleanup.cpp
+++ b/src/App/AppCleanup.cpp
@@ -63,6 +63,11 @@ App::~App() {
         m_dnxhrThread.join();
         LogToFile("[App::~App] DNxHR export thread joined.");
     }
+    if (m_hevcThread.joinable()) {
+        LogToFile("[App::~App] Joining HEVC export thread...");
+        m_hevcThread.join();
+        LogToFile("[App::~App] HEVC export thread joined.");
+    }
 #endif
 
     destroyPersistentStagingBuffers();

--- a/src/App/AppIO.cpp
+++ b/src/App/AppIO.cpp
@@ -32,6 +32,8 @@
 #ifdef ENABLE_PRORES_EXPORT
 #include "ffmpeg_headers.hpp"
 #include "Graphics/GpuYuvConverter.h"
+#include <libavutil/error.h>
+#include <libavutil/pixdesc.h>
 #endif
 #include "Utils/ColorPipelineCPU.h"
 
@@ -40,6 +42,7 @@ namespace fs = std::filesystem;
 #ifdef ENABLE_PRORES_EXPORT
 static bool g_useGpuProRes = false;
 static bool g_useGpuDNxHR = false;
+static bool g_useGpuHevc = false;
 #endif
 namespace {
     bool writeDngInternal(
@@ -2213,6 +2216,359 @@ void App::convertCurrentClipToDNxHR() {
     LogProRes("[App] convertCurrentClipToDNxHR invoked");
     g_useGpuDNxHR = true;
     exportCurrentClipToDNxHR();
+#else
+    showActionMessage("FFmpeg support not built");
+#endif
+}
+
+#ifdef ENABLE_PRORES_EXPORT
+void App::exportCurrentClipToHEVC_AMD() {
+    if (m_hevcStatus.active.load()) {
+        showActionMessage("Export already running");
+        return;
+    }
+
+    std::string outputPath = openSaveMp4Dialog();
+    if (outputPath.empty()) return;
+    if (outputPath.size() < 4 || outputPath.substr(outputPath.size() - 4) != ".mp4") {
+        outputPath += ".mp4";
+    }
+
+    if (!m_decoderWrapper_ptr || !m_decoderWrapper_ptr->getDecoder()) {
+        showActionMessage("No clip loaded");
+        return;
+    }
+
+    LogHevc(std::string("[HEVCExport] Starting export to ") + outputPath);
+
+    m_hevcStatus.totalFrames = static_cast<int>(m_decoderWrapper_ptr->getDecoder()->getFrames().size());
+    LogHevc(std::string("[HEVCExport] Total frames: ") + std::to_string(m_hevcStatus.totalFrames));
+    m_hevcStatus.currentFrame.store(0);
+    m_hevcStatus.active.store(true);
+    m_hevcStatus.errorMsg.clear();
+    m_showHevcExportProgressPopup.store(true);
+    showActionMessage("Export Started");
+
+    if (m_hevcThread.joinable()) {
+        m_hevcThread.join();
+    }
+
+    bool useGpu = g_useGpuHevc;
+    m_hevcThread = std::thread([this, outputPath, useGpu]() {
+        av_log_set_level(AV_LOG_ERROR);
+        LogHevc("[HEVCExport] Thread started");
+        LogHevc(std::string("[HEVCExport] MODE = ") + (useGpu ? "GPU (Vulkan hw_frames)" : "CPU (swscale)"));
+
+        auto* dec = m_decoderWrapper_ptr->getDecoder();
+        const auto& frames = dec->getFrames();
+        LogHevc(std::string("[HEVCExport] Frames to export: ") + std::to_string(frames.size()));
+        if (frames.empty()) {
+            m_hevcStatus.errorMsg = "No frames to export";
+            m_hevcStatus.active.store(false);
+            return;
+        }
+
+        RawBytes rawBuf;
+        nlohmann::json meta;
+        try {
+            dec->loadFrame(frames[0], rawBuf, meta);
+        } catch (const std::exception& e) {
+            LogToFile(std::string("[HEVCExport] Failed to load first frame: ") + e.what());
+            m_hevcStatus.errorMsg = "Failed to load first frame";
+            m_hevcStatus.active.store(false);
+            return;
+        }
+        int width = meta.value("width", 0);
+        int height = meta.value("height", 0);
+        LogHevc(std::string("[HEVCExport] Frame dimensions: ") + std::to_string(width) + "x" + std::to_string(height));
+        if (width <= 0 || height <= 0) {
+            m_hevcStatus.errorMsg = "Invalid frame dimensions";
+            m_hevcStatus.active.store(false);
+            return;
+        }
+
+        GpuYuvConverter converter(m_rendererVk.get());
+        bool gpuActive = useGpu;
+        if (gpuActive) {
+            if (!converter.init(width, height)) {
+                LogHevc("[HEVCExport] GPU init failed, falling back to CPU");
+                gpuActive = false;
+            }
+        }
+
+        int64_t frameDurationNs = 0;
+        if (frames.size() >= 2) {
+            frameDurationNs = frames[1] - frames[0];
+        } else {
+            frameDurationNs = 41708333; // ~24fps fallback
+        }
+        AVRational timeBase{ static_cast<int>(frameDurationNs / 1000), 1000000 };
+        LogHevc(std::string("[HEVCExport] Time base: ") + std::to_string(timeBase.num) + "/" + std::to_string(timeBase.den));
+
+        AVFormatContext* fmt = nullptr;
+        if (avformat_alloc_output_context2(&fmt, nullptr, nullptr, outputPath.c_str()) < 0 || !fmt) {
+            m_hevcStatus.errorMsg = "avformat_alloc_output_context2 failed";
+            m_hevcStatus.active.store(false);
+            return;
+        }
+
+        const AVCodec* vcodec = avcodec_find_encoder_by_name("hevc_amf");
+        if (!vcodec) {
+            m_hevcStatus.errorMsg = "AMD hardware encoder not available. Aborting export.";
+            m_hevcStatus.active.store(false);
+            avformat_free_context(fmt);
+            return;
+        }
+        LogHevc(std::string("[HEVCExport] HEVC encoder: ") + avcodec_get_name(vcodec->id));
+
+        AVStream* vstream = avformat_new_stream(fmt, nullptr);
+        if (!vstream) {
+            m_hevcStatus.errorMsg = "avformat_new_stream failed";
+            m_hevcStatus.active.store(false);
+            avformat_free_context(fmt);
+            return;
+        }
+        AVCodecContext* vctx = avcodec_alloc_context3(vcodec);
+        vctx->codec_id = vcodec->id;
+        vctx->codec_type = AVMEDIA_TYPE_VIDEO;
+        vctx->pix_fmt = AV_PIX_FMT_P010;
+        vctx->width = width;
+        vctx->height = height;
+        vctx->time_base = timeBase;
+        vctx->framerate = av_inv_q(timeBase);
+        if (fmt->oformat->flags & AVFMT_GLOBALHEADER)
+            vctx->flags |= AV_CODEC_FLAG_GLOBAL_HEADER;
+
+        av_opt_set(vctx->priv_data, "usage", "transcoding", 0);
+        av_opt_set(vctx->priv_data, "quality", "slow", 0);
+        av_opt_set(vctx->priv_data, "profile", "main", 0);
+        av_opt_set(vctx->priv_data, "tier", "high", 0);
+        av_opt_set(vctx->priv_data, "b", "0", 0);
+        av_opt_set(vctx->priv_data, "rc", "cqp", 0);
+        av_opt_set(vctx->priv_data, "qp_i", "22", 0);
+        av_opt_set(vctx->priv_data, "g", "250", 0);
+
+        LogHevc("[HEVCExport] usage=transcoding quality=slow profile=main tier=high rc=cqp qp_i=22 g=250");
+        char pixDesc[64];
+        snprintf(pixDesc, sizeof(pixDesc), "[HEVCExport] pix_fmt=%s", av_get_pix_fmt_name(vctx->pix_fmt));
+        LogHevc(pixDesc);
+
+        int openErr = avcodec_open2(vctx, vcodec, nullptr);
+        if (openErr < 0) {
+            char errbuf[AV_ERROR_MAX_STRING_SIZE] = {0};
+            av_strerror(openErr, errbuf, sizeof(errbuf));
+            m_hevcStatus.errorMsg = std::string("avcodec_open2 failed: ") + errbuf;
+            m_hevcStatus.active.store(false);
+            avcodec_free_context(&vctx);
+            avformat_free_context(fmt);
+            return;
+        }
+        avcodec_parameters_from_context(vstream->codecpar, vctx);
+        vstream->time_base = timeBase;
+
+        const AVCodec* acodec = avcodec_find_encoder(AV_CODEC_ID_PCM_S16LE);
+        AVStream* astream = nullptr;
+        AVCodecContext* actx = nullptr;
+        if (acodec) {
+            astream = avformat_new_stream(fmt, nullptr);
+            actx = avcodec_alloc_context3(acodec);
+            actx->codec_id = AV_CODEC_ID_PCM_S16LE;
+            actx->sample_rate = 48000;
+            av_channel_layout_default(&actx->ch_layout, 2);
+            actx->sample_fmt = AV_SAMPLE_FMT_S16;
+            actx->time_base = {1, actx->sample_rate};
+            if (fmt->oformat->flags & AVFMT_GLOBALHEADER)
+                actx->flags |= AV_CODEC_FLAG_GLOBAL_HEADER;
+            if (avcodec_open2(actx, acodec, nullptr) >= 0) {
+                avcodec_parameters_from_context(astream->codecpar, actx);
+                astream->time_base = actx->time_base;
+            } else {
+                avcodec_free_context(&actx);
+                actx = nullptr;
+            }
+        }
+
+        if (!(fmt->oformat->flags & AVFMT_NOFILE)) {
+            if (avio_open(&fmt->pb, outputPath.c_str(), AVIO_FLAG_WRITE) < 0) {
+                m_hevcStatus.errorMsg = "avio_open failed";
+                m_hevcStatus.active.store(false);
+                if (actx) avcodec_free_context(&actx);
+                avcodec_free_context(&vctx);
+                avformat_free_context(fmt);
+                return;
+            }
+        }
+
+        if (avformat_write_header(fmt, nullptr) < 0) {
+            m_hevcStatus.errorMsg = "avformat_write_header failed";
+            m_hevcStatus.active.store(false);
+            if (!(fmt->oformat->flags & AVFMT_NOFILE)) avio_closep(&fmt->pb);
+            if (actx) avcodec_free_context(&actx);
+            avcodec_free_context(&vctx);
+            avformat_free_context(fmt);
+            return;
+        }
+
+        AVFrame* frame = av_frame_alloc();
+        frame->format = vctx->pix_fmt;
+        frame->width = width;
+        frame->height = height;
+        if (av_frame_get_buffer(frame, 32) < 0) {
+            m_hevcStatus.errorMsg = "av_frame_get_buffer failed";
+            av_frame_free(&frame);
+            if (actx) avcodec_free_context(&actx);
+            if (!(fmt->oformat->flags & AVFMT_NOFILE)) avio_closep(&fmt->pb);
+            avcodec_free_context(&vctx);
+            avformat_free_context(fmt);
+            m_hevcStatus.active.store(false);
+            return;
+        }
+
+        SwsContext* sws = sws_getContext(width, height, AV_PIX_FMT_RGB24,
+                                         width, height, AV_PIX_FMT_P010,
+                                         SWS_BILINEAR, nullptr,nullptr,nullptr);
+        unsigned threads = std::thread::hardware_concurrency();
+        av_opt_set_int(sws, "threads", threads, 0);
+
+        CPUColorParams cpParams{};
+        cpParams.width = width;
+        cpParams.height = height;
+        cpParams.cfaType = m_cfaTypeFromMetadata;
+        cpParams.blackLevel = m_staticBlack;
+        cpParams.whiteLevel = m_staticWhite;
+
+        GpuColorParams gpuParams{};
+        gpuParams.cfaType = m_cfaTypeFromMetadata;
+        gpuParams.fullSwing = 0;
+        gpuParams.black = static_cast<unsigned int>(m_staticBlack);
+        gpuParams.white = static_cast<unsigned int>(m_staticWhite);
+
+        auto asn_json = meta.value("asShotNeutral", std::vector<double>{1.0,1.0,1.0});
+        if (asn_json.size() >= 3) {
+            cpParams.gainR = (asn_json[1] > 1e-6 && asn_json[0] > 1e-6) ? (float)(asn_json[1]/asn_json[0]) : 1.0f;
+            cpParams.gainB = (asn_json[1] > 1e-6 && asn_json[2] > 1e-6) ? (float)(asn_json[1]/asn_json[2]) : 1.0f;
+            gpuParams.wbR = cpParams.gainR;
+            gpuParams.wbG = 1.0f;
+            gpuParams.wbB = cpParams.gainB;
+        }
+        auto ccm_json = meta.value("ColorMatrix2", std::vector<double>{});
+        if (ccm_json.empty()) ccm_json = meta.value("ColorMatrix1", std::vector<double>{});
+        for (size_t i = 0; i < 9 && i < ccm_json.size(); ++i)
+            cpParams.ccm[i] = static_cast<float>(ccm_json[i]);
+
+        std::vector<uint8_t> rgbBuf;
+        RawBytes raw;
+        int framesEncoded = 0;
+
+        for (size_t idx = 0; idx < frames.size(); ++idx) {
+            try { dec->loadFrame(frames[idx], raw, meta); }
+            catch (...) { m_hevcStatus.errorMsg = "Frame read error"; break; }
+
+            if (gpuActive) {
+                converter.convertToFrame(asU16(raw), width, height, frame, gpuParams);
+            } else {
+                convertRawToRGB24(asU16(raw), cpParams, rgbBuf, threads);
+                const uint8_t* srcSlice[1] = { rgbBuf.data() };
+                int srcStride[1] = { width * 3 };
+                sws_scale(sws, srcSlice, srcStride, 0, height, frame->data, frame->linesize);
+            }
+            frame->pts = idx;
+            if (avcodec_send_frame(vctx, frame) < 0) { m_hevcStatus.errorMsg = "send_frame failed"; break; }
+            AVPacket pkt{};
+            while (avcodec_receive_packet(vctx, &pkt) == 0) {
+                pkt.stream_index = vstream->index;
+                pkt.duration = 1;
+                pkt.pts = av_rescale_q(pkt.pts, vctx->time_base, vstream->time_base);
+                pkt.dts = pkt.pts;
+                if (av_interleaved_write_frame(fmt, &pkt) < 0) { m_hevcStatus.errorMsg = "write_frame failed"; av_packet_unref(&pkt); break; }
+                av_packet_unref(&pkt);
+                ++framesEncoded;
+                m_hevcStatus.currentFrame.store(static_cast<int>(idx + 1));
+            }
+            if (!m_hevcStatus.errorMsg.empty()) break;
+        }
+
+        avcodec_send_frame(vctx, nullptr);
+        AVPacket pkt{};
+        while (avcodec_receive_packet(vctx, &pkt) == 0) {
+            pkt.stream_index = vstream->index;
+            pkt.duration = 1;
+            pkt.pts = av_rescale_q(pkt.pts, vctx->time_base, vstream->time_base);
+            pkt.dts = pkt.pts;
+            av_interleaved_write_frame(fmt, &pkt);
+            av_packet_unref(&pkt);
+            ++framesEncoded;
+        }
+
+        if (actx && astream) {
+            motioncam::AudioChunkLoader* loader = m_decoderWrapper_ptr->makeFreshAudioLoader();
+            motioncam::AudioChunk chunk;
+            int64_t audioPts = 0;
+            while (loader && loader->next(chunk)) {
+                if (chunk.second.empty()) break;
+                AVFrame* af = av_frame_alloc();
+                af->format = actx->sample_fmt;
+                av_channel_layout_copy(&af->ch_layout, &actx->ch_layout);
+                af->sample_rate = actx->sample_rate;
+                int nb = chunk.second.size() / actx->ch_layout.nb_channels;
+                af->nb_samples = nb;
+                av_frame_get_buffer(af, 0);
+                memcpy(af->data[0], chunk.second.data(), chunk.second.size()*sizeof(int16_t));
+                af->pts = audioPts;
+                audioPts += nb;
+                if (avcodec_send_frame(actx, af) >= 0) {
+                    AVPacket apkt{};
+                    while (avcodec_receive_packet(actx, &apkt) == 0) {
+                        apkt.stream_index = astream->index;
+                        apkt.pts = av_rescale_q(apkt.pts, actx->time_base, astream->time_base);
+                        apkt.dts = apkt.pts;
+                        av_interleaved_write_frame(fmt, &apkt);
+                        av_packet_unref(&apkt);
+                    }
+                }
+                av_frame_free(&af);
+            }
+            avcodec_send_frame(actx, nullptr);
+            AVPacket apkt{};
+            while (avcodec_receive_packet(actx, &apkt) == 0) {
+                apkt.stream_index = astream->index;
+                apkt.pts = av_rescale_q(apkt.pts, actx->time_base, astream->time_base);
+                apkt.dts = apkt.pts;
+                av_interleaved_write_frame(fmt, &apkt);
+                av_packet_unref(&apkt);
+            }
+        }
+
+        av_write_trailer(fmt);
+        sws_freeContext(sws);
+        av_frame_free(&frame);
+        if (actx) avcodec_free_context(&actx);
+        if (!(fmt->oformat->flags & AVFMT_NOFILE)) avio_closep(&fmt->pb);
+        avcodec_free_context(&vctx);
+        avformat_free_context(fmt);
+
+        if (m_hevcStatus.errorMsg.empty()) {
+            showActionMessage("Export Finished");
+            LogHevc(std::string("[HEVCExport] Export finished successfully, frames encoded: ") + std::to_string(framesEncoded));
+        } else {
+            LogToFile(std::string("[HEVCExport] Error: ") + m_hevcStatus.errorMsg);
+            LogHevc(std::string("[HEVCExport] Error: ") + m_hevcStatus.errorMsg);
+        }
+        m_hevcStatus.active.store(false);
+        g_useGpuHevc = false;
+    });
+}
+#else
+void App::exportCurrentClipToHEVC_AMD() {
+    showActionMessage("FFmpeg support not built");
+}
+#endif
+
+void App::convertCurrentClipToHEVC_AMD() {
+#ifdef ENABLE_PRORES_EXPORT
+    LogHevc("[App] convertCurrentClipToHEVC_AMD invoked");
+    g_useGpuHevc = true;
+    exportCurrentClipToHEVC_AMD();
 #else
     showActionMessage("FFmpeg support not built");
 #endif

--- a/src/App/AppInit.cpp
+++ b/src/App/AppInit.cpp
@@ -151,6 +151,8 @@ App::App(const std::string& filePath) :
     , m_proResStatus()
     , m_showDNxHRExportProgressPopup(false)
     , m_dnxhrStatus()
+    , m_showHevcExportProgressPopup(false)
+    , m_hevcStatus()
 #endif
 {
     LogToFile(std::string("App::App Constructor called for file: ") + this->m_filePath);

--- a/src/App/AppInput.cpp
+++ b/src/App/AppInput.cpp
@@ -560,6 +560,42 @@ std::string App::openSaveMxfDialog() {
     return {};
 }
 
+std::string App::openSaveMp4Dialog() {
+#ifdef _WIN32
+    OPENFILENAMEW ofn{};
+    wchar_t szFile[MAX_PATH] = { 0 };
+    ofn.lStructSize = sizeof(ofn);
+
+    HWND ownerHwnd = NULL;
+    if (m_window) {
+        ownerHwnd = glfwGetWin32Window(m_window);
+    }
+
+    ofn.hwndOwner = ownerHwnd;
+    ofn.lpstrFilter = L"MP4 files\0*.mp4\0All Files\0*.*\0";
+    ofn.lpstrFile = szFile;
+    ofn.nMaxFile = MAX_PATH;
+    ofn.Flags = OFN_OVERWRITEPROMPT | OFN_PATHMUSTEXIST | OFN_NOCHANGEDIR;
+    ofn.lpstrDefExt = L"mp4";
+
+    if (GetSaveFileNameW(&ofn)) {
+        std::string utf8Path = DebugLogHelper::wstring_to_utf8(szFile);
+        if (utf8Path.empty() && szFile[0] != L'\0') {
+            LogToFile("[App::openSaveMp4Dialog] UTF-8 conversion failed for selected path.");
+            return {};
+        }
+        return utf8Path;
+    }
+#else
+    LogToFile("[App::openSaveMp4Dialog] Save dialog not implemented for this platform. Using console fallback.");
+    std::string path;
+    std::cout << "Enter output .mp4 path: " << std::flush;
+    std::getline(std::cin, path);
+    return path;
+#endif
+    return {};
+}
+
 void App::triggerOpenFileViaDialog() {
     std::string newPath = openMcrawDialog();
     if (!newPath.empty()) {

--- a/src/Gui/GuiRender.cpp
+++ b/src/Gui/GuiRender.cpp
@@ -251,6 +251,9 @@ namespace GuiOverlay {
             if (ImGui::MenuItem("Convert to DNxHR (GPU)", nullptr, false, canOperateOnCurrentFile)) {
                 if (appInstance) appInstance->convertCurrentClipToDNxHR();
             }
+            if (ImGui::MenuItem("Convert to HEVC (GPU, AMD 10-bit HQ)", nullptr, false, canOperateOnCurrentFile)) {
+                if (appInstance) appInstance->convertCurrentClipToHEVC_AMD();
+            }
 #else
             ImGui::MenuItem("Export to ProRes", nullptr, false, false);
 #endif
@@ -713,6 +716,26 @@ namespace GuiOverlay {
                 if (ImGui::Button("Close")) {
                     ImGui::CloseCurrentPopup();
                     appInstance->m_showDNxHRExportProgressPopup.store(false);
+                }
+            }
+            ImGui::EndPopup();
+        }
+        if (appInstance->m_showHevcExportProgressPopup.load()) {
+            ImGui::OpenPopup("HEVC_EXPORT_PROGRESS");
+        }
+        if (ImGui::BeginPopupModal("HEVC_EXPORT_PROGRESS", nullptr, ImGuiWindowFlags_AlwaysAutoResize)) {
+            int cur = appInstance->m_hevcStatus.currentFrame.load();
+            int total = appInstance->m_hevcStatus.totalFrames;
+            float progress = total > 0 ? static_cast<float>(cur) / static_cast<float>(total) : 0.0f;
+            ImGui::Text("Exporting to HEVC %d / %d", cur, total);
+            ImGui::ProgressBar(progress, ImVec2(200, 0));
+            if (!appInstance->m_hevcStatus.errorMsg.empty()) {
+                ImGui::TextColored(ImVec4(1,0,0,1), "%s", appInstance->m_hevcStatus.errorMsg.c_str());
+            }
+            if (!appInstance->m_hevcStatus.active.load()) {
+                if (ImGui::Button("Close")) {
+                    ImGui::CloseCurrentPopup();
+                    appInstance->m_showHevcExportProgressPopup.store(false);
                 }
             }
             ImGui::EndPopup();

--- a/src/Utils/DebugLog.cpp
+++ b/src/Utils/DebugLog.cpp
@@ -102,6 +102,20 @@ static std::ofstream& get_dnxhr_log_file() {
     return log_file;
 }
 
+static std::ofstream& get_hevc_log_file() {
+    static std::ofstream log_file;
+    static bool initialized = false;
+    if (!initialized) {
+        std::filesystem::path logDir = getLogDirectory();
+        std::error_code ec;
+        std::filesystem::create_directories(logDir, ec);
+        std::filesystem::path logPath = logDir / "hevc_export_log.txt";
+        log_file.open(logPath, std::ios_base::app | std::ios_base::out);
+        initialized = true;
+    }
+    return log_file;
+}
+
 void LogToFile(const std::string& message) {
     std::lock_guard<std::mutex> lock(g_log_mutex); // Lock for thread safety
 
@@ -141,6 +155,15 @@ void LogDnxhr(const std::string& message) {
     std::lock_guard<std::mutex> lock(g_log_mutex);
 
     std::ofstream& log_file = get_dnxhr_log_file();
+    if (log_file.is_open()) {
+        log_file << "[" << make_timestamp() << "] " << message << std::endl;
+    }
+}
+
+void LogHevc(const std::string& message) {
+    std::lock_guard<std::mutex> lock(g_log_mutex);
+
+    std::ofstream& log_file = get_hevc_log_file();
     if (log_file.is_open()) {
         log_file << "[" << make_timestamp() << "] " << message << std::endl;
     }


### PR DESCRIPTION
## Summary
- introduce HEVC export using hevc_amf encoder
- log HEVC workflow to `hevc_export_log.txt`
- support `.mp4` save dialog
- show progress for HEVC export in GUI
- update README with instructions
- refine encoder options for 10-bit HQ
- fix missing pixdesc header

## Testing
- `cmake -S . -B build` *(fails: Cannot find source file `src/Export/DnxhrExporter.cpp`)*

------
https://chatgpt.com/codex/tasks/task_e_68750389c7b48327bec4c3bd9d824077