### PR TITLE
Add runtime encoding config via JSON

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -172,6 +172,7 @@ set(APP_SOURCES
   src/Utils/DebugLog.cpp
   src/Utils/OrientationUtils.cpp
   src/Utils/ColorPipelineCPU.cpp
+  src/Utils/EncodingConfig.cpp
 
   src/main.cpp
 )

--- a/README.md
+++ b/README.md
@@ -92,3 +92,51 @@ runtime DLLs will be copied automatically.
 - BT.709 color metadata is written so DaVinci Resolve interprets the clip correctly.
 - If the AMD encoder is unavailable the export aborts and logs to `hevc_export_log.txt`.
 - The log file lists these settings so you can verify the parameters used.
+
+## Encoding Configuration
+
+Runtime encoder settings can be overridden by placing an `encoding_config.json`
+file next to the executable. Options are grouped by encoder and all values are
+optional:
+
+```
+{
+  "prores": {
+    "codec": "prores_ks",
+    "profile": "standard",
+    "pix_fmt": "yuv422p10le",
+    "bitrate": 185000000,
+    "slice_count": 8,
+    "thread_count": 0
+  },
+  "dnxhr": {
+    "profile": "dnxhr_hqx",
+    "pix_fmt": "yuv422p10le",
+    "bitrate": 185000000,
+    "thread_count": 0
+  },
+  "hevc_gpu": {
+    "encoder": "hevc_amf",
+    "usage": "transcoding",
+    "quality": "slow",
+    "profile": "main10",
+    "tier": "high",
+    "pix_fmt": "p010",
+    "rate_control": "abr",
+    "bitrate": "1500M",
+    "maxrate": "1500M",
+    "bufsize": "500M",
+    "gop": 1,
+    "forced_idr": 1,
+    "color_primaries": "bt709",
+    "color_trc": "bt709",
+    "colorspace": "bt709",
+    "qp_i": 0,
+    "qp_p": 0,
+    "qp_b": 0
+  }
+}
+```
+
+When present, the file is loaded each time an export starts and any specified
+values override the built‑in defaults.

--- a/include/Utils/EncodingConfig.h
+++ b/include/Utils/EncodingConfig.h
@@ -1,0 +1,14 @@
+#ifndef ENCODING_CONFIG_H
+#define ENCODING_CONFIG_H
+
+#include <nlohmann/json.hpp>
+
+struct EncodingConfig {
+    nlohmann::json prores;
+    nlohmann::json dnxhr;
+    nlohmann::json hevc_gpu;
+};
+
+EncodingConfig loadEncodingConfig();
+
+#endif // ENCODING_CONFIG_H

--- a/src/App/AppIO.cpp
+++ b/src/App/AppIO.cpp
@@ -7,6 +7,7 @@
 #include "Utils/DebugLog.h"
 #include "Utils/RawFrameBuffer.h"
 #include "Utils/OrientationUtils.h"
+#include "Utils/EncodingConfig.h"
 #include <motioncam/Decoder.hpp>
 #include <motioncam/RawData.hpp>
 
@@ -1280,7 +1281,10 @@ void App::exportCurrentClipToProRes() {
                 std::chrono::steady_clock::now() - allocStart).count();
         LogProRes("[ProResExport] Output context created in " + std::to_string(allocMs) + "ms");
 
-        const AVCodec* vcodec = avcodec_find_encoder_by_name("prores_ks");
+        EncodingConfig encCfg = loadEncodingConfig();
+        nlohmann::json pcfg = encCfg.prores;
+        std::string prCodec = pcfg.value("codec", "prores_ks");
+        const AVCodec* vcodec = avcodec_find_encoder_by_name(prCodec.c_str());
         if (!vcodec) {
             m_proResStatus.errorMsg = "ProRes encoder not found";
             m_proResStatus.active.store(false);
@@ -1299,16 +1303,24 @@ void App::exportCurrentClipToProRes() {
         AVCodecContext* vctx = avcodec_alloc_context3(vcodec);
         vctx->codec_id = vcodec->id;
         vctx->codec_type = AVMEDIA_TYPE_VIDEO;
-        vctx->pix_fmt = AV_PIX_FMT_YUV422P10LE;
+        {
+            std::string pix = pcfg.value("pix_fmt", "yuv422p10le");
+            AVPixelFormat pf = av_get_pix_fmt(pix.c_str());
+            vctx->pix_fmt = (pf == AV_PIX_FMT_NONE) ? AV_PIX_FMT_YUV422P10LE : pf;
+            char pd[64];
+            snprintf(pd, sizeof(pd), "[ProResExport] pix_fmt=%s", av_get_pix_fmt_name(vctx->pix_fmt));
+            LogProRes(pd);
+        }
         vctx->width = width;
         vctx->height = height;
         vctx->time_base = timeBase;
         vctx->framerate = av_inv_q(timeBase);
         unsigned threads = std::thread::hardware_concurrency();
         if (threads == 0) threads = 1;
-        int bitrate = (width == 1920) ? 185000000 : 90000000;
+        int bitrate = pcfg.contains("bitrate") ? pcfg["bitrate"].get<int>() : ((width == 1920) ? 185000000 : 90000000);
         vctx->bit_rate = bitrate;
-        vctx->thread_count = 0; // let FFmpeg decide based on HW
+        LogProRes(std::string("[ProResExport] Bitrate: ") + std::to_string(bitrate));
+        vctx->thread_count = pcfg.value("thread_count", 0);
         vctx->thread_type = FF_THREAD_FRAME;
         LogProRes(std::string("[ProResExport] Detected CPU threads: ") +
                   std::to_string(threads));
@@ -1316,8 +1328,11 @@ void App::exportCurrentClipToProRes() {
         if (fmt->oformat->flags & AVFMT_GLOBALHEADER)
             vctx->flags |= AV_CODEC_FLAG_GLOBAL_HEADER;
         AVDictionary* encOpts = nullptr;
-        av_dict_set(&encOpts, "slice_count", std::to_string(threads).c_str(), 0);
-        LogProRes(std::string("[ProResExport] Slice count: ") + std::to_string(threads));
+        int slices = pcfg.contains("slice_count") ? pcfg["slice_count"].get<int>() : static_cast<int>(threads);
+        av_dict_set(&encOpts, "slice_count", std::to_string(slices).c_str(), 0);
+        std::string prof = pcfg.value("profile", "");
+        if (!prof.empty()) av_dict_set(&encOpts, "profile", prof.c_str(), 0);
+        LogProRes(std::string("[ProResExport] Slice count: ") + std::to_string(slices));
         auto openVStart = std::chrono::steady_clock::now();
         if (avcodec_open2(vctx, vcodec, &encOpts) < 0) {
             m_proResStatus.errorMsg = "avcodec_open2 failed";
@@ -1805,6 +1820,8 @@ void App::exportCurrentClipToDNxHR() {
                 std::chrono::steady_clock::now() - allocStart).count();
         LogProRes("[DNxHRExport] Output context created in " + std::to_string(allocMs) + "ms");
 
+        EncodingConfig encCfg = loadEncodingConfig();
+        nlohmann::json dcfg = encCfg.dnxhr;
         const AVCodec* vcodec = avcodec_find_encoder_by_name("dnxhd");
         if (!vcodec) {
             m_dnxhrStatus.errorMsg = "DNxHR encoder not found";
@@ -1824,7 +1841,14 @@ void App::exportCurrentClipToDNxHR() {
         AVCodecContext* vctx = avcodec_alloc_context3(vcodec);
         vctx->codec_id = vcodec->id;
         vctx->codec_type = AVMEDIA_TYPE_VIDEO;
-        vctx->pix_fmt = AV_PIX_FMT_YUV422P10LE;
+        {
+            std::string pix = dcfg.value("pix_fmt", "yuv422p10le");
+            AVPixelFormat pf = av_get_pix_fmt(pix.c_str());
+            vctx->pix_fmt = (pf == AV_PIX_FMT_NONE) ? AV_PIX_FMT_YUV422P10LE : pf;
+            char pd[64];
+            snprintf(pd, sizeof(pd), "[DNxHRExport] pix_fmt=%s", av_get_pix_fmt_name(vctx->pix_fmt));
+            LogProRes(pd);
+        }
         vctx->bits_per_raw_sample = 10;
         vctx->profile = FF_PROFILE_DNXHR_HQX;
         vctx->width = width;
@@ -1833,9 +1857,9 @@ void App::exportCurrentClipToDNxHR() {
         vctx->framerate = av_inv_q(timeBase);
         unsigned threads = std::thread::hardware_concurrency();
         if (threads == 0) threads = 1;
-        vctx->thread_count = 0;
+        vctx->thread_count = dcfg.value("thread_count", 0);
         vctx->thread_type = FF_THREAD_FRAME;
-        int bitrate = (width == 1920) ? 185000000 : 90000000;
+        int bitrate = dcfg.contains("bitrate") ? dcfg["bitrate"].get<int>() : ((width == 1920) ? 185000000 : 90000000);
         vctx->bit_rate = bitrate;
         LogProRes(std::string("[DNxHRExport] Bitrate: ") + std::to_string(bitrate));
         LogProRes(std::string("[DNxHRExport] Detected CPU threads: ") + std::to_string(threads));
@@ -1843,7 +1867,8 @@ void App::exportCurrentClipToDNxHR() {
         if (fmt->oformat->flags & AVFMT_GLOBALHEADER)
             vctx->flags |= AV_CODEC_FLAG_GLOBAL_HEADER;
         AVDictionary* encOpts = nullptr;
-        av_dict_set(&encOpts, "profile", "dnxhr_hqx", 0);
+        std::string dprofile = dcfg.value("profile", "dnxhr_hqx");
+        av_dict_set(&encOpts, "profile", dprofile.c_str(), 0);
         auto openVStart = std::chrono::steady_clock::now();
         if (avcodec_open2(vctx, vcodec, &encOpts) < 0) {
             m_dnxhrStatus.errorMsg = "avcodec_open2 failed";
@@ -1863,7 +1888,8 @@ void App::exportCurrentClipToDNxHR() {
             vinfo << "[DNxHRExport] Video encoder settings: "
                   << avcodec_get_name(vctx->codec_id) << " "
                   << vctx->width << "x" << vctx->height
-                  << " pix_fmt=YUV422P10LE profile=HQX";
+                  << " pix_fmt=" << av_get_pix_fmt_name(vctx->pix_fmt)
+                  << " profile=" << dprofile;
             LogProRes(vinfo.str());
         }
         avcodec_parameters_from_context(vstream->codecpar, vctx);
@@ -2315,7 +2341,10 @@ void App::exportCurrentClipToHEVC_AMD() {
             return;
         }
 
-        const AVCodec* vcodec = avcodec_find_encoder_by_name("hevc_amf");
+        EncodingConfig encCfg = loadEncodingConfig();
+        nlohmann::json hcfg = encCfg.hevc_gpu;
+        std::string hevcEnc = hcfg.value("encoder", "hevc_amf");
+        const AVCodec* vcodec = avcodec_find_encoder_by_name(hevcEnc.c_str());
         if (!vcodec) {
             m_hevcStatus.errorMsg = "AMD hardware encoder not available. Aborting export.";
             m_hevcStatus.active.store(false);
@@ -2334,30 +2363,94 @@ void App::exportCurrentClipToHEVC_AMD() {
         AVCodecContext* vctx = avcodec_alloc_context3(vcodec);
         vctx->codec_id = vcodec->id;
         vctx->codec_type = AVMEDIA_TYPE_VIDEO;
-        vctx->pix_fmt = AV_PIX_FMT_P010;
+        {
+            std::string pix = hcfg.value("pix_fmt", "p010");
+            AVPixelFormat pf = av_get_pix_fmt(pix.c_str());
+            vctx->pix_fmt = (pf == AV_PIX_FMT_NONE) ? AV_PIX_FMT_P010 : pf;
+        }
         vctx->width = width;
         vctx->height = height;
         vctx->time_base = timeBase;
         vctx->framerate = av_inv_q(timeBase);
         if (fmt->oformat->flags & AVFMT_GLOBALHEADER)
             vctx->flags |= AV_CODEC_FLAG_GLOBAL_HEADER;
+        auto optStr = [&](const std::string& key, const std::string& def) {
+            if (hcfg.contains(key)) {
+                if (hcfg[key].is_number()) return std::to_string(hcfg[key].get<int>());
+                if (hcfg[key].is_string()) return hcfg[key].get<std::string>();
+            }
+            return def;
+        };
 
-        av_opt_set(vctx->priv_data, "usage", "transcoding", 0);
-        av_opt_set(vctx->priv_data, "quality", "slow", 0);
-        av_opt_set(vctx->priv_data, "profile", "main10", 0);
-        av_opt_set(vctx->priv_data, "tier", "high", 0);
-        av_opt_set(vctx->priv_data, "rc", "abr", 0);
-        av_opt_set(vctx->priv_data, "b", "1500M", 0);
-        av_opt_set(vctx->priv_data, "maxrate", "1500M", 0);
-        av_opt_set(vctx->priv_data, "bufsize", "500M", 0);
-        av_opt_set(vctx->priv_data, "g", "1", 0);
-        av_opt_set(vctx->priv_data, "forced-idr", "1", 0);
-        vctx->color_primaries = AVCOL_PRI_BT709;
-        vctx->color_trc = AVCOL_TRC_BT709;
-        vctx->colorspace = AVCOL_SPC_BT709;
-        LogHevc("[HEVCExport] color_primaries=bt709 color_trc=bt709 colorspace=bt709");
+        auto primFromStr = [&](const std::string& s){
+            if (s == "bt709") return AVCOL_PRI_BT709;
+            if (s == "bt2020") return AVCOL_PRI_BT2020;
+            return AVCOL_PRI_UNSPECIFIED;
+        };
+        auto trcFromStr = [&](const std::string& s){
+            if (s == "bt709") return AVCOL_TRC_BT709;
+            if (s == "smpte2084") return AVCOL_TRC_SMPTE2084;
+            return AVCOL_TRC_UNSPECIFIED;
+        };
+        auto cspFromStr = [&](const std::string& s){
+            if (s == "bt709") return AVCOL_SPC_BT709;
+            if (s == "bt2020_ncl") return AVCOL_SPC_BT2020_NCL;
+            return AVCOL_SPC_UNSPECIFIED;
+        };
 
-        LogHevc("[HEVCExport] usage=transcoding quality=slow profile=main10 tier=high rc=abr b=250M maxrate=250M bufsize=500M g=1 color=bt709");
+        av_opt_set(vctx->priv_data, "usage", optStr("usage", "transcoding").c_str(), 0);
+        av_opt_set(vctx->priv_data, "quality", optStr("quality", "slow").c_str(), 0);
+        av_opt_set(vctx->priv_data, "profile", optStr("profile", "main10").c_str(), 0);
+        av_opt_set(vctx->priv_data, "tier", optStr("tier", "high").c_str(), 0);
+        av_opt_set(vctx->priv_data, "rc", optStr("rate_control", "abr").c_str(), 0);
+        av_opt_set(vctx->priv_data, "b", optStr("bitrate", "1500M").c_str(), 0);
+        av_opt_set(vctx->priv_data, "maxrate", optStr("maxrate", "1500M").c_str(), 0);
+        av_opt_set(vctx->priv_data, "bufsize", optStr("bufsize", "500M").c_str(), 0);
+        av_opt_set(vctx->priv_data, "g", optStr("gop", "1").c_str(), 0);
+        av_opt_set(vctx->priv_data, "forced-idr", optStr("forced_idr", "1").c_str(), 0);
+        vctx->color_primaries = primFromStr(optStr("color_primaries", "bt709"));
+        vctx->color_trc = trcFromStr(optStr("color_trc", "bt709"));
+        vctx->colorspace = cspFromStr(optStr("colorspace", "bt709"));
+        int qp_i = hcfg.value("qp_i", 0);
+        int qp_p = hcfg.value("qp_p", 0);
+        int qp_b = hcfg.value("qp_b", 0);
+        if (qp_i) av_opt_set_int(vctx->priv_data, "qp_i", qp_i, 0);
+        if (qp_p) av_opt_set_int(vctx->priv_data, "qp_p", qp_p, 0);
+        if (qp_b) av_opt_set_int(vctx->priv_data, "qp_b", qp_b, 0);
+        auto primName = [&](int val){
+            switch(val){
+                case AVCOL_PRI_BT709: return "bt709";
+                case AVCOL_PRI_BT2020: return "bt2020";
+                default: return "unspecified";
+            }
+        };
+        auto trcName = [&](int val){
+            switch(val){
+                case AVCOL_TRC_BT709: return "bt709";
+                case AVCOL_TRC_SMPTE2084: return "smpte2084";
+                default: return "unspecified";
+            }
+        };
+        auto cspName = [&](int val){
+            switch(val){
+                case AVCOL_SPC_BT709: return "bt709";
+                case AVCOL_SPC_BT2020_NCL: return "bt2020_ncl";
+                default: return "unspecified";
+            }
+        };
+        LogHevc(std::string("[HEVCExport] color_primaries=") + primName(vctx->color_primaries) +
+                " color_trc=" + trcName(vctx->color_trc) +
+                " colorspace=" + cspName(vctx->colorspace));
+
+        LogHevc("[HEVCExport] usage=" + optStr("usage", "transcoding") +
+                " quality=" + optStr("quality", "slow") +
+                " profile=" + optStr("profile", "main10") +
+                " tier=" + optStr("tier", "high") +
+                " rc=" + optStr("rate_control", "abr") +
+                " b=" + optStr("bitrate", "1500M") +
+                " maxrate=" + optStr("maxrate", "1500M") +
+                " bufsize=" + optStr("bufsize", "500M") +
+                " g=" + optStr("gop", "1"));
         char pixDesc[64];
         snprintf(pixDesc, sizeof(pixDesc), "[HEVCExport] pix_fmt=%s", av_get_pix_fmt_name(vctx->pix_fmt));
         LogHevc(pixDesc);

--- a/src/Utils/EncodingConfig.cpp
+++ b/src/Utils/EncodingConfig.cpp
@@ -1,0 +1,29 @@
+#include "Utils/EncodingConfig.h"
+#include "Utils/DebugLog.h"
+#include <filesystem>
+#include <fstream>
+
+extern std::string g_AppBasePath;
+
+EncodingConfig loadEncodingConfig() {
+    EncodingConfig cfg;
+    namespace fs = std::filesystem;
+    fs::path base = g_AppBasePath.empty() ? fs::current_path() : fs::path(g_AppBasePath);
+    fs::path path = base / "encoding_config.json";
+    if (!fs::exists(path)) {
+        LogToFile("[EncodingConfig] File not found: " + path.string());
+        return cfg;
+    }
+    try {
+        std::ifstream f(path);
+        nlohmann::json j;
+        f >> j;
+        cfg.prores = j.value("prores", nlohmann::json{});
+        cfg.dnxhr = j.value("dnxhr", nlohmann::json{});
+        cfg.hevc_gpu = j.value("hevc_gpu", nlohmann::json{});
+        LogToFile("[EncodingConfig] Loaded config from " + path.string());
+    } catch (const std::exception& e) {
+        LogToFile(std::string("[EncodingConfig] Failed to parse ") + path.string() + ": " + e.what());
+    }
+    return cfg;
+}


### PR DESCRIPTION
## Summary
- load optional encoding_config.json at export time
- expose ProRes/DNxHR/HEVC encoder settings from JSON
- document new configuration file in README

## Testing
- `cmake ..`
- `cmake --build .` *(fails: libavutil/frame.h: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_6876321f494083278c87bacaa7040fb8