### PR TITLE
Improve HEVC export settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,3 +89,5 @@ runtime DLLs will be copied automatically.
 - Choose **Convert to HEVC (GPU, AMD 10-bit HQ)** to encode using the `hevc_amf` hardware encoder.
 - Encoding runs in constant quality mode using 10‑bit P010 frames with the `transcoding` usage preset and `slow` quality setting.
 - If the AMD encoder is unavailable the export aborts and logs to `hevc_export_log.txt`.
+- Intra frames now use a QP value of 16 and the encoder writes BT.709 color metadata.
+- The log file lists these settings so you can verify the parameters used.

--- a/src/App/AppIO.cpp
+++ b/src/App/AppIO.cpp
@@ -2348,10 +2348,14 @@ void App::exportCurrentClipToHEVC_AMD() {
         av_opt_set(vctx->priv_data, "tier", "high", 0);
         av_opt_set(vctx->priv_data, "b", "0", 0);
         av_opt_set(vctx->priv_data, "rc", "cqp", 0);
-        av_opt_set(vctx->priv_data, "qp_i", "22", 0);
+        av_opt_set(vctx->priv_data, "qp_i", "16", 0);
         av_opt_set(vctx->priv_data, "g", "250", 0);
+        vctx->color_primaries = AVCOL_PRI_BT709;
+        vctx->color_trc = AVCOL_TRC_BT709;
+        vctx->colorspace = AVCOL_SPC_BT709;
+        LogHevc("[HEVCExport] color_primaries=bt709 color_trc=bt709 colorspace=bt709");
 
-        LogHevc("[HEVCExport] usage=transcoding quality=slow profile=main tier=high rc=cqp qp_i=22 g=250");
+        LogHevc("[HEVCExport] usage=transcoding quality=slow profile=main tier=high rc=cqp qp_i=16 g=250 color=bt709");
         char pixDesc[64];
         snprintf(pixDesc, sizeof(pixDesc), "[HEVCExport] pix_fmt=%s", av_get_pix_fmt_name(vctx->pix_fmt));
         LogHevc(pixDesc);


### PR DESCRIPTION
## Summary
- tweak HEVC export quality
- document BT.709 color metadata and new QP value

## Testing
- `cmake -S . -B build`
- `cmake --build build -j 4` *(fails: cannot find -lavcodec.lib)*

------
https://chatgpt.com/codex/tasks/task_e_687558f8b7c08327ae83dccc273dcc3c