### PR TITLE
Rename MotionCam Player to Converter and fix preview panel

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.16)
 cmake_policy(SET CMP0111 NEW)
-project(MotionCam_Batcher VERSION 0.7 LANGUAGES C CXX)
+project(MotionCam_Converter VERSION 0.7 LANGUAGES C CXX)
 
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
@@ -199,7 +199,7 @@ add_dependencies(${PROJECT_NAME} CompileShaders glm motioncam_decoder imgui)
 
 target_compile_definitions(${PROJECT_NAME} PRIVATE SDL_MAIN_HANDLED)
 target_compile_definitions(${PROJECT_NAME} PRIVATE GLFW_INCLUDE_NONE)
-target_compile_definitions(${PROJECT_NAME} PRIVATE MOTIONCAM_BATCHER)
+target_compile_definitions(${PROJECT_NAME} PRIVATE MOTIONCAM_CONVERTER)
 if(HAVE_FFMPEG)
     target_compile_definitions(${PROJECT_NAME} PRIVATE ENABLE_PRORES_EXPORT)
 endif()
@@ -299,7 +299,7 @@ endif()
 
 set_target_properties(${PROJECT_NAME} PROPERTIES
     RUNTIME_OUTPUT_DIRECTORY "${CMAKE_RUNTIME_OUTPUT_DIRECTORY}"
-    OUTPUT_NAME "motioncam_batcher"
+    OUTPUT_NAME "motioncam_converter"
 )
 
 add_custom_command(TARGET ${PROJECT_NAME} POST_BUILD
@@ -326,9 +326,9 @@ endif()
 
 message(STATUS "---------------------------------------------------------------------")
 message(STATUS "Final Configuration Summary:")
-message(STATUS "  Target Executable: MotionCam Player")
+message(STATUS "  Target Executable: MotionCam Converter")
 message(STATUS "  Output Directory:  ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${CMAKE_CFG_INTDIR}")
-message(STATUS "  Output Executable: ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${CMAKE_CFG_INTDIR}/MotionCam Player${CMAKE_EXECUTABLE_SUFFIX}")
+message(STATUS "  Output Executable: ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${CMAKE_CFG_INTDIR}/MotionCam Converter${CMAKE_EXECUTABLE_SUFFIX}")
 message(STATUS "---------------------------------------------------------------------")
 
 # Only enable the optional tests if the directory exists. Some

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# MotionCam Player
+# MotionCam Converter
 
-This project builds a desktop player for MotionCam `.mcraw` files.
+This project builds a desktop converter for MotionCam `.mcraw` files.
 
 ## Building
 
@@ -42,7 +42,7 @@ runtime DLLs will be copied automatically.
 
 ## ProRes Export
 
-- Right-click anywhere in the player window to open the context menu.
+- Right-click anywhere in the converter window to open the context menu.
 - Choose **Export to ProRes** and select a `.mov` file path.
 - Encoding uses FFmpeg linked via vcpkg. Make sure the libraries are installed in your vcpkg instance.
  - Progress is shown in a modal popup while the encoding thread runs.
@@ -93,4 +93,4 @@ runtime DLLs will be copied automatically.
 - If the AMD encoder is unavailable the export aborts and logs to `hevc_export_log.txt`.
 - The log file lists these settings so you can verify the parameters used.
 
-See `docs/Batcher_Enhancement_Spec.md` for proposed improvements to the MotionCam Batcher add-on.
+See `docs/Converter_Enhancement_Spec.md` for proposed improvements to the MotionCam Converter add-on.

--- a/include/App/App.h
+++ b/include/App/App.h
@@ -124,7 +124,7 @@ public:
     void setPlaybackMode(PlaybackController::PlaybackMode mode);
     void showActionMessage(const std::string& msg);
 
-#ifdef MOTIONCAM_BATCHER
+#ifdef MOTIONCAM_CONVERTER
     enum class ExportFormat {
         PRORES_CPU,
         PRORES_GPU,

--- a/src/App/AppCleanup.cpp
+++ b/src/App/AppCleanup.cpp
@@ -93,7 +93,7 @@ App::~App() {
         DestroyWindow(_ipcWnd);
         _ipcWnd = nullptr;
     }
-    const wchar_t* ipcClassName = L"MOTIONCAM_PLAYER_IPC_WND_CLASS";
+    const wchar_t* ipcClassName = L"MOTIONCAM_CONVERTER_IPC_WND_CLASS";
     UnregisterClassW(ipcClassName, GetModuleHandleW(nullptr));
     LogToFile("[App::~App] Unregistered IPC window class (attempted).");
 #ifndef NDEBUG

--- a/src/App/AppIO.cpp
+++ b/src/App/AppIO.cpp
@@ -162,7 +162,7 @@ namespace {
         dng.SetAsShotNeutral(asShotNeutral.size(), asShotNeutral.data());
         dng.SetCalibrationIlluminant1(21);
         dng.SetCalibrationIlluminant2(17);
-        dng.SetUniqueCameraModel("MotionCam App Player Export");
+        dng.SetUniqueCameraModel("MotionCam App Converter Export");
         dng.SetSubfileType(false, false, false);
         const uint32_t activeArea[4] = { 0, 0, height, width };
         dng.SetActiveArea(activeArea);
@@ -2758,7 +2758,7 @@ void App::loadFileForExport(const std::string& path) {
     }
 }
 
-#ifdef MOTIONCAM_BATCHER
+#ifdef MOTIONCAM_CONVERTER
 void App::startBatchConversion() {
     if (m_batchActive.load()) return;
     m_batchActive.store(true);
@@ -2767,7 +2767,7 @@ void App::startBatchConversion() {
     fs::path logDir = fs::path(getLogDirectory());
     std::error_code ec;
     fs::create_directories(logDir, ec);
-    fs::path logPath = logDir / "MotionCamBatcher.txt";
+    fs::path logPath = logDir / "MotionCamConverter.txt";
     std::ofstream logFile(logPath.string());
     m_batchThread = std::thread([this, logFile = std::move(logFile)]() mutable {
         namespace fs = std::filesystem;

--- a/src/App/AppInit.cpp
+++ b/src/App/AppInit.cpp
@@ -291,10 +291,10 @@ bool App::initVulkan() {
     LogToFile("App::initVulkan GLFW initialized.");
 
     glfwWindowHint(GLFW_CLIENT_API, GLFW_NO_API);
-#ifdef MOTIONCAM_BATCHER
-    m_window = glfwCreateWindow(m_windowWidth, m_windowHeight, "MotionCam Batcher", nullptr, nullptr);
+#ifdef MOTIONCAM_CONVERTER
+    m_window = glfwCreateWindow(m_windowWidth, m_windowHeight, "MotionCam Converter", nullptr, nullptr);
 #else
-    m_window = glfwCreateWindow(m_windowWidth, m_windowHeight, "MotionCam Player", nullptr, nullptr);
+    m_window = glfwCreateWindow(m_windowWidth, m_windowHeight, "MotionCam Converter", nullptr, nullptr);
 #endif
     if (!m_window) {
         LogToFile("App::initVulkan ERROR: Failed to create GLFW window");
@@ -325,7 +325,7 @@ bool App::initVulkan() {
 #ifdef _WIN32
     {
         LogToFile("App::initVulkan Creating IPC message-only window.");
-        const wchar_t* ipcClassName = L"MOTIONCAM_PLAYER_IPC_WND_CLASS";
+        const wchar_t* ipcClassName = L"MOTIONCAM_CONVERTER_IPC_WND_CLASS";
         WNDCLASSW wc{};
         wc.lpfnWndProc = App::IpcWndProcStatic;
         wc.hInstance = GetModuleHandleW(nullptr);
@@ -336,7 +336,7 @@ bool App::initVulkan() {
         else {
             LogToFile("App::initVulkan IPC Window class registered or already exists.");
         }
-        _ipcWnd = CreateWindowExW(0, ipcClassName, L"MOTIONCAM_PLAYER_IPC_HIDDEN_WINDOW", 0, 0, 0, 0, 0, HWND_MESSAGE, nullptr, GetModuleHandleW(nullptr), this);
+        _ipcWnd = CreateWindowExW(0, ipcClassName, L"MOTIONCAM_CONVERTER_IPC_HIDDEN_WINDOW", 0, 0, 0, 0, 0, HWND_MESSAGE, nullptr, GetModuleHandleW(nullptr), this);
         if (!_ipcWnd) LogToFile(std::string("App::initVulkan ERROR: CreateWindowExW for IPC window failed. Error: ") + std::to_string(GetLastError()));
         else LogToFile("App::initVulkan IPC message-only window created successfully.");
     }
@@ -385,10 +385,10 @@ void App::createInstance() {
 
     VkApplicationInfo appInfo{};
     appInfo.sType = VK_STRUCTURE_TYPE_APPLICATION_INFO;
-#ifdef MOTIONCAM_BATCHER
-    appInfo.pApplicationName = "MotionCam Batcher";
+#ifdef MOTIONCAM_CONVERTER
+    appInfo.pApplicationName = "MotionCam Converter";
 #else
-    appInfo.pApplicationName = "MotionCam Player";
+    appInfo.pApplicationName = "MotionCam Converter";
 #endif
     appInfo.applicationVersion = VK_MAKE_VERSION(1, 2, 0);
     appInfo.pEngineName = "No Engine";

--- a/src/App/AppInput.cpp
+++ b/src/App/AppInput.cpp
@@ -79,7 +79,7 @@ void App::framebufferSizeCallback(int width, int height) {
 
 
 void App::handleKey(int key, int mods) {
-#ifdef MOTIONCAM_BATCHER
+#ifdef MOTIONCAM_CONVERTER
     (void)key; (void)mods;
     return;
 #else
@@ -363,7 +363,7 @@ void App::handleKey(int key, int mods) {
         // So, this specific else-if branch might not need additional action here, as performSeek should handle it.
         // LogToFile("[App::handleKey] Seek action occurred while paused. Anchor already updated by performSeek. Audio reset by performSeek.");
     }
-#endif // MOTIONCAM_BATCHER
+#endif // MOTIONCAM_CONVERTER
 }
 
 void App::handleDrop(int count, const char** paths) {

--- a/src/App/AppLoop.cpp
+++ b/src/App/AppLoop.cpp
@@ -198,10 +198,10 @@ bool App::run() {
             std::string currentTitleString;
 
             std::ostringstream ss;
-#ifdef MOTIONCAM_BATCHER
-            ss << "MotionCam Batcher -  ";
+#ifdef MOTIONCAM_CONVERTER
+            ss << "MotionCam Converter -  ";
 #else
-            ss << "MotionCam Player -  ";
+            ss << "MotionCam Converter -  ";
 #endif
             if (m_currentFileIndex >= 0 && static_cast<size_t>(m_currentFileIndex) < m_fileList.size()) {
                 ss << fs::path(m_fileList[m_currentFileIndex]).filename().string();

--- a/src/Gui/GuiRender.cpp
+++ b/src/Gui/GuiRender.cpp
@@ -184,18 +184,18 @@ namespace GuiOverlay {
 
 
     void render(App* appInstance) {
-#ifdef MOTIONCAM_BATCHER
+#ifdef MOTIONCAM_CONVERTER
         if (!appInstance) return;
         ImGuiIO& io = ImGui::GetIO();
         ImGuiViewport* vp = ImGui::GetMainViewport();
         ImGui::SetNextWindowPos(vp->WorkPos);
         ImGui::SetNextWindowSize(vp->WorkSize);
         ImGui::SetNextWindowBgAlpha(0.f);
-        ImGui::Begin("BatcherMain", nullptr, ImGuiWindowFlags_NoDecoration | ImGuiWindowFlags_NoMove | ImGuiWindowFlags_NoBackground);
+        ImGui::Begin("ConverterMain", nullptr, ImGuiWindowFlags_NoDecoration | ImGuiWindowFlags_NoMove | ImGuiWindowFlags_NoBackground);
 
         ImGui::BeginChild("FileListPanel", ImVec2(vp->WorkSize.x * 0.5f, vp->WorkSize.y - 150), true);
         if (ImGui::CollapsingHeader("Preview", &appInstance->m_previewOpen, ImGuiTreeNodeFlags_DefaultOpen)) {
-            ImGui::BeginChild("PreviewArea", ImVec2(0, 220), true, ImGuiWindowFlags_NoBackground);
+            ImGui::BeginChild("PreviewArea", ImVec2(0, 220), true);
             ImVec2 innerPos = ImGui::GetWindowPos();
             ImVec2 innerSize = ImGui::GetWindowSize();
             appInstance->m_previewRect.x = (int)(innerPos.x - vp->WorkPos.x);
@@ -333,7 +333,7 @@ namespace GuiOverlay {
         ImGui::EndChild();
 
         ImGui::Separator();
-        ImGui::Text("MotionCam Batcher v0.36.0 — RAW VIDEO CONVERTER");
+        ImGui::Text("MotionCam Converter v0.36.0 — RAW VIDEO CONVERTER");
         ImGui::Text("www.motioncamapp.com");
 
         ImGui::End();

--- a/src/Utils/DebugLog.cpp
+++ b/src/Utils/DebugLog.cpp
@@ -49,17 +49,17 @@ std::string getLogDirectory() {
         WideCharToMultiByte(CP_UTF8, 0, appDataPath, -1, &appData[0], size, nullptr, nullptr);
         CoTaskMemFree(appDataPath);
         logDir = appData + "\\MotionCam Tools\\";
-#ifdef MOTIONCAM_BATCHER
-        logDir += "Batcher\\logs";
+#ifdef MOTIONCAM_CONVERTER
+        logDir += "Converter\\logs";
 #else
-        logDir += "Player\\logs";
+        logDir += "Converter\\logs";
 #endif
     } else {
         logDir = std::filesystem::temp_directory_path().string() + "\\MotionCam Tools\\";
-#ifdef MOTIONCAM_BATCHER
-        logDir += "Batcher\\logs";
+#ifdef MOTIONCAM_CONVERTER
+        logDir += "Converter\\logs";
 #else
-        logDir += "Player\\logs";
+        logDir += "Converter\\logs";
 #endif
     }
     return logDir;
@@ -76,10 +76,10 @@ static std::ofstream& get_log_file() {
         std::filesystem::path logDir = getLogDirectory();
         std::error_code ec;
         std::filesystem::create_directories(logDir, ec); // Ignore errors, file open will fail if directory can't be created
-#ifdef MOTIONCAM_BATCHER
-        std::filesystem::path logPath = logDir / "MotionCamBatcher.txt";
+#ifdef MOTIONCAM_CONVERTER
+        std::filesystem::path logPath = logDir / "MotionCamConverter.txt";
 #else
-        std::filesystem::path logPath = logDir / "motioncam_player_log.txt";
+        std::filesystem::path logPath = logDir / "MotionCamConverter.txt";
 #endif
         log_file.open(logPath, std::ios_base::app | std::ios_base::out);
         initialized = true;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -208,7 +208,7 @@ int main(int argc, char* argv[]) {
 
 
 #ifdef _WIN32
-    static const wchar_t* kMutexName = L"MCRAW_PLAYER_SINGLE_INSTANCE_MUTEX_V2_UNIQUE";
+    static const wchar_t* kMutexName = L"MCRAW_CONVERTER_SINGLE_INSTANCE_MUTEX_V2_UNIQUE";
     SingleInstanceGuard instanceGuard(kMutexName);
 
     LogToFile(std::string("[main] SingleInstanceGuard created. Mutex handle valid: ") + (instanceGuard.getMutexHandle() != NULL && instanceGuard.getMutexHandle() != INVALID_HANDLE_VALUE ? "YES" : "NO") +
@@ -219,7 +219,7 @@ int main(int argc, char* argv[]) {
         LogToFile("[main] Another instance is already running (detected by alreadyRunning() == true).");
 
         if (argc >= 2 && argv[1] != nullptr) {
-            HWND hwnd = FindWindowW(L"MCRAW_PLAYER_IPC_WND_CLASS", nullptr);
+            HWND hwnd = FindWindowW(L"MCRAW_CONVERTER_IPC_WND_CLASS", nullptr);
             if (hwnd) {
                 LogToFile(std::string("[main] Found existing instance window (HWND: ") + std::to_string(reinterpret_cast<uintptr_t>(hwnd)) + "). Sending file: " + argv[1]);
                 std::filesystem::path fsPath(argv[1]);
@@ -234,7 +234,7 @@ int main(int argc, char* argv[]) {
                 LogToFile("[main] WM_COPYDATA sent.");
             }
             else {
-                LogToFile("[main] Could not find existing instance window by class MCRAW_PLAYER_IPC_WND_CLASS to forward arguments.");
+                LogToFile("[main] Could not find existing instance window by class MCRAW_CONVERTER_IPC_WND_CLASS to forward arguments.");
             }
         }
         else {
@@ -275,7 +275,7 @@ int main(int argc, char* argv[]) {
         std::string errorMsg = "[main] Input file not found or not a regular file: " + inPath;
         LogToFile(errorMsg);
 #ifdef _WIN32
-        MessageBoxA(NULL, errorMsg.c_str(), "Error - MCRAW Batcher", MB_OK | MB_ICONERROR);
+        MessageBoxA(NULL, errorMsg.c_str(), "Error - MCRAW Converter", MB_OK | MB_ICONERROR);
 #endif
         std::cerr << errorMsg << std::endl;
         return 1;
@@ -284,7 +284,7 @@ int main(int argc, char* argv[]) {
         std::string errorMsg = "[main] Input file must have a .mcraw extension: " + inPath;
         LogToFile(errorMsg);
 #ifdef _WIN32
-        MessageBoxA(NULL, errorMsg.c_str(), "Error - MCRAW Batcher", MB_OK | MB_ICONERROR);
+        MessageBoxA(NULL, errorMsg.c_str(), "Error - MCRAW Converter", MB_OK | MB_ICONERROR);
 #endif
         std::cerr << errorMsg << std::endl;
         return 1;
@@ -297,7 +297,7 @@ int main(int argc, char* argv[]) {
         if (!app.run()) {
             LogToFile("[main] App::run() returned false. Application will exit.");
 #ifdef _WIN32
-            MessageBoxA(NULL, "Application run failed. See mcraw_player_debug_log.txt for details.", "Runtime Error - MCRAW Batcher", MB_OK | MB_ICONERROR);
+            MessageBoxA(NULL, "Application run failed. See mcraw_converter_debug_log.txt for details.", "Runtime Error - MCRAW Converter", MB_OK | MB_ICONERROR);
 #endif
             std::cerr << "[main] App::run() returned false. Application will exit." << std::endl;
             return 1;
@@ -308,7 +308,7 @@ int main(int argc, char* argv[]) {
         std::string errorMsg = "[main] FATAL STD EXCEPTION: " + std::string(e.what());
         LogToFile(errorMsg);
 #ifdef _WIN32
-        MessageBoxA(NULL, errorMsg.c_str(), "Runtime Error - MCRAW Batcher", MB_OK | MB_ICONERROR);
+        MessageBoxA(NULL, errorMsg.c_str(), "Runtime Error - MCRAW Converter", MB_OK | MB_ICONERROR);
 #endif
         std::cerr << errorMsg << std::endl;
         return 1;
@@ -317,7 +317,7 @@ int main(int argc, char* argv[]) {
         std::string errorMsg = "[main] FATAL UNKNOWN EXCEPTION occurred.";
         LogToFile(errorMsg);
 #ifdef _WIN32
-        MessageBoxA(NULL, errorMsg.c_str(), "Runtime Error - MCRAW Batcher", MB_OK | MB_ICONERROR);
+        MessageBoxA(NULL, errorMsg.c_str(), "Runtime Error - MCRAW Converter", MB_OK | MB_ICONERROR);
 #endif
         std::cerr << errorMsg << std::endl;
         return 1;


### PR DESCRIPTION
## Summary
- rename Player/Batcher references to **Converter**
- update build output and compile definitions
- rename log paths to `Converter/logs`
- embed preview panel as standard child widget
- adjust single-instance IPC constants

## Testing
- `cmake -S . -B build -DCMAKE_BUILD_TYPE=Release`

------
https://chatgpt.com/codex/tasks/task_e_6878a98902688327bf7a3eef69f099e0