### PR TITLE
Add runtime encoding config

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -172,6 +172,7 @@ set(APP_SOURCES
   src/Utils/DebugLog.cpp
   src/Utils/OrientationUtils.cpp
   src/Utils/ColorPipelineCPU.cpp
+  src/App/EncodingConfig.cpp
 
   src/main.cpp
 )

--- a/README.md
+++ b/README.md
@@ -92,3 +92,31 @@ runtime DLLs will be copied automatically.
 - BT.709 color metadata is written so DaVinci Resolve interprets the clip correctly.
 - If the AMD encoder is unavailable the export aborts and logs to `hevc_export_log.txt`.
 - The log file lists these settings so you can verify the parameters used.
+
+## Encoding Configuration
+
+The player checks for a file named `encoding_config.json` next to the executable.
+When present, ProRes, DNxHR and HEVC export routines read their parameters from
+this file. All values are optional and fall back to the built in defaults if
+omitted. Example contents:
+
+```json
+{
+  "prores": {
+    "codec": "prores_ks",
+    "profile": "standard",
+    "pix_fmt": "yuv422p10le",
+    "bitrate": 185000000
+  },
+  "dnxhr": {
+    "profile": "HQX",
+    "pix_fmt": "yuv422p10le"
+  },
+  "hevc_gpu": {
+    "encoder": "hevc_amf",
+    "usage": "transcoding",
+    "quality": "slow",
+    "qp_i": 22
+  }
+}
+```

--- a/encoding_config.json
+++ b/encoding_config.json
@@ -1,0 +1,36 @@
+{
+  "prores": {
+    "codec": "prores_ks",
+    "profile": "standard",
+    "pix_fmt": "yuv422p10le",
+    "bitrate": 185000000,
+    "slice_count": 8,
+    "thread_count": 0
+  },
+  "dnxhr": {
+    "profile": "HQX",
+    "pix_fmt": "yuv422p10le",
+    "bitrate": 185000000,
+    "thread_count": 0
+  },
+  "hevc_gpu": {
+    "encoder": "hevc_amf",
+    "usage": "transcoding",
+    "quality": "slow",
+    "profile": "main10",
+    "tier": "high",
+    "pix_fmt": "p010",
+    "rate_control": "abr",
+    "bitrate": "250M",
+    "maxrate": "250M",
+    "bufsize": "500M",
+    "gop": 1,
+    "forced_idr": 1,
+    "color_primaries": "bt709",
+    "color_trc": "bt709",
+    "colorspace": "bt709",
+    "qp_i": 22,
+    "qp_p": 23,
+    "qp_b": 25
+  }
+}

--- a/include/App/EncodingConfig.h
+++ b/include/App/EncodingConfig.h
@@ -1,0 +1,51 @@
+#ifndef ENCODING_CONFIG_H
+#define ENCODING_CONFIG_H
+
+#include <string>
+
+struct ProResSettings {
+    std::string codec = "prores_ks";
+    std::string profile = "standard";
+    std::string pixFmt = "yuv422p10le";
+    int bitrate = 185000000;
+    int sliceCount = 0;
+    int threadCount = 0;
+};
+
+struct DnxhrSettings {
+    std::string profile = "HQX";
+    std::string pixFmt = "yuv422p10le";
+    int bitrate = 185000000;
+    int threadCount = 0;
+};
+
+struct HevcGpuSettings {
+    std::string encoder = "hevc_amf";
+    std::string usage = "transcoding";
+    std::string quality = "slow";
+    std::string profile = "main10";
+    std::string tier = "high";
+    std::string pixFmt = "p010";
+    std::string rateControl = "abr";
+    std::string bitrate = "250M";
+    std::string maxrate = "250M";
+    std::string bufsize = "500M";
+    int gop = 1;
+    int forcedIdr = 1;
+    std::string colorPrimaries = "bt709";
+    std::string colorTrc = "bt709";
+    std::string colorspace = "bt709";
+    int qpI = -1;
+    int qpP = -1;
+    int qpB = -1;
+};
+
+struct EncodingConfig {
+    ProResSettings prores;
+    DnxhrSettings dnxhr;
+    HevcGpuSettings hevcGpu;
+};
+
+EncodingConfig loadEncodingConfig(const std::string& path);
+
+#endif // ENCODING_CONFIG_H

--- a/src/App/AppIO.cpp
+++ b/src/App/AppIO.cpp
@@ -11,6 +11,7 @@
 #include <motioncam/RawData.hpp>
 
 #include "App/AppConfig.h"
+#include "App/EncodingConfig.h"
 
 #ifndef TINY_DNG_WRITER_IMPLEMENTATION
 #define TINY_DNG_WRITER_IMPLEMENTATION
@@ -1280,7 +1281,10 @@ void App::exportCurrentClipToProRes() {
                 std::chrono::steady_clock::now() - allocStart).count();
         LogProRes("[ProResExport] Output context created in " + std::to_string(allocMs) + "ms");
 
-        const AVCodec* vcodec = avcodec_find_encoder_by_name("prores_ks");
+        const AVCodec* vcodec = avcodec_find_encoder_by_name(pcfg.codec.c_str());
+        if (!vcodec) {
+            vcodec = avcodec_find_encoder_by_name("prores_ks");
+        }
         if (!vcodec) {
             m_proResStatus.errorMsg = "ProRes encoder not found";
             m_proResStatus.active.store(false);
@@ -1299,16 +1303,17 @@ void App::exportCurrentClipToProRes() {
         AVCodecContext* vctx = avcodec_alloc_context3(vcodec);
         vctx->codec_id = vcodec->id;
         vctx->codec_type = AVMEDIA_TYPE_VIDEO;
-        vctx->pix_fmt = AV_PIX_FMT_YUV422P10LE;
+        AVPixelFormat pfmt = av_get_pix_fmt(pcfg.pixFmt.c_str());
+        vctx->pix_fmt = (pfmt == AV_PIX_FMT_NONE) ? AV_PIX_FMT_YUV422P10LE : pfmt;
         vctx->width = width;
         vctx->height = height;
         vctx->time_base = timeBase;
         vctx->framerate = av_inv_q(timeBase);
         unsigned threads = std::thread::hardware_concurrency();
         if (threads == 0) threads = 1;
-        int bitrate = (width == 1920) ? 185000000 : 90000000;
+        int bitrate = pcfg.bitrate > 0 ? pcfg.bitrate : ((width == 1920) ? 185000000 : 90000000);
         vctx->bit_rate = bitrate;
-        vctx->thread_count = 0; // let FFmpeg decide based on HW
+        vctx->thread_count = pcfg.threadCount;
         vctx->thread_type = FF_THREAD_FRAME;
         LogProRes(std::string("[ProResExport] Detected CPU threads: ") +
                   std::to_string(threads));
@@ -1316,8 +1321,11 @@ void App::exportCurrentClipToProRes() {
         if (fmt->oformat->flags & AVFMT_GLOBALHEADER)
             vctx->flags |= AV_CODEC_FLAG_GLOBAL_HEADER;
         AVDictionary* encOpts = nullptr;
-        av_dict_set(&encOpts, "slice_count", std::to_string(threads).c_str(), 0);
-        LogProRes(std::string("[ProResExport] Slice count: ") + std::to_string(threads));
+        int slices = pcfg.sliceCount > 0 ? pcfg.sliceCount : threads;
+        av_dict_set(&encOpts, "slice_count", std::to_string(slices).c_str(), 0);
+        if (!pcfg.profile.empty())
+            av_dict_set(&encOpts, "profile", pcfg.profile.c_str(), 0);
+        LogProRes(std::string("[ProResExport] Slice count: ") + std::to_string(slices));
         auto openVStart = std::chrono::steady_clock::now();
         if (avcodec_open2(vctx, vcodec, &encOpts) < 0) {
             m_proResStatus.errorMsg = "avcodec_open2 failed";
@@ -1793,6 +1801,9 @@ void App::exportCurrentClipToDNxHR() {
         AVRational timeBase{ static_cast<int>(frameDurationNs / 1000), 1000000 };
         LogProRes(std::string("[DNxHRExport] Time base: ") + std::to_string(timeBase.num) + "/" + std::to_string(timeBase.den));
 
+        EncodingConfig encCfg = loadEncodingConfig((fs::current_path() / "encoding_config.json").string());
+        const auto& dcfg = encCfg.dnxhr;
+
         LogProRes("[DNxHRExport] Allocating output context");
         auto allocStart = std::chrono::steady_clock::now();
         AVFormatContext* fmt = nullptr;
@@ -1824,18 +1835,20 @@ void App::exportCurrentClipToDNxHR() {
         AVCodecContext* vctx = avcodec_alloc_context3(vcodec);
         vctx->codec_id = vcodec->id;
         vctx->codec_type = AVMEDIA_TYPE_VIDEO;
-        vctx->pix_fmt = AV_PIX_FMT_YUV422P10LE;
+        AVPixelFormat pfmt_d = av_get_pix_fmt(dcfg.pixFmt.c_str());
+        vctx->pix_fmt = (pfmt_d == AV_PIX_FMT_NONE) ? AV_PIX_FMT_YUV422P10LE : pfmt_d;
         vctx->bits_per_raw_sample = 10;
-        vctx->profile = FF_PROFILE_DNXHR_HQX;
+        if (dcfg.profile == "HQX")
+            vctx->profile = FF_PROFILE_DNXHR_HQX;
         vctx->width = width;
         vctx->height = height;
         vctx->time_base = timeBase;
         vctx->framerate = av_inv_q(timeBase);
         unsigned threads = std::thread::hardware_concurrency();
         if (threads == 0) threads = 1;
-        vctx->thread_count = 0;
+        vctx->thread_count = dcfg.threadCount;
         vctx->thread_type = FF_THREAD_FRAME;
-        int bitrate = (width == 1920) ? 185000000 : 90000000;
+        int bitrate = dcfg.bitrate > 0 ? dcfg.bitrate : ((width == 1920) ? 185000000 : 90000000);
         vctx->bit_rate = bitrate;
         LogProRes(std::string("[DNxHRExport] Bitrate: ") + std::to_string(bitrate));
         LogProRes(std::string("[DNxHRExport] Detected CPU threads: ") + std::to_string(threads));
@@ -1843,7 +1856,10 @@ void App::exportCurrentClipToDNxHR() {
         if (fmt->oformat->flags & AVFMT_GLOBALHEADER)
             vctx->flags |= AV_CODEC_FLAG_GLOBAL_HEADER;
         AVDictionary* encOpts = nullptr;
-        av_dict_set(&encOpts, "profile", "dnxhr_hqx", 0);
+        if (!dcfg.profile.empty()) {
+            std::string profStr = dcfg.profile == "HQX" ? "dnxhr_hqx" : dcfg.profile;
+            av_dict_set(&encOpts, "profile", profStr.c_str(), 0);
+        }
         auto openVStart = std::chrono::steady_clock::now();
         if (avcodec_open2(vctx, vcodec, &encOpts) < 0) {
             m_dnxhrStatus.errorMsg = "avcodec_open2 failed";
@@ -2308,6 +2324,9 @@ void App::exportCurrentClipToHEVC_AMD() {
         AVRational timeBase{ static_cast<int>(frameDurationNs / 1000), 1000000 };
         LogHevc(std::string("[HEVCExport] Time base: ") + std::to_string(timeBase.num) + "/" + std::to_string(timeBase.den));
 
+        EncodingConfig encCfg = loadEncodingConfig((fs::current_path() / "encoding_config.json").string());
+        const auto& hcfg = encCfg.hevcGpu;
+
         AVFormatContext* fmt = nullptr;
         if (avformat_alloc_output_context2(&fmt, nullptr, nullptr, outputPath.c_str()) < 0 || !fmt) {
             m_hevcStatus.errorMsg = "avformat_alloc_output_context2 failed";
@@ -2315,7 +2334,7 @@ void App::exportCurrentClipToHEVC_AMD() {
             return;
         }
 
-        const AVCodec* vcodec = avcodec_find_encoder_by_name("hevc_amf");
+        const AVCodec* vcodec = avcodec_find_encoder_by_name(hcfg.encoder.c_str());
         if (!vcodec) {
             m_hevcStatus.errorMsg = "AMD hardware encoder not available. Aborting export.";
             m_hevcStatus.active.store(false);
@@ -2334,7 +2353,8 @@ void App::exportCurrentClipToHEVC_AMD() {
         AVCodecContext* vctx = avcodec_alloc_context3(vcodec);
         vctx->codec_id = vcodec->id;
         vctx->codec_type = AVMEDIA_TYPE_VIDEO;
-        vctx->pix_fmt = AV_PIX_FMT_P010;
+        AVPixelFormat pfmt_h = av_get_pix_fmt(hcfg.pixFmt.c_str());
+        vctx->pix_fmt = (pfmt_h == AV_PIX_FMT_NONE) ? AV_PIX_FMT_P010 : pfmt_h;
         vctx->width = width;
         vctx->height = height;
         vctx->time_base = timeBase;
@@ -2342,27 +2362,47 @@ void App::exportCurrentClipToHEVC_AMD() {
         if (fmt->oformat->flags & AVFMT_GLOBALHEADER)
             vctx->flags |= AV_CODEC_FLAG_GLOBAL_HEADER;
 
-        av_opt_set(vctx->priv_data, "usage", "transcoding", 0);
-        av_opt_set(vctx->priv_data, "quality", "slow", 0);
-        av_opt_set(vctx->priv_data, "profile", "main10", 0);
-        av_opt_set(vctx->priv_data, "tier", "high", 0);
-        av_opt_set(vctx->priv_data, "rc", "abr", 0);
-        av_opt_set(vctx->priv_data, "b", "250M", 0);
-        av_opt_set(vctx->priv_data, "maxrate", "250M", 0);
-        av_opt_set(vctx->priv_data, "bufsize", "500M", 0);
-        av_opt_set(vctx->priv_data, "g", "1", 0);
-        av_opt_set(vctx->priv_data, "forced-idr", "1", 0);
+        av_opt_set(vctx->priv_data, "usage", hcfg.usage.c_str(), 0);
+        av_opt_set(vctx->priv_data, "quality", hcfg.quality.c_str(), 0);
+        av_opt_set(vctx->priv_data, "profile", hcfg.profile.c_str(), 0);
+        av_opt_set(vctx->priv_data, "tier", hcfg.tier.c_str(), 0);
+        av_opt_set(vctx->priv_data, "rc", hcfg.rateControl.c_str(), 0);
+        av_opt_set(vctx->priv_data, "b", hcfg.bitrate.c_str(), 0);
+        av_opt_set(vctx->priv_data, "maxrate", hcfg.maxrate.c_str(), 0);
+        av_opt_set(vctx->priv_data, "bufsize", hcfg.bufsize.c_str(), 0);
+        av_opt_set(vctx->priv_data, "g", std::to_string(hcfg.gop).c_str(), 0);
+        av_opt_set(vctx->priv_data, "forced-idr", std::to_string(hcfg.forcedIdr).c_str(), 0);
+
         vctx->color_primaries = AVCOL_PRI_BT709;
         vctx->color_trc = AVCOL_TRC_BT709;
         vctx->colorspace = AVCOL_SPC_BT709;
-        LogHevc("[HEVCExport] color_primaries=bt709 color_trc=bt709 colorspace=bt709");
+        if (hcfg.colorPrimaries != "bt709") {
+            // simple mapping
+            if (hcfg.colorPrimaries == "bt2020") vctx->color_primaries = AVCOL_PRI_BT2020;
+        }
+        if (hcfg.colorTrc != "bt709") {
+            if (hcfg.colorTrc == "smpte2084") vctx->color_trc = AVCOL_TRC_SMPTE2084;
+        }
+        if (hcfg.colorspace != "bt709") {
+            if (hcfg.colorspace == "bt2020_ncl") vctx->colorspace = AVCOL_SPC_BT2020_NCL;
+        }
 
-        LogHevc("[HEVCExport] usage=transcoding quality=slow profile=main10 tier=high rc=abr b=250M maxrate=250M bufsize=500M g=1 color=bt709");
+        LogHevc("[HEVCExport] color_primaries=" + hcfg.colorPrimaries + " color_trc=" + hcfg.colorTrc + " colorspace=" + hcfg.colorspace);
+
+        LogHevc("[HEVCExport] usage=" + hcfg.usage + " quality=" + hcfg.quality + " profile=" + hcfg.profile + " tier=" + hcfg.tier +
+                " rc=" + hcfg.rateControl + " b=" + hcfg.bitrate + " maxrate=" + hcfg.maxrate + " bufsize=" + hcfg.bufsize +
+                " g=" + std::to_string(hcfg.gop) + " color=" + hcfg.colorPrimaries);
         char pixDesc[64];
         snprintf(pixDesc, sizeof(pixDesc), "[HEVCExport] pix_fmt=%s", av_get_pix_fmt_name(vctx->pix_fmt));
         LogHevc(pixDesc);
 
-        int openErr = avcodec_open2(vctx, vcodec, nullptr);
+        AVDictionary* hevcOpts = nullptr;
+        if (hcfg.qpI >= 0) av_dict_set(&hevcOpts, "qp_i", std::to_string(hcfg.qpI).c_str(), 0);
+        if (hcfg.qpP >= 0) av_dict_set(&hevcOpts, "qp_p", std::to_string(hcfg.qpP).c_str(), 0);
+        if (hcfg.qpB >= 0) av_dict_set(&hevcOpts, "qp_b", std::to_string(hcfg.qpB).c_str(), 0);
+
+        int openErr = avcodec_open2(vctx, vcodec, &hevcOpts);
+        av_dict_free(&hevcOpts);
         if (openErr < 0) {
             char errbuf[AV_ERROR_MAX_STRING_SIZE] = {0};
             av_strerror(openErr, errbuf, sizeof(errbuf));

--- a/src/App/EncodingConfig.cpp
+++ b/src/App/EncodingConfig.cpp
@@ -1,0 +1,53 @@
+#include "App/EncodingConfig.h"
+#include <nlohmann/json.hpp>
+#include <fstream>
+
+EncodingConfig loadEncodingConfig(const std::string& path) {
+    EncodingConfig cfg;
+    std::ifstream in(path);
+    if (!in.is_open()) return cfg;
+    nlohmann::json j;
+    try {
+        in >> j;
+    } catch (...) {
+        return cfg;
+    }
+    if (j.contains("prores")) {
+        const auto& p = j["prores"];
+        cfg.prores.codec = p.value("codec", cfg.prores.codec);
+        cfg.prores.profile = p.value("profile", cfg.prores.profile);
+        cfg.prores.pixFmt = p.value("pix_fmt", cfg.prores.pixFmt);
+        cfg.prores.bitrate = p.value("bitrate", cfg.prores.bitrate);
+        cfg.prores.sliceCount = p.value("slice_count", cfg.prores.sliceCount);
+        cfg.prores.threadCount = p.value("thread_count", cfg.prores.threadCount);
+    }
+    if (j.contains("dnxhr")) {
+        const auto& d = j["dnxhr"];
+        cfg.dnxhr.profile = d.value("profile", cfg.dnxhr.profile);
+        cfg.dnxhr.pixFmt = d.value("pix_fmt", cfg.dnxhr.pixFmt);
+        cfg.dnxhr.bitrate = d.value("bitrate", cfg.dnxhr.bitrate);
+        cfg.dnxhr.threadCount = d.value("thread_count", cfg.dnxhr.threadCount);
+    }
+    if (j.contains("hevc_gpu")) {
+        const auto& h = j["hevc_gpu"];
+        cfg.hevcGpu.encoder = h.value("encoder", cfg.hevcGpu.encoder);
+        cfg.hevcGpu.usage = h.value("usage", cfg.hevcGpu.usage);
+        cfg.hevcGpu.quality = h.value("quality", cfg.hevcGpu.quality);
+        cfg.hevcGpu.profile = h.value("profile", cfg.hevcGpu.profile);
+        cfg.hevcGpu.tier = h.value("tier", cfg.hevcGpu.tier);
+        cfg.hevcGpu.pixFmt = h.value("pix_fmt", cfg.hevcGpu.pixFmt);
+        cfg.hevcGpu.rateControl = h.value("rate_control", cfg.hevcGpu.rateControl);
+        cfg.hevcGpu.bitrate = h.value("bitrate", cfg.hevcGpu.bitrate);
+        cfg.hevcGpu.maxrate = h.value("maxrate", cfg.hevcGpu.maxrate);
+        cfg.hevcGpu.bufsize = h.value("bufsize", cfg.hevcGpu.bufsize);
+        cfg.hevcGpu.gop = h.value("gop", cfg.hevcGpu.gop);
+        cfg.hevcGpu.forcedIdr = h.value("forced_idr", cfg.hevcGpu.forcedIdr);
+        cfg.hevcGpu.colorPrimaries = h.value("color_primaries", cfg.hevcGpu.colorPrimaries);
+        cfg.hevcGpu.colorTrc = h.value("color_trc", cfg.hevcGpu.colorTrc);
+        cfg.hevcGpu.colorspace = h.value("colorspace", cfg.hevcGpu.colorspace);
+        cfg.hevcGpu.qpI = h.value("qp_i", cfg.hevcGpu.qpI);
+        cfg.hevcGpu.qpP = h.value("qp_p", cfg.hevcGpu.qpP);
+        cfg.hevcGpu.qpB = h.value("qp_b", cfg.hevcGpu.qpB);
+    }
+    return cfg;
+}


### PR DESCRIPTION
## Summary
- rename example encoding profile to `encoding_config.json`
- introduce `EncodingConfig` with ProRes, DNxHR and HEVC GPU options
- load `encoding_config.json` at export time
- document runtime config in README

## Testing
- `cmake -S . -B build`
- `cmake --build build -j2` *(fails: libavutil headers missing)*

------
https://chatgpt.com/codex/tasks/task_e_6876155f7304832799b92f5500417c03