### PR TITLE
Add advanced encoding profile

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,3 +92,19 @@ runtime DLLs will be copied automatically.
 - BT.709 color metadata is written so DaVinci Resolve interprets the clip correctly.
 - If the AMD encoder is unavailable the export aborts and logs to `hevc_export_log.txt`.
 - The log file lists these settings so you can verify the parameters used.
+
+## Custom Encoding Configuration
+
+An `advanced_encoding_profile.json` file is included in the project root with example parameters for the ProRes, DNxHR and HEVC export paths. Each section lists encoder options that can be modified before running the tools. The fields mirror the values set inside the application source so you can experiment with different bitrates, profiles or quality levels.
+
+```json
+{
+  "HEVC": {
+    "bitrate": 250000000,
+    "qp": 20,
+    "gpu_preset": "extreme"
+  }
+}
+```
+
+Edit the numbers to suit your needs. The configuration is provided for reference and can be adapted for custom scripts or future enhancements.

--- a/advanced_encoding_profile.json
+++ b/advanced_encoding_profile.json
@@ -1,0 +1,35 @@
+{
+  "ProRes": {
+    "encoder": "prores_ks",
+    "profile": "standard",
+    "bits_per_mb": 8000,
+    "pix_fmt": "yuv422p10le",
+    "slice_count": 16,
+    "gop": 1,
+    "color_primaries": "bt709"
+  },
+  "DNxHR": {
+    "profile": "hq",
+    "pix_fmt": "yuv422p10le",
+    "threads": 8,
+    "bitrate": 185000000,
+    "gop": 1,
+    "color_primaries": "bt709"
+  },
+  "HEVC": {
+    "encoder": "hevc_amf",
+    "usage": "transcoding",
+    "quality": "slow",
+    "profile": "main10",
+    "tier": "high",
+    "rc": "abr",
+    "bitrate": 250000000,
+    "maxrate": 250000000,
+    "bufsize": 500000000,
+    "gop": 1,
+    "forced_idr": true,
+    "qp": 20,
+    "color_primaries": "bt709",
+    "gpu_preset": "extreme"
+  }
+}


### PR DESCRIPTION
## Summary
- add `advanced_encoding_profile.json` with tunable ProRes, DNxHR and HEVC parameters
- document configuration file usage in README

## Testing
- `cmake -S . -B build`
- `cmake --build build` *(fails: libavutil/frame.h: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_6876155f7304832799b92f5500417c03