### PR TITLE
Add MotionCam Batcher interface

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -167,6 +167,9 @@ set(APP_SOURCES
   src/Gui/GuiUtils.cpp
   src/Gui/GuiStyles.cpp
 
+  src/Gui/BatcherGui.cpp
+  src/App/BatchProcessing.cpp
+
   src/Playback/PlaybackController.cpp
 
   src/Utils/DebugLog.cpp
@@ -193,6 +196,84 @@ target_sources(${PROJECT_NAME} PRIVATE ${APP_SOURCES})
 if(WIN32 AND EXISTS "${APP_ROOT_DIR}/icon.rc")
     target_sources(${PROJECT_NAME} PRIVATE "${APP_ROOT_DIR}/icon.rc")
     message(STATUS "Added Windows icon resource: ${APP_ROOT_DIR}/icon.rc")
+endif()
+
+add_executable(MotionCam_Batcher WIN32 "")
+target_sources(MotionCam_Batcher PRIVATE ${APP_SOURCES})
+if(WIN32 AND EXISTS "${APP_ROOT_DIR}/icon.rc")
+    target_sources(MotionCam_Batcher PRIVATE "${APP_ROOT_DIR}/icon.rc")
+endif()
+add_dependencies(MotionCam_Batcher CompileShaders glm motioncam_decoder imgui)
+target_compile_definitions(MotionCam_Batcher PRIVATE SDL_MAIN_HANDLED GLFW_INCLUDE_NONE MOTIONCAM_BATCHER)
+if(HAVE_FFMPEG)
+    target_compile_definitions(MotionCam_Batcher PRIVATE ENABLE_PRORES_EXPORT)
+endif()
+if(MSVC AND CMAKE_SYSTEM_NAME STREQUAL "Windows")
+    set_target_properties(MotionCam_Batcher PROPERTIES LINK_FLAGS "/ENTRY:mainCRTStartup")
+endif()
+target_include_directories(MotionCam_Batcher PRIVATE
+  "${PROJECT_SOURCE_DIR}/include"
+  "${PROJECT_SOURCE_DIR}/include/App"
+  "${PROJECT_SOURCE_DIR}/include/Audio"
+  "${PROJECT_SOURCE_DIR}/include/Decoder"
+  "${PROJECT_SOURCE_DIR}/include/Graphics"
+  "${PROJECT_SOURCE_DIR}/include/Gui"
+  "${PROJECT_SOURCE_DIR}/include/Playback"
+  "${PROJECT_SOURCE_DIR}/include/Utils"
+
+  "${VMA_INCLUDE_DIR}"
+  "${Vulkan_INCLUDE_DIRS}"
+  "${GLFW_PATH}/include"
+  "${SDL2_PATH}/include"
+
+  "${APP_ROOT_DIR}/motioncam-decoder/lib/include"
+  "${APP_ROOT_DIR}/motioncam-decoder/thirdparty"
+
+  "${IMGUI_SOURCE_DIR}"
+  "${IMGUI_SOURCE_DIR}/backends"
+  "${APP_EXTERNAL_DIR}/tinydngwriter"
+)
+target_link_libraries(MotionCam_Batcher PRIVATE
+    motioncam_decoder
+    imgui
+    glm
+    "${GLFW_LIB_PATH_VC_SPECIFIC}"
+    "${SDL2_LIBRARY_DIR}/SDL2.lib"
+    ${Vulkan_LIBRARIES}
+)
+target_include_directories(MotionCam_Batcher PRIVATE ${FFMPEG_INCLUDE_DIR})
+target_link_directories(MotionCam_Batcher PRIVATE ${FFMPEG_LIBRARY_DIR})
+target_link_libraries(MotionCam_Batcher PRIVATE
+    avcodec.lib
+    avformat.lib
+    avutil.lib
+    swscale.lib
+    swresample.lib
+)
+if(WIN32)
+    target_link_libraries(MotionCam_Batcher PRIVATE Shlwapi.lib Comdlg32.lib dwmapi.lib Shell32.lib)
+endif()
+if(CMAKE_CXX_COMPILER_ID MATCHES "GNU|Clang|AppleClang")
+    target_link_libraries(MotionCam_Batcher PRIVATE Threads::Threads)
+elseif(MSVC)
+endif()
+set_target_properties(MotionCam_Batcher PROPERTIES
+    RUNTIME_OUTPUT_DIRECTORY "${CMAKE_RUNTIME_OUTPUT_DIRECTORY}"
+    OUTPUT_NAME "motioncam_batcher"
+)
+add_custom_command(TARGET MotionCam_Batcher POST_BUILD
+    COMMAND ${CMAKE_COMMAND} -E copy_directory
+        "${SHADER_COMPILED_DIR}"
+        "$<TARGET_FILE_DIR:MotionCam_Batcher>/shaders_spv"
+    VERBATIM
+)
+if(EXISTS "${APP_ASSETS_DIR}")
+    add_custom_command(TARGET MotionCam_Batcher POST_BUILD
+        COMMAND ${CMAKE_COMMAND} -E copy_directory
+            "${APP_ASSETS_DIR}"
+            "$<TARGET_FILE_DIR:MotionCam_Batcher>/assets"
+        VERBATIM
+    )
 endif()
 
 add_dependencies(${PROJECT_NAME} CompileShaders glm motioncam_decoder imgui)

--- a/include/App/App.h
+++ b/include/App/App.h
@@ -40,6 +40,9 @@ class DecoderWrapper;
 class Renderer_VK;
 
 #include "Gui/GuiOverlay.h"
+#ifdef MOTIONCAM_BATCHER
+#include "Gui/BatcherGui.h"
+#endif
 #include "Utils/ThreadSafeQueue.h"
 #include "Decoder/DecoderTypes.h"
 
@@ -56,6 +59,12 @@ public:
     friend GuiOverlay::UIData GuiOverlay::gatherData(App* appInstance);
     friend void GuiOverlay::render(App* appInstance);
     friend void GuiOverlay::setup(GLFWwindow* window, App* appInstance);
+#ifdef MOTIONCAM_BATCHER
+    friend void BatcherGui::render(App* appInstance);
+    friend void BatcherGui::setup(GLFWwindow* window, App* appInstance);
+    friend void BatcherGui::beginFrame();
+    friend void BatcherGui::endFrame(VkCommandBuffer commandBuffer);
+#endif
 
     GLFWwindow* m_window = nullptr;
     VkInstance m_vkInstance = VK_NULL_HANDLE;
@@ -111,12 +120,12 @@ public:
     void toggleHelpPage() { m_showHelpPage = !m_showHelpPage; }
     void saveCurrentFrameAsDng();
     void convertCurrentFileToDngs();
-    void exportCurrentClipToProRes();
-    void convertCurrentClipToProRes();
-    void exportCurrentClipToDNxHR();
-    void convertCurrentClipToDNxHR();
-    void exportCurrentClipToHEVC_AMD();
-    void convertCurrentClipToHEVC_AMD();
+    void exportCurrentClipToProRes(const std::string& outputPath = "");
+    void convertCurrentClipToProRes(const std::string& outputPath = "");
+    void exportCurrentClipToDNxHR(const std::string& outputPath = "");
+    void convertCurrentClipToDNxHR(const std::string& outputPath = "");
+    void exportCurrentClipToHEVC_AMD(const std::string& outputPath = "");
+    void convertCurrentClipToHEVC_AMD(const std::string& outputPath = "");
     void performSeek(size_t new_frame_index);
     void triggerOpenFileViaDialog();
 	void setPlaybackMode(PlaybackController::PlaybackMode mode);
@@ -250,6 +259,16 @@ private:
     } m_hevcStatus;
     std::atomic<bool> m_showHevcExportProgressPopup{ false };
     std::thread m_hevcThread;
+#endif
+
+#ifdef MOTIONCAM_BATCHER
+    std::vector<std::string> m_batchFileQueue;
+    std::vector<std::string> m_conversionLog;
+    std::string m_outputFolder;
+    int m_selectedFormat = 0; // 0=ProRes 1=DNxHR 2=HEVC
+    bool m_batchActive = false;
+    std::thread m_batchThread;
+    void startBatchConversion();
 #endif
 
 

--- a/include/Gui/BatcherGui.h
+++ b/include/Gui/BatcherGui.h
@@ -1,0 +1,16 @@
+#ifndef BATCHER_GUI_H
+#define BATCHER_GUI_H
+
+#include <vulkan/vulkan.h>
+struct GLFWwindow;
+class App;
+
+namespace BatcherGui {
+    void setup(GLFWwindow* window, App* appInstance);
+    void cleanup();
+    void beginFrame();
+    void render(App* appInstance);
+    void endFrame(VkCommandBuffer commandBuffer);
+}
+
+#endif // BATCHER_GUI_H

--- a/src/App/AppCleanup.cpp
+++ b/src/App/AppCleanup.cpp
@@ -5,7 +5,11 @@
 #include "Playback/PlaybackController.h"
 #include "Graphics/Renderer_VK.h"
 #include "Utils/DebugLog.h"
+#ifdef MOTIONCAM_BATCHER
+#include "Gui/BatcherGui.h"
+#else
 #include "Gui/GuiOverlay.h"
+#endif
 
 #include <iostream>
 #include <stdexcept>
@@ -207,8 +211,12 @@ void App::cleanupVulkan() {
         m_rendererVk.reset();
     }
 
-    LogToFile("[App::cleanupVulkan] Cleaning up GuiOverlay (ImGui shutdown)...");
+    LogToFile("[App::cleanupVulkan] Cleaning up GUI (ImGui shutdown)...");
+#ifdef MOTIONCAM_BATCHER
+    BatcherGui::cleanup();
+#else
     GuiOverlay::cleanup();
+#endif
 
     if (m_imguiDescriptorPool != VK_NULL_HANDLE) {
         LogToFile("[App::cleanupVulkan] Destroying ImGui descriptor pool...");

--- a/src/App/AppIO.cpp
+++ b/src/App/AppIO.cpp
@@ -1186,14 +1186,16 @@ void App::sendAllPlaylistFilesToMotionCamFS()
 }
 
 #ifdef ENABLE_PRORES_EXPORT
-void App::exportCurrentClipToProRes() {
+void App::exportCurrentClipToProRes(const std::string& outputOverride) {
     if (m_proResStatus.active.load()) {
         showActionMessage("Export already running");
         return;
     }
-
-    std::string outputPath = openSaveMovDialog();
-    if (outputPath.empty()) return;
+    std::string outputPath = outputOverride;
+    if (outputPath.empty()) {
+        outputPath = openSaveMovDialog();
+        if (outputPath.empty()) return;
+    }
     if (outputPath.size() < 4 || outputPath.substr(outputPath.size() - 4) != ".mov") {
         outputPath += ".mov";
     }
@@ -1711,30 +1713,32 @@ void App::exportCurrentClipToProRes() {
     });
 }
 #else
-void App::exportCurrentClipToProRes() {
+void App::exportCurrentClipToProRes(const std::string&) {
     showActionMessage("FFmpeg support not built");
 }
 #endif
 
-void App::convertCurrentClipToProRes() {
+void App::convertCurrentClipToProRes(const std::string& outPath) {
 #ifdef ENABLE_PRORES_EXPORT
     LogProRes("[App] convertCurrentClipToProRes invoked");
     g_useGpuProRes = true;
-    exportCurrentClipToProRes();
+    exportCurrentClipToProRes(outPath);
 #else
     showActionMessage("FFmpeg support not built");
 #endif
 }
 
 #ifdef ENABLE_PRORES_EXPORT
-void App::exportCurrentClipToDNxHR() {
+void App::exportCurrentClipToDNxHR(const std::string& outputOverride) {
     if (m_dnxhrStatus.active.load()) {
         showActionMessage("Export already running");
         return;
     }
-
-    std::string outputPath = openSaveMovDialog();
-    if (outputPath.empty()) return;
+    std::string outputPath = outputOverride;
+    if (outputPath.empty()) {
+        outputPath = openSaveMovDialog();
+        if (outputPath.empty()) return;
+    }
     if (outputPath.size() < 4 || outputPath.substr(outputPath.size() - 4) != ".mov") {
         outputPath += ".mov";
     }
@@ -2245,30 +2249,32 @@ void App::exportCurrentClipToDNxHR() {
     });
 }
 #else
-void App::exportCurrentClipToDNxHR() {
+void App::exportCurrentClipToDNxHR(const std::string&) {
     showActionMessage("FFmpeg support not built");
 }
 #endif
 
-void App::convertCurrentClipToDNxHR() {
+void App::convertCurrentClipToDNxHR(const std::string& outPath) {
 #ifdef ENABLE_PRORES_EXPORT
     LogProRes("[App] convertCurrentClipToDNxHR invoked");
     g_useGpuDNxHR = true;
-    exportCurrentClipToDNxHR();
+    exportCurrentClipToDNxHR(outPath);
 #else
     showActionMessage("FFmpeg support not built");
 #endif
 }
 
 #ifdef ENABLE_PRORES_EXPORT
-void App::exportCurrentClipToHEVC_AMD() {
+void App::exportCurrentClipToHEVC_AMD(const std::string& outputOverride) {
     if (m_hevcStatus.active.load()) {
         showActionMessage("Export already running");
         return;
     }
-
-    std::string outputPath = openSaveMp4Dialog();
-    if (outputPath.empty()) return;
+    std::string outputPath = outputOverride;
+    if (outputPath.empty()) {
+        outputPath = openSaveMp4Dialog();
+        if (outputPath.empty()) return;
+    }
     if (outputPath.size() < 4 || outputPath.substr(outputPath.size() - 4) != ".mp4") {
         outputPath += ".mp4";
     }
@@ -2687,16 +2693,16 @@ void App::exportCurrentClipToHEVC_AMD() {
     });
 }
 #else
-void App::exportCurrentClipToHEVC_AMD() {
+void App::exportCurrentClipToHEVC_AMD(const std::string&) {
     showActionMessage("FFmpeg support not built");
 }
 #endif
 
-void App::convertCurrentClipToHEVC_AMD() {
+void App::convertCurrentClipToHEVC_AMD(const std::string& outPath) {
 #ifdef ENABLE_PRORES_EXPORT
     LogHevc("[App] convertCurrentClipToHEVC_AMD invoked");
     g_useGpuHevc = true;
-    exportCurrentClipToHEVC_AMD();
+    exportCurrentClipToHEVC_AMD(outPath);
 #else
     showActionMessage("FFmpeg support not built");
 #endif

--- a/src/App/AppInit.cpp
+++ b/src/App/AppInit.cpp
@@ -19,6 +19,12 @@
 #include "Decoder/DecoderWrapper.h"
 #include <motioncam/Decoder.hpp>
 
+#ifdef MOTIONCAM_BATCHER
+#include "Gui/BatcherGui.h"
+#else
+#include "Gui/GuiOverlay.h"
+#endif
+
 #include "Playback/PlaybackController.h"
 #include "Graphics/Renderer_VK.h"
 #include "Utils/DebugLog.h"
@@ -865,8 +871,13 @@ void App::initImGuiVulkan() {
     VK_APP_CHECK(vkCreateDescriptorPool(m_device, &pool_info, nullptr, &m_imguiDescriptorPool));
     LogToFile("App::initImGuiVulkan ImGui descriptor pool created.");
 
+#ifdef MOTIONCAM_BATCHER
+    BatcherGui::setup(m_window, this);
+    LogToFile("App::initImGuiVulkan BatcherGui::setup() called.");
+#else
     GuiOverlay::setup(m_window, this);
     LogToFile("App::initImGuiVulkan GuiOverlay::setup() called.");
+#endif
 }
 
 void App::createPersistentStagingBuffers() {

--- a/src/App/AppLoop.cpp
+++ b/src/App/AppLoop.cpp
@@ -5,7 +5,11 @@
 #include "Playback/PlaybackController.h"
 #include "Graphics/Renderer_VK.h"
 #include "Utils/DebugLog.h"
+#ifdef MOTIONCAM_BATCHER
+#include "Gui/BatcherGui.h"
+#else
 #include "Gui/GuiOverlay.h"
+#endif
 
 #include <chrono>
 #include <thread>
@@ -448,9 +452,15 @@ void App::drawFrame() {
     }
 
     if (m_uiOpacity > 0.0f) {
+#ifdef MOTIONCAM_BATCHER
+        BatcherGui::beginFrame();
+        BatcherGui::render(this);
+        BatcherGui::endFrame(cmd);
+#else
         GuiOverlay::beginFrame();
         GuiOverlay::render(this);
         GuiOverlay::endFrame(cmd);
+#endif
     }
     vkCmdEndRenderPass(cmd);
 

--- a/src/App/BatchProcessing.cpp
+++ b/src/App/BatchProcessing.cpp
@@ -1,0 +1,52 @@
+#include "App/App.h"
+#include <filesystem>
+#include <thread>
+#include <chrono>
+
+namespace fs = std::filesystem;
+
+void App::startBatchConversion() {
+#ifdef MOTIONCAM_BATCHER
+    if (m_batchActive) return;
+    m_batchActive = true;
+    if (m_batchThread.joinable()) m_batchThread.join();
+    m_batchThread = std::thread([this]() {
+        for (const auto& file : m_batchFileQueue) {
+            fs::path inPath(file);
+            m_conversionLog.push_back("Converting " + inPath.filename().string() + "...");
+            m_fileList.clear();
+            m_fileList.push_back(file);
+            loadFileAtIndex(0);
+            fs::path outDir = m_outputFolder.empty() ? inPath.parent_path() : fs::path(m_outputFolder);
+            fs::create_directories(outDir);
+            std::string outPath;
+            if (m_selectedFormat == 0) {
+                outPath = (outDir / (inPath.stem().string() + ".mov")).string();
+                convertCurrentClipToProRes(outPath);
+                while (m_proResStatus.active.load()) std::this_thread::sleep_for(std::chrono::milliseconds(200));
+                if (m_proResStatus.errorMsg.empty())
+                    m_conversionLog.push_back("Export complete: ProRes");
+                else
+                    m_conversionLog.push_back(std::string("Error: ") + m_proResStatus.errorMsg);
+            } else if (m_selectedFormat == 1) {
+                outPath = (outDir / (inPath.stem().string() + ".mov")).string();
+                convertCurrentClipToDNxHR(outPath);
+                while (m_dnxhrStatus.active.load()) std::this_thread::sleep_for(std::chrono::milliseconds(200));
+                if (m_dnxhrStatus.errorMsg.empty())
+                    m_conversionLog.push_back("Export complete: DNxHR");
+                else
+                    m_conversionLog.push_back(std::string("Error: ") + m_dnxhrStatus.errorMsg);
+            } else {
+                outPath = (outDir / (inPath.stem().string() + ".mp4")).string();
+                convertCurrentClipToHEVC_AMD(outPath);
+                while (m_hevcStatus.active.load()) std::this_thread::sleep_for(std::chrono::milliseconds(200));
+                if (m_hevcStatus.errorMsg.empty())
+                    m_conversionLog.push_back("Export complete: HEVC");
+                else
+                    m_conversionLog.push_back(std::string("Error: ") + m_hevcStatus.errorMsg);
+            }
+        }
+        m_batchActive = false;
+    });
+#endif
+}

--- a/src/Gui/BatcherGui.cpp
+++ b/src/Gui/BatcherGui.cpp
@@ -1,0 +1,84 @@
+#include "Gui/BatcherGui.h"
+#include "Gui/GuiOverlay.h"
+#include "Gui/GuiStyles.h"
+#include "App/App.h"
+
+#include <imgui.h>
+#include <imgui_impl_glfw.h>
+#include <imgui_impl_vulkan.h>
+#include <filesystem>
+
+namespace fs = std::filesystem;
+
+namespace BatcherGui {
+
+static int selectedIndex = -1;
+
+void setup(GLFWwindow* window, App* appInstance) {
+    GuiOverlay::setup(window, appInstance);
+}
+
+void cleanup() { GuiOverlay::cleanup(); }
+void beginFrame() { GuiOverlay::beginFrame(); }
+void endFrame(VkCommandBuffer cmd) { GuiOverlay::endFrame(cmd); }
+
+void render(App* app) {
+    ImGui::Begin("Batch Export", nullptr, ImGuiWindowFlags_NoCollapse);
+
+    // File queue panel
+    ImGui::Text("Files:");
+    ImGui::BeginChild("file_list", ImVec2(0,150), true);
+    for(size_t i=0;i<app->m_batchFileQueue.size();++i){
+        std::string name = fs::path(app->m_batchFileQueue[i]).filename().string();
+        if(ImGui::Selectable(name.c_str(), selectedIndex==static_cast<int>(i)))
+            selectedIndex = static_cast<int>(i);
+    }
+    ImGui::EndChild();
+    if(ImGui::Button("Add")){
+        std::string p = app->openMcrawDialog();
+        if(!p.empty()) app->m_batchFileQueue.push_back(p);
+    }
+    ImGui::SameLine();
+    if(ImGui::Button("Remove") && selectedIndex>=0 && selectedIndex < (int)app->m_batchFileQueue.size()){
+        app->m_batchFileQueue.erase(app->m_batchFileQueue.begin()+selectedIndex);
+        if(selectedIndex >= (int)app->m_batchFileQueue.size()) selectedIndex = (int)app->m_batchFileQueue.size()-1;
+    }
+    ImGui::SameLine();
+    if(ImGui::Button("Clear")){
+        app->m_batchFileQueue.clear();
+        selectedIndex = -1;
+    }
+
+    ImGui::Separator();
+
+    // Render format
+    ImGui::Text("Render Format:");
+    ImGui::RadioButton("ProRes", &app->m_selectedFormat, 0); ImGui::SameLine();
+    ImGui::RadioButton("DNxHR", &app->m_selectedFormat, 1); ImGui::SameLine();
+    ImGui::RadioButton("HEVC (GPU)", &app->m_selectedFormat, 2);
+
+    // Output folder
+    char buf[512];
+    strncpy(buf, app->m_outputFolder.c_str(), sizeof(buf));
+    if(ImGui::InputText("Output Folder", buf, sizeof(buf))) {
+        app->m_outputFolder = buf;
+    }
+
+    if(ImGui::Button("Convert All") && !app->m_batchActive){
+        app->startBatchConversion();
+    }
+
+    ImGui::End();
+
+    ImGui::Begin("Conversion Log", nullptr, ImGuiWindowFlags_NoCollapse);
+    for(const auto& line : app->m_conversionLog){
+        ImGui::TextUnformatted(line.c_str());
+    }
+    ImGui::End();
+
+    ImGui::SetCursorPosY(ImGui::GetIO().DisplaySize.y - 40);
+    ImGui::TextUnformatted("MotionCam Batcher v0.36.0 — RAW VIDEO CONVERTER");
+    ImGui::TextUnformatted("www.motioncamapp.com");
+}
+
+} // namespace BatcherGui


### PR DESCRIPTION
## Summary
- add Batcher GUI for batch conversion workflow
- implement batch processing logic in `App`
- expose output path parameters for export helpers
- integrate Batcher GUI through compile-time flag and new CMake target

## Testing
- `cmake -S . -B build`
- `cmake --build build --target MotionCam_Batcher --config Release -j $(nproc)` *(fails: libavutil/frame.h not found)*

------
https://chatgpt.com/codex/tasks/task_e_6877c357c88c83278b5e10c2d105d345