### PR TITLE
Add spec for MotionCam Batcher enhancements

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,3 +92,5 @@ runtime DLLs will be copied automatically.
 - BT.709 color metadata is written so DaVinci Resolve interprets the clip correctly.
 - If the AMD encoder is unavailable the export aborts and logs to `hevc_export_log.txt`.
 - The log file lists these settings so you can verify the parameters used.
+
+See `docs/Batcher_Enhancement_Spec.md` for proposed improvements to the MotionCam Batcher add-on.

--- a/docs/Batcher_Enhancement_Spec.md
+++ b/docs/Batcher_Enhancement_Spec.md
@@ -1,0 +1,92 @@
+# MotionCam Batcher Enhancement Specification
+
+This document describes proposed improvements to the **MotionCam Batcher** add‑on. The goal is to achieve feature parity with the export options available in MotionCam Player and to improve overall usability.
+
+## 1. Encoding Options (CPU & GPU)
+
+### Requirements
+- Mirror all export modes from the player:
+  - **ProRes** – support both CPU and GPU processing.
+  - **DNxHR** – support both CPU and GPU processing.
+  - **HEVC** – GPU encoding, with AMD, Intel and Nvidia variants.
+- Allow selecting the desired encoder per job so a batch can mix CPU and GPU tasks.
+- Provide radio buttons or a dropdown in the batcher UI for choosing the mode.
+
+### Implementation Notes
+- The existing batch export uses `App::startBatchConversion` with an `ExportFormat` enum that currently exposes `PRORES`, `DNXHR` and `HEVC`.
+- Extend the enum with explicit CPU/GPU variants:
+  ```cpp
+  enum class ExportFormat {
+      PRORES_CPU,
+      PRORES_GPU,
+      DNXHR_CPU,
+      DNXHR_GPU,
+      HEVC_AMD,
+      HEVC_INTEL,
+      HEVC_NVIDIA
+  };
+  ```
+- Update `startBatchConversion` and the GUI code in `GuiRender.cpp` to handle the new values.
+- Use the existing `convertCurrentClipToProRes` and `convertCurrentClipToDNxHR` helpers when GPU conversion is requested. CPU paths use `exportCurrentClipToProRes` and `exportCurrentClipToDNxHR`.
+- For HEVC variants, map the selection to the appropriate encoder name in `encoding_config.json` (`hevc_gpu.encoder`).
+
+## 2. Clip Preview Window
+
+### Requirements
+- Selecting a clip in the batch list should open a resizable preview pane.
+- Controls: **Play**, **Pause**, **Stop**, a seek bar with frame skip buttons, and a display of current time vs total duration.
+- The pane should be dockable or float above the main window.
+
+### Implementation Notes
+- Reuse the existing playback components (`PlaybackController`, `App::performSeek`) to display the clip.
+- Add a new ImGui window (e.g. `BatchPreview`) which becomes visible when `m_selectedBatchIndex >= 0`.
+- Draw playback controls using ImGui buttons and slider. Use `PlaybackController` to update frames while playing.
+
+## 3. Custom Log File Naming
+
+### Requirements
+- Each batch run writes a log file named `batcher_YYYYMMDD_HHMMSS.log`.
+- Logs are placed under `logs/batcher` and never overwrite MotionCam Player logs.
+- Include the start/end time and status per job plus a summary section.
+
+### Implementation Notes
+- On batch start, generate the timestamped filename using `std::chrono` and `std::put_time`.
+- Append log lines in `App::m_batchLog` to this file in addition to the on‑screen panel.
+- Create the `logs/batcher` folder if it does not exist.
+- After `startBatchConversion` finishes, write totals for succeeded/failed jobs and the elapsed time.
+
+## 4. Usability Improvements
+
+### Drag & Drop
+- Allow dragging `.mcraw` files or folders onto the file list. Use GLFW drop callbacks to collect paths and append them to `m_fileList`.
+- When a folder is dropped, recursively add all `.mcraw` clips.
+
+### Batch Presets
+- Introduce a small JSON file storing common export settings (format, output folder, concurrency limits).
+- Provide **Save Preset** and **Load Preset** buttons next to the export options.
+
+### Progress Indicators
+- Display a progress bar for the current job and an overall bar for the entire batch.
+- Estimate ETA based on the average time per completed job.
+
+### Error Handling
+- Detect when an export function reports an error (non‑empty `errorMsg`) and mark that job in red in the log panel.
+- Continue processing remaining items.
+
+### Output Folder Browser
+- Add a **Browse…** button that opens the system directory chooser to fill `m_outputFolder`.
+
+### Multi‑Threading / Queue Control
+- Expose numeric inputs for **Max CPU encodes** and **Max GPU encodes**.
+- Manage separate queues so at most the configured number of threads are active for each type.
+
+### Notifications
+- Optionally show a desktop notification when the batch completes or when any job fails. This can be toggled via a checkbox in the UI.
+
+## 5. File Locations
+- GUI updates take place in `src/Gui/GuiRender.cpp` starting around line 190 where the batcher UI is defined.
+- Batch processing logic is in `src/App/AppIO.cpp` around `startBatchConversion` (line ~2760).
+- Header adjustments go into `include/App/App.h` where the enum and member variables are declared.
+
+## 6. Summary
+These enhancements bring the batcher closer to the functionality of the main MotionCam Player while improving the user experience with previews, better logging and progress tracking. The updated design also enables mixing CPU and GPU tasks in one batch and prepares the application for future encoder additions.

--- a/include/App/App.h
+++ b/include/App/App.h
@@ -125,13 +125,22 @@ public:
     void showActionMessage(const std::string& msg);
 
 #ifdef MOTIONCAM_BATCHER
-    enum class ExportFormat { PRORES, DNXHR, HEVC };
-    void startBatchConversion(ExportFormat fmt, const std::string& outputDir);
+    enum class ExportFormat {
+        PRORES_CPU,
+        PRORES_GPU,
+        DNXHR_CPU,
+        DNXHR_GPU,
+        HEVC_CPU,
+        HEVC_GPU
+    };
+    void startBatchConversion();
     std::vector<std::string> m_batchLog;
     std::atomic<bool> m_batchActive{ false };
     std::thread m_batchThread;
     int m_selectedBatchIndex = -1;
     char m_outputFolder[1024] = "";
+    std::vector<ExportFormat> m_fileExportFormats;
+    bool m_previewOpen = true;
 #endif
 
     std::vector<VkImage> m_swapChainImages;
@@ -307,6 +316,7 @@ private:
     std::string openSaveMovDialog();
     std::string openSaveMxfDialog();
     std::string openSaveMp4Dialog();
+    std::string openFolderDialog();
 
     struct SwapChainSupportDetails {
         VkSurfaceCapabilitiesKHR capabilities;

--- a/src/App/AppIO.cpp
+++ b/src/App/AppIO.cpp
@@ -837,6 +837,7 @@ void App::softDeleteCurrentFile() {
         }
 
         m_fileList.clear();
+        m_fileExportFormats.clear();
         fs::path anchorPathFs = fs::absolute(originalAnchorFilePath);
         fs::path parent_folder_of_anchor = anchorPathFs.parent_path();
         if (!fs::exists(parent_folder_of_anchor)) {
@@ -848,6 +849,7 @@ void App::softDeleteCurrentFile() {
         for (const auto& entry : fs::directory_iterator(parent_folder_of_anchor)) {
             if (entry.is_regular_file() && entry.path().extension() == ".mcraw") {
                 m_fileList.push_back(entry.path().string());
+                m_fileExportFormats.push_back(ExportFormat::PRORES_CPU);
             }
         }
         std::sort(m_fileList.begin(), m_fileList.end());
@@ -2757,22 +2759,42 @@ void App::loadFileForExport(const std::string& path) {
 }
 
 #ifdef MOTIONCAM_BATCHER
-void App::startBatchConversion(ExportFormat fmt, const std::string& outputDir) {
+void App::startBatchConversion() {
     if (m_batchActive.load()) return;
     m_batchActive.store(true);
     m_batchLog.clear();
-    m_batchThread = std::thread([this, fmt, outputDir]() {
+    // open log file with timestamp
+    namespace fs = std::filesystem;
+    auto now = std::chrono::system_clock::now();
+    std::time_t t = std::chrono::system_clock::to_time_t(now);
+    std::tm tm{};
+#ifdef _WIN32
+    localtime_s(&tm, &t);
+#else
+    localtime_r(&t, &tm);
+#endif
+    char ts[32];
+    std::strftime(ts, sizeof(ts), "%Y%m%d_%H%M%S", &tm);
+    fs::path logDir = fs::path(getLogDirectory()) / "batcher";
+    std::error_code ec;
+    fs::create_directories(logDir, ec);
+    fs::path logPath = logDir / (std::string("batcher_") + ts + ".log");
+    std::ofstream logFile(logPath.string());
+    m_batchThread = std::thread([this, logFile = std::move(logFile)]() mutable {
         namespace fs = std::filesystem;
         for (size_t i = 0; i < m_fileList.size(); ++i) {
             if (m_window && glfwWindowShouldClose(m_window)) break;
             const std::string& path = m_fileList[i];
             m_batchLog.push_back(std::string("Converting ") + fs::path(path).filename().string() + "...");
+            if (logFile.is_open()) logFile << "[start] " << fs::path(path).filename().string() << std::endl;
             loadFileForExport(path);
-            std::string outFolder = outputDir.empty() ? fs::path(path).parent_path().string() : outputDir;
+            std::string outFolder = m_outputFolder[0] ? std::string(m_outputFolder) : fs::path(path).parent_path().string();
             std::string stem = fs::path(path).stem().string();
             std::string outPath;
+            ExportFormat fmt = ExportFormat::PRORES_CPU;
+            if (i < m_fileExportFormats.size()) fmt = m_fileExportFormats[i];
             switch (fmt) {
-            case ExportFormat::PRORES:
+            case ExportFormat::PRORES_CPU:
                 outPath = (fs::path(outFolder) / (stem + ".mov")).string();
                 exportCurrentClipToProRes(outPath);
 #ifdef ENABLE_PRORES_EXPORT
@@ -2782,7 +2804,17 @@ void App::startBatchConversion(ExportFormat fmt, const std::string& outputDir) {
                 else m_batchLog.push_back(std::string("Error: ") + m_proResStatus.errorMsg);
 #endif
                 break;
-            case ExportFormat::DNXHR:
+            case ExportFormat::PRORES_GPU:
+                outPath = (fs::path(outFolder) / (stem + ".mov")).string();
+                convertCurrentClipToProRes(outPath);
+#ifdef ENABLE_PRORES_EXPORT
+                while (m_proResStatus.active.load()) std::this_thread::sleep_for(std::chrono::milliseconds(100));
+                if (m_proResThread.joinable()) m_proResThread.join();
+                if (m_proResStatus.errorMsg.empty()) m_batchLog.push_back(fs::path(path).filename().string() + " -> ProRes(GPU) done");
+                else m_batchLog.push_back(std::string("Error: ") + m_proResStatus.errorMsg);
+#endif
+                break;
+            case ExportFormat::DNXHR_CPU:
                 outPath = (fs::path(outFolder) / (stem + ".mov")).string();
                 exportCurrentClipToDNxHR(outPath);
 #ifdef ENABLE_PRORES_EXPORT
@@ -2792,9 +2824,19 @@ void App::startBatchConversion(ExportFormat fmt, const std::string& outputDir) {
                 else m_batchLog.push_back(std::string("Error: ") + m_dnxhrStatus.errorMsg);
 #endif
                 break;
-            case ExportFormat::HEVC:
+            case ExportFormat::DNXHR_GPU:
+                outPath = (fs::path(outFolder) / (stem + ".mov")).string();
+                convertCurrentClipToDNxHR(outPath);
+#ifdef ENABLE_PRORES_EXPORT
+                while (m_dnxhrStatus.active.load()) std::this_thread::sleep_for(std::chrono::milliseconds(100));
+                if (m_dnxhrThread.joinable()) m_dnxhrThread.join();
+                if (m_dnxhrStatus.errorMsg.empty()) m_batchLog.push_back(fs::path(path).filename().string() + " -> DNxHR(GPU) done");
+                else m_batchLog.push_back(std::string("Error: ") + m_dnxhrStatus.errorMsg);
+#endif
+                break;
+            case ExportFormat::HEVC_CPU:
                 outPath = (fs::path(outFolder) / (stem + ".mp4")).string();
-                convertCurrentClipToHEVC_AMD(outPath);
+                exportCurrentClipToHEVC_AMD(outPath);
 #ifdef ENABLE_PRORES_EXPORT
                 while (m_hevcStatus.active.load()) std::this_thread::sleep_for(std::chrono::milliseconds(100));
                 if (m_hevcThread.joinable()) m_hevcThread.join();
@@ -2802,9 +2844,21 @@ void App::startBatchConversion(ExportFormat fmt, const std::string& outputDir) {
                 else m_batchLog.push_back(std::string("Error: ") + m_hevcStatus.errorMsg);
 #endif
                 break;
+            case ExportFormat::HEVC_GPU:
+                outPath = (fs::path(outFolder) / (stem + ".mp4")).string();
+                convertCurrentClipToHEVC_AMD(outPath);
+#ifdef ENABLE_PRORES_EXPORT
+                while (m_hevcStatus.active.load()) std::this_thread::sleep_for(std::chrono::milliseconds(100));
+                if (m_hevcThread.joinable()) m_hevcThread.join();
+                if (m_hevcStatus.errorMsg.empty()) m_batchLog.push_back(fs::path(path).filename().string() + " -> HEVC(GPU) done");
+                else m_batchLog.push_back(std::string("Error: ") + m_hevcStatus.errorMsg);
+#endif
+                break;
             }
+            if (logFile.is_open()) logFile << "[end] " << fs::path(path).filename().string() << std::endl;
         }
         m_batchLog.push_back("Batch finished");
+        if (logFile.is_open()) logFile << "[summary] total=" << m_fileList.size() << std::endl;
         m_batchActive.store(false);
     });
 }

--- a/src/App/AppInit.cpp
+++ b/src/App/AppInit.cpp
@@ -180,6 +180,7 @@ App::App(const std::string& filePath) :
         for (const auto& e : fs::directory_iterator(folder)) {
             if (e.is_regular_file() && e.path().extension() == ".mcraw") {
                 m_fileList.push_back(e.path().string());
+                m_fileExportFormats.push_back(ExportFormat::PRORES_CPU);
             }
         }
         if (!m_fileList.empty()) {
@@ -190,6 +191,7 @@ App::App(const std::string& filePath) :
         if (it == m_fileList.end()) {
             LogToFile("App::App Initial file not found in directory scan, adding it to list: " + target.string());
             m_fileList.push_back(target.string());
+            m_fileExportFormats.push_back(ExportFormat::PRORES_CPU);
             std::sort(m_fileList.begin(), m_fileList.end());
             it = std::find(m_fileList.begin(), m_fileList.end(), target.string());
             if (it == m_fileList.end()) {

--- a/src/App/AppInput.cpp
+++ b/src/App/AppInput.cpp
@@ -12,6 +12,7 @@
 #ifdef _WIN32
 #define GLFW_EXPOSE_NATIVE_WIN32
 #include <GLFW/glfw3native.h>
+#include <ShlObj.h>
 #include <commdlg.h>
 namespace DebugLogHelper {
     extern std::string wstring_to_utf8(const std::wstring& wstr);
@@ -383,6 +384,7 @@ void App::handleDrop(int count, const char** paths) {
                 }
                 if (std::find(m_fileList.begin(), m_fileList.end(), s) == m_fileList.end()) {
                     m_fileList.push_back(s);
+                    m_fileExportFormats.push_back(ExportFormat::PRORES_CPU);
                     newFilesAddedToPlaylist = true;
                 }
             }
@@ -400,6 +402,7 @@ void App::handleDrop(int count, const char** paths) {
                     std::string s = e.path().string();
                     if (std::find(m_fileList.begin(), m_fileList.end(), s) == m_fileList.end()) {
                         m_fileList.push_back(s);
+                        m_fileExportFormats.push_back(ExportFormat::PRORES_CPU);
                         newFilesAddedToPlaylist = true;
                     }
                 }
@@ -641,6 +644,30 @@ std::string App::openSaveMp4Dialog() {
     return {};
 }
 
+std::string App::openFolderDialog() {
+#ifdef _WIN32
+    BROWSEINFOW bi{};
+    bi.ulFlags = BIF_RETURNONLYFSDIRS | BIF_USENEWUI;
+    bi.hwndOwner = m_window ? glfwGetWin32Window(m_window) : NULL;
+    PIDLIST_ABSOLUTE pidl = SHBrowseForFolderW(&bi);
+    if (pidl) {
+        wchar_t path[MAX_PATH];
+        if (SHGetPathFromIDListW(pidl, path)) {
+            std::string utf8 = DebugLogHelper::wstring_to_utf8(path);
+            CoTaskMemFree(pidl);
+            return utf8;
+        }
+        CoTaskMemFree(pidl);
+    }
+#else
+    std::string folder;
+    std::cout << "Output folder: " << std::flush;
+    std::getline(std::cin, folder);
+    return folder;
+#endif
+    return {};
+}
+
 void App::triggerOpenFileViaDialog() {
     std::vector<std::string> paths = openMultipleMcrawDialog();
     if (!paths.empty()) {
@@ -648,6 +675,7 @@ void App::triggerOpenFileViaDialog() {
         for (const std::string& p : paths) {
             if (std::find(m_fileList.begin(), m_fileList.end(), p) == m_fileList.end()) {
                 m_fileList.push_back(p);
+                m_fileExportFormats.push_back(ExportFormat::PRORES_CPU);
                 added = true;
             }
         }

--- a/src/Gui/GuiRender.cpp
+++ b/src/Gui/GuiRender.cpp
@@ -197,10 +197,12 @@ namespace GuiOverlay {
         ImGui::SameLine();
         if (ImGui::Button("Remove") && appInstance->m_selectedBatchIndex >= 0 && appInstance->m_selectedBatchIndex < (int)appInstance->m_fileList.size()) {
             appInstance->m_fileList.erase(appInstance->m_fileList.begin() + appInstance->m_selectedBatchIndex);
+            if (appInstance->m_selectedBatchIndex < (int)appInstance->m_fileExportFormats.size())
+                appInstance->m_fileExportFormats.erase(appInstance->m_fileExportFormats.begin() + appInstance->m_selectedBatchIndex);
             appInstance->m_selectedBatchIndex = -1;
         }
         ImGui::SameLine();
-        if (ImGui::Button("Clear")) { appInstance->m_fileList.clear(); appInstance->m_selectedBatchIndex = -1; }
+        if (ImGui::Button("Clear")) { appInstance->m_fileList.clear(); appInstance->m_fileExportFormats.clear(); appInstance->m_selectedBatchIndex = -1; }
         ImGui::Separator();
         for (int i = 0; i < (int)appInstance->m_fileList.size(); ++i) {
             bool sel = (i == appInstance->m_selectedBatchIndex);
@@ -215,15 +217,72 @@ namespace GuiOverlay {
         ImGui::SameLine();
 
         ImGui::BeginChild("ExportSettings", ImVec2(0, vp->WorkSize.y - 150), true);
-        static int fmt = 0;
-        ImGui::RadioButton("ProRes", &fmt, 0);
-        ImGui::RadioButton("DNxHR", &fmt, 1);
-        ImGui::RadioButton("HEVC (GPU)", &fmt, 2);
+        if (appInstance->m_selectedBatchIndex >= 0 && appInstance->m_selectedBatchIndex < (int)appInstance->m_fileExportFormats.size()) {
+            int fmt = static_cast<int>(appInstance->m_fileExportFormats[appInstance->m_selectedBatchIndex]);
+            ImGui::Text("Export Format for selected clip:");
+            ImGui::RadioButton("ProRes (CPU)", &fmt, (int)App::ExportFormat::PRORES_CPU); ImGui::SameLine();
+            ImGui::RadioButton("ProRes (GPU)", &fmt, (int)App::ExportFormat::PRORES_GPU);
+            ImGui::RadioButton("DNxHR (CPU)", &fmt, (int)App::ExportFormat::DNXHR_CPU); ImGui::SameLine();
+            ImGui::RadioButton("DNxHR (GPU)", &fmt, (int)App::ExportFormat::DNXHR_GPU);
+            ImGui::RadioButton("HEVC (CPU)", &fmt, (int)App::ExportFormat::HEVC_CPU); ImGui::SameLine();
+            ImGui::RadioButton("HEVC (GPU)", &fmt, (int)App::ExportFormat::HEVC_GPU);
+            appInstance->m_fileExportFormats[appInstance->m_selectedBatchIndex] = static_cast<App::ExportFormat>(fmt);
+        }
         ImGui::InputText("Output Folder", appInstance->m_outputFolder, IM_ARRAYSIZE(appInstance->m_outputFolder));
+        ImGui::SameLine();
+        if (ImGui::Button("Browse...")) {
+            std::string folder = appInstance->openFolderDialog();
+            if (!folder.empty()) strncpy(appInstance->m_outputFolder, folder.c_str(), sizeof(appInstance->m_outputFolder)-1);
+        }
         if (ImGui::Button("Convert All") && !appInstance->m_batchActive.load()) {
-            appInstance->startBatchConversion(static_cast<App::ExportFormat>(fmt), appInstance->m_outputFolder);
+            appInstance->startBatchConversion();
         }
         ImGui::EndChild();
+
+        if (appInstance->m_previewOpen && appInstance->m_decoderWrapper_ptr) {
+            ImGui::SetNextWindowSize(ImVec2(400,300), ImGuiCond_FirstUseEver);
+            ImGui::Begin("Preview", &appInstance->m_previewOpen);
+            bool paused = true;
+            if (appInstance->m_playbackController_ptr)
+                paused = appInstance->m_playbackController_ptr->isPaused();
+            if (ImGui::Button(paused ? "Play" : "Pause")) {
+                if (appInstance->m_playbackController_ptr)
+                    appInstance->m_playbackController_ptr->togglePause();
+            }
+            ImGui::SameLine();
+            if (ImGui::Button("Stop")) {
+                if (appInstance->m_playbackController_ptr) {
+                    appInstance->m_playbackController_ptr->setPlaybackMode(PlaybackController::PlaybackMode::REALTIME);
+                    appInstance->performSeek(0);
+                    if (!appInstance->m_playbackController_ptr->isPaused())
+                        appInstance->m_playbackController_ptr->togglePause();
+                }
+            }
+            ImGui::SameLine();
+            if (ImGui::Button("<")) {
+                if (appInstance->m_playbackController_ptr)
+                    appInstance->m_playbackController_ptr->stepBackward(appInstance->m_decoderWrapper_ptr->getDecoder()->getFrames().size());
+            }
+            ImGui::SameLine();
+            if (ImGui::Button(">")) {
+                if (appInstance->m_playbackController_ptr)
+                    appInstance->m_playbackController_ptr->stepForward(appInstance->m_decoderWrapper_ptr->getDecoder()->getFrames().size());
+            }
+            size_t curIdx = 0, total = 0;
+            if (appInstance->m_playbackController_ptr && appInstance->m_decoderWrapper_ptr && appInstance->m_decoderWrapper_ptr->getDecoder()) {
+                curIdx = appInstance->m_playbackController_ptr->getCurrentFrameIndex();
+                total = appInstance->m_decoderWrapper_ptr->getDecoder()->getFrames().size();
+            }
+            float prog = total ? (float)curIdx / (float)total : 0.f;
+            if (ImGui::SliderFloat("Seek", &prog, 0.f, 1.f)) {
+                if (appInstance->m_decoderWrapper_ptr) {
+                    size_t newIdx = static_cast<size_t>(prog * total);
+                    appInstance->performSeek(newIdx);
+                }
+            }
+            ImGui::Text("Frame %zu / %zu", curIdx, total);
+            ImGui::End();
+        }
 
         ImGui::BeginChild("Log", ImVec2(0, 120), true);
         for (const std::string& line : appInstance->m_batchLog) ImGui::TextUnformatted(line.c_str());


### PR DESCRIPTION
## Summary
- implement per-clip export format selection with CPU/GPU options
- write batch logs with timestamps
- add output folder browser and preview controls
- maintain format list when adding/removing files

## Testing
- `cmake --build build -j 4` *(fails: libavutil/frame.h not found)*

------
https://chatgpt.com/codex/tasks/task_e_6877ee2d32cc8327b4105a361555d9d2