### PR TITLE
Rename MotionCam Batcher to Converter

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.16)
 cmake_policy(SET CMP0111 NEW)
-project(MotionCam_Batcher VERSION 0.7 LANGUAGES C CXX)
+project(MotionCam_Converter VERSION 0.7 LANGUAGES C CXX)
 
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
@@ -199,7 +199,7 @@ add_dependencies(${PROJECT_NAME} CompileShaders glm motioncam_decoder imgui)
 
 target_compile_definitions(${PROJECT_NAME} PRIVATE SDL_MAIN_HANDLED)
 target_compile_definitions(${PROJECT_NAME} PRIVATE GLFW_INCLUDE_NONE)
-target_compile_definitions(${PROJECT_NAME} PRIVATE MOTIONCAM_BATCHER)
+target_compile_definitions(${PROJECT_NAME} PRIVATE MOTIONCAM_CONVERTER)
 if(HAVE_FFMPEG)
     target_compile_definitions(${PROJECT_NAME} PRIVATE ENABLE_PRORES_EXPORT)
 endif()
@@ -299,7 +299,7 @@ endif()
 
 set_target_properties(${PROJECT_NAME} PROPERTIES
     RUNTIME_OUTPUT_DIRECTORY "${CMAKE_RUNTIME_OUTPUT_DIRECTORY}"
-    OUTPUT_NAME "motioncam_batcher"
+    OUTPUT_NAME "motioncam_converter"
 )
 
 add_custom_command(TARGET ${PROJECT_NAME} POST_BUILD
@@ -326,9 +326,9 @@ endif()
 
 message(STATUS "---------------------------------------------------------------------")
 message(STATUS "Final Configuration Summary:")
-message(STATUS "  Target Executable: MotionCam Player")
+message(STATUS "  Target Executable: MotionCam Converter")
 message(STATUS "  Output Directory:  ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${CMAKE_CFG_INTDIR}")
-message(STATUS "  Output Executable: ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${CMAKE_CFG_INTDIR}/MotionCam Player${CMAKE_EXECUTABLE_SUFFIX}")
+message(STATUS "  Output Executable: ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${CMAKE_CFG_INTDIR}/MotionCam Converter${CMAKE_EXECUTABLE_SUFFIX}")
 message(STATUS "---------------------------------------------------------------------")
 
 # Only enable the optional tests if the directory exists. Some

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# MotionCam Player
+# MotionCam Converter
 
-This project builds a desktop player for MotionCam `.mcraw` files.
+This project builds a desktop converter for MotionCam `.mcraw` files.
 
 ## Building
 
@@ -93,4 +93,4 @@ runtime DLLs will be copied automatically.
 - If the AMD encoder is unavailable the export aborts and logs to `hevc_export_log.txt`.
 - The log file lists these settings so you can verify the parameters used.
 
-See `docs/Batcher_Enhancement_Spec.md` for proposed improvements to the MotionCam Batcher add-on.
+See `docs/Converter_Enhancement_Spec.md` for proposed improvements to the MotionCam Converter add-on.

--- a/include/App/App.h
+++ b/include/App/App.h
@@ -124,7 +124,7 @@ public:
     void setPlaybackMode(PlaybackController::PlaybackMode mode);
     void showActionMessage(const std::string& msg);
 
-#ifdef MOTIONCAM_BATCHER
+#ifdef MOTIONCAM_CONVERTER
     enum class ExportFormat {
         PRORES_CPU,
         PRORES_GPU,

--- a/src/App/AppIO.cpp
+++ b/src/App/AppIO.cpp
@@ -2758,7 +2758,7 @@ void App::loadFileForExport(const std::string& path) {
     }
 }
 
-#ifdef MOTIONCAM_BATCHER
+#ifdef MOTIONCAM_CONVERTER
 void App::startBatchConversion() {
     if (m_batchActive.load()) return;
     m_batchActive.store(true);
@@ -2767,7 +2767,7 @@ void App::startBatchConversion() {
     fs::path logDir = fs::path(getLogDirectory());
     std::error_code ec;
     fs::create_directories(logDir, ec);
-    fs::path logPath = logDir / "MotionCamBatcher.txt";
+    fs::path logPath = logDir / "MotionCamConverter.txt";
     std::ofstream logFile(logPath.string());
     m_batchThread = std::thread([this, logFile = std::move(logFile)]() mutable {
         namespace fs = std::filesystem;

--- a/src/App/AppInit.cpp
+++ b/src/App/AppInit.cpp
@@ -291,11 +291,7 @@ bool App::initVulkan() {
     LogToFile("App::initVulkan GLFW initialized.");
 
     glfwWindowHint(GLFW_CLIENT_API, GLFW_NO_API);
-#ifdef MOTIONCAM_BATCHER
-    m_window = glfwCreateWindow(m_windowWidth, m_windowHeight, "MotionCam Batcher", nullptr, nullptr);
-#else
-    m_window = glfwCreateWindow(m_windowWidth, m_windowHeight, "MotionCam Player", nullptr, nullptr);
-#endif
+    m_window = glfwCreateWindow(m_windowWidth, m_windowHeight, "MotionCam Converter", nullptr, nullptr);
     if (!m_window) {
         LogToFile("App::initVulkan ERROR: Failed to create GLFW window");
         glfwTerminate();
@@ -385,11 +381,7 @@ void App::createInstance() {
 
     VkApplicationInfo appInfo{};
     appInfo.sType = VK_STRUCTURE_TYPE_APPLICATION_INFO;
-#ifdef MOTIONCAM_BATCHER
-    appInfo.pApplicationName = "MotionCam Batcher";
-#else
-    appInfo.pApplicationName = "MotionCam Player";
-#endif
+    appInfo.pApplicationName = "MotionCam Converter";
     appInfo.applicationVersion = VK_MAKE_VERSION(1, 2, 0);
     appInfo.pEngineName = "No Engine";
     appInfo.engineVersion = VK_MAKE_VERSION(1, 0, 0);

--- a/src/App/AppInput.cpp
+++ b/src/App/AppInput.cpp
@@ -79,7 +79,7 @@ void App::framebufferSizeCallback(int width, int height) {
 
 
 void App::handleKey(int key, int mods) {
-#ifdef MOTIONCAM_BATCHER
+#ifdef MOTIONCAM_CONVERTER
     (void)key; (void)mods;
     return;
 #else
@@ -363,7 +363,7 @@ void App::handleKey(int key, int mods) {
         // So, this specific else-if branch might not need additional action here, as performSeek should handle it.
         // LogToFile("[App::handleKey] Seek action occurred while paused. Anchor already updated by performSeek. Audio reset by performSeek.");
     }
-#endif // MOTIONCAM_BATCHER
+#endif // MOTIONCAM_CONVERTER
 }
 
 void App::handleDrop(int count, const char** paths) {

--- a/src/App/AppLoop.cpp
+++ b/src/App/AppLoop.cpp
@@ -198,11 +198,7 @@ bool App::run() {
             std::string currentTitleString;
 
             std::ostringstream ss;
-#ifdef MOTIONCAM_BATCHER
-            ss << "MotionCam Batcher -  ";
-#else
-            ss << "MotionCam Player -  ";
-#endif
+            ss << "MotionCam Converter -  ";
             if (m_currentFileIndex >= 0 && static_cast<size_t>(m_currentFileIndex) < m_fileList.size()) {
                 ss << fs::path(m_fileList[m_currentFileIndex]).filename().string();
                 if (m_playbackController && m_decoderWrapper && m_decoderWrapper->getDecoder()) {

--- a/src/Gui/GuiRender.cpp
+++ b/src/Gui/GuiRender.cpp
@@ -184,18 +184,18 @@ namespace GuiOverlay {
 
 
     void render(App* appInstance) {
-#ifdef MOTIONCAM_BATCHER
+#ifdef MOTIONCAM_CONVERTER
         if (!appInstance) return;
         ImGuiIO& io = ImGui::GetIO();
         ImGuiViewport* vp = ImGui::GetMainViewport();
         ImGui::SetNextWindowPos(vp->WorkPos);
         ImGui::SetNextWindowSize(vp->WorkSize);
         ImGui::SetNextWindowBgAlpha(0.f);
-        ImGui::Begin("BatcherMain", nullptr, ImGuiWindowFlags_NoDecoration | ImGuiWindowFlags_NoMove | ImGuiWindowFlags_NoBackground);
+        ImGui::Begin("ConverterMain", nullptr, ImGuiWindowFlags_NoDecoration | ImGuiWindowFlags_NoMove | ImGuiWindowFlags_NoBackground);
 
         ImGui::BeginChild("FileListPanel", ImVec2(vp->WorkSize.x * 0.5f, vp->WorkSize.y - 150), true);
         if (ImGui::CollapsingHeader("Preview", &appInstance->m_previewOpen, ImGuiTreeNodeFlags_DefaultOpen)) {
-            ImGui::BeginChild("PreviewArea", ImVec2(0, 220), true, ImGuiWindowFlags_NoBackground);
+            ImGui::BeginChild("PreviewArea", ImVec2(0, 220), true);
             ImVec2 innerPos = ImGui::GetWindowPos();
             ImVec2 innerSize = ImGui::GetWindowSize();
             appInstance->m_previewRect.x = (int)(innerPos.x - vp->WorkPos.x);
@@ -333,7 +333,7 @@ namespace GuiOverlay {
         ImGui::EndChild();
 
         ImGui::Separator();
-        ImGui::Text("MotionCam Batcher v0.36.0 — RAW VIDEO CONVERTER");
+        ImGui::Text("MotionCam Converter v0.36.0 — RAW VIDEO CONVERTER");
         ImGui::Text("www.motioncamapp.com");
 
         ImGui::End();

--- a/src/Utils/DebugLog.cpp
+++ b/src/Utils/DebugLog.cpp
@@ -49,18 +49,10 @@ std::string getLogDirectory() {
         WideCharToMultiByte(CP_UTF8, 0, appDataPath, -1, &appData[0], size, nullptr, nullptr);
         CoTaskMemFree(appDataPath);
         logDir = appData + "\\MotionCam Tools\\";
-#ifdef MOTIONCAM_BATCHER
-        logDir += "Batcher\\logs";
-#else
-        logDir += "Player\\logs";
-#endif
+        logDir += "Converter\\logs";
     } else {
         logDir = std::filesystem::temp_directory_path().string() + "\\MotionCam Tools\\";
-#ifdef MOTIONCAM_BATCHER
-        logDir += "Batcher\\logs";
-#else
-        logDir += "Player\\logs";
-#endif
+        logDir += "Converter\\logs";
     }
     return logDir;
 #else
@@ -76,11 +68,7 @@ static std::ofstream& get_log_file() {
         std::filesystem::path logDir = getLogDirectory();
         std::error_code ec;
         std::filesystem::create_directories(logDir, ec); // Ignore errors, file open will fail if directory can't be created
-#ifdef MOTIONCAM_BATCHER
-        std::filesystem::path logPath = logDir / "MotionCamBatcher.txt";
-#else
-        std::filesystem::path logPath = logDir / "motioncam_player_log.txt";
-#endif
+        std::filesystem::path logPath = logDir / "MotionCamConverter.txt";
         log_file.open(logPath, std::ios_base::app | std::ios_base::out);
         initialized = true;
     }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -275,7 +275,7 @@ int main(int argc, char* argv[]) {
         std::string errorMsg = "[main] Input file not found or not a regular file: " + inPath;
         LogToFile(errorMsg);
 #ifdef _WIN32
-        MessageBoxA(NULL, errorMsg.c_str(), "Error - MCRAW Batcher", MB_OK | MB_ICONERROR);
+        MessageBoxA(NULL, errorMsg.c_str(), "Error - MCRAW Converter", MB_OK | MB_ICONERROR);
 #endif
         std::cerr << errorMsg << std::endl;
         return 1;
@@ -284,7 +284,7 @@ int main(int argc, char* argv[]) {
         std::string errorMsg = "[main] Input file must have a .mcraw extension: " + inPath;
         LogToFile(errorMsg);
 #ifdef _WIN32
-        MessageBoxA(NULL, errorMsg.c_str(), "Error - MCRAW Batcher", MB_OK | MB_ICONERROR);
+        MessageBoxA(NULL, errorMsg.c_str(), "Error - MCRAW Converter", MB_OK | MB_ICONERROR);
 #endif
         std::cerr << errorMsg << std::endl;
         return 1;
@@ -297,7 +297,7 @@ int main(int argc, char* argv[]) {
         if (!app.run()) {
             LogToFile("[main] App::run() returned false. Application will exit.");
 #ifdef _WIN32
-            MessageBoxA(NULL, "Application run failed. See mcraw_player_debug_log.txt for details.", "Runtime Error - MCRAW Batcher", MB_OK | MB_ICONERROR);
+            MessageBoxA(NULL, "Application run failed. See mcraw_converter_debug_log.txt for details.", "Runtime Error - MCRAW Converter", MB_OK | MB_ICONERROR);
 #endif
             std::cerr << "[main] App::run() returned false. Application will exit." << std::endl;
             return 1;
@@ -308,7 +308,7 @@ int main(int argc, char* argv[]) {
         std::string errorMsg = "[main] FATAL STD EXCEPTION: " + std::string(e.what());
         LogToFile(errorMsg);
 #ifdef _WIN32
-        MessageBoxA(NULL, errorMsg.c_str(), "Runtime Error - MCRAW Batcher", MB_OK | MB_ICONERROR);
+        MessageBoxA(NULL, errorMsg.c_str(), "Runtime Error - MCRAW Converter", MB_OK | MB_ICONERROR);
 #endif
         std::cerr << errorMsg << std::endl;
         return 1;
@@ -317,7 +317,7 @@ int main(int argc, char* argv[]) {
         std::string errorMsg = "[main] FATAL UNKNOWN EXCEPTION occurred.";
         LogToFile(errorMsg);
 #ifdef _WIN32
-        MessageBoxA(NULL, errorMsg.c_str(), "Runtime Error - MCRAW Batcher", MB_OK | MB_ICONERROR);
+        MessageBoxA(NULL, errorMsg.c_str(), "Runtime Error - MCRAW Converter", MB_OK | MB_ICONERROR);
 #endif
         std::cerr << errorMsg << std::endl;
         return 1;


### PR DESCRIPTION
## Summary
- rename all Batcher/Player wording to **MotionCam Converter**
- update executable name and build messages
- adjust log paths
- embed preview child widget with normal styling

## Testing
- `cmake -B build -S .`

------
https://chatgpt.com/codex/tasks/task_e_6878a98673888327a19cecc0f9feb9d7