### PR TITLE
Improve HEVC export settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,7 +87,8 @@ runtime DLLs will be copied automatically.
 ## HEVC Export (AMD)
 
 - Choose **Convert to HEVC (GPU, AMD 10-bit HQ)** to encode using the `hevc_amf` hardware encoder.
-- Encoding runs in constant quality mode using 10‑bit P010 frames with the `transcoding` usage preset and `slow` quality setting.
+- Encoding uses the `transcoding` usage preset with the `slow` quality setting and 10‑bit P010 frames.
+- The encoder runs in high quality **ABR** mode at ~250&nbsp;Mbps with an IDR frame every frame (GOP&nbsp;= 1).
+- BT.709 color metadata is written so DaVinci Resolve interprets the clip correctly.
 - If the AMD encoder is unavailable the export aborts and logs to `hevc_export_log.txt`.
-- Intra frames now use a QP value of 16 and the encoder writes BT.709 color metadata.
 - The log file lists these settings so you can verify the parameters used.

--- a/src/App/AppIO.cpp
+++ b/src/App/AppIO.cpp
@@ -2344,18 +2344,20 @@ void App::exportCurrentClipToHEVC_AMD() {
 
         av_opt_set(vctx->priv_data, "usage", "transcoding", 0);
         av_opt_set(vctx->priv_data, "quality", "slow", 0);
-        av_opt_set(vctx->priv_data, "profile", "main", 0);
+        av_opt_set(vctx->priv_data, "profile", "main10", 0);
         av_opt_set(vctx->priv_data, "tier", "high", 0);
-        av_opt_set(vctx->priv_data, "b", "0", 0);
-        av_opt_set(vctx->priv_data, "rc", "cqp", 0);
-        av_opt_set(vctx->priv_data, "qp_i", "16", 0);
-        av_opt_set(vctx->priv_data, "g", "250", 0);
+        av_opt_set(vctx->priv_data, "rc", "abr", 0);
+        av_opt_set(vctx->priv_data, "b", "250M", 0);
+        av_opt_set(vctx->priv_data, "maxrate", "250M", 0);
+        av_opt_set(vctx->priv_data, "bufsize", "500M", 0);
+        av_opt_set(vctx->priv_data, "g", "1", 0);
+        av_opt_set(vctx->priv_data, "forced-idr", "1", 0);
         vctx->color_primaries = AVCOL_PRI_BT709;
         vctx->color_trc = AVCOL_TRC_BT709;
         vctx->colorspace = AVCOL_SPC_BT709;
         LogHevc("[HEVCExport] color_primaries=bt709 color_trc=bt709 colorspace=bt709");
 
-        LogHevc("[HEVCExport] usage=transcoding quality=slow profile=main tier=high rc=cqp qp_i=16 g=250 color=bt709");
+        LogHevc("[HEVCExport] usage=transcoding quality=slow profile=main10 tier=high rc=abr b=250M maxrate=250M bufsize=500M g=1 color=bt709");
         char pixDesc[64];
         snprintf(pixDesc, sizeof(pixDesc), "[HEVCExport] pix_fmt=%s", av_get_pix_fmt_name(vctx->pix_fmt));
         LogHevc(pixDesc);


### PR DESCRIPTION
## Summary
- refine HEVC settings for better 10-bit quality
- document the new AMD HEVC export behaviour

## Testing
- `cmake -S . -B build`
- `cmake --build build -j$(nproc)` *(fails: libavutil/frame.h missing)*

------
https://chatgpt.com/codex/tasks/task_e_68755fcd8a308327912cbadc4b9d3fce