### PR TITLE
Embed preview playback in panel

### DIFF
--- a/include/App/App.h
+++ b/include/App/App.h
@@ -67,6 +67,7 @@ public:
     VkQueue m_graphicsQueue = VK_NULL_HANDLE;
     VkQueue m_presentQueue = VK_NULL_HANDLE;
     VkDescriptorPool m_imguiDescriptorPool = VK_NULL_HANDLE;
+    VkDescriptorSet m_previewTextureSet = VK_NULL_HANDLE;
     VkCommandPool m_commandPool = VK_NULL_HANDLE;
     VkRenderPass m_renderPass = VK_NULL_HANDLE;
 

--- a/src/App/AppCleanup.cpp
+++ b/src/App/AppCleanup.cpp
@@ -6,6 +6,7 @@
 #include "Graphics/Renderer_VK.h"
 #include "Utils/DebugLog.h"
 #include "Gui/GuiOverlay.h"
+#include <imgui_impl_vulkan.h>
 
 #include <iostream>
 #include <stdexcept>
@@ -209,6 +210,11 @@ void App::cleanupVulkan() {
 
     LogToFile("[App::cleanupVulkan] Cleaning up GuiOverlay (ImGui shutdown)...");
     GuiOverlay::cleanup();
+
+    if (m_previewTextureSet != VK_NULL_HANDLE) {
+        ImGui_ImplVulkan_RemoveTexture(m_previewTextureSet);
+        m_previewTextureSet = VK_NULL_HANDLE;
+    }
 
     if (m_imguiDescriptorPool != VK_NULL_HANDLE) {
         LogToFile("[App::cleanupVulkan] Destroying ImGui descriptor pool...");

--- a/src/App/AppInit.cpp
+++ b/src/App/AppInit.cpp
@@ -25,6 +25,7 @@
 #include "Utils/RawFrameBuffer.h"
 
 #include <imgui.h>
+#include <imgui_impl_vulkan.h>
 #include <nlohmann/json.hpp>
 #include <filesystem>
 #include <iostream>
@@ -869,6 +870,10 @@ void App::initImGuiVulkan() {
 
     GuiOverlay::setup(m_window, this);
     LogToFile("App::initImGuiVulkan GuiOverlay::setup() called.");
+    m_previewTextureSet = ImGui_ImplVulkan_AddTexture(
+        m_rendererVk->m_rawImageSampler,
+        m_rendererVk->m_rawImageView,
+        VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL);
 }
 
 void App::createPersistentStagingBuffers() {

--- a/src/App/AppLoop.cpp
+++ b/src/App/AppLoop.cpp
@@ -448,7 +448,8 @@ void App::drawFrame() {
         int ph = m_previewRect.h > 0 ? m_previewRect.h : m_windowHeight;
         int px = m_previewRect.x;
         int py = m_previewRect.y;
-        m_rendererVk->recordDrawCommands(cmd, m_currentFrame, pw, ph, px, py);
+        // Video rendering now handled via ImGui texture
+        (void)pw; (void)ph; (void)px; (void)py; // prevent unused warnings
     }
 
     if (m_uiOpacity > 0.0f) {

--- a/src/Gui/GuiRender.cpp
+++ b/src/Gui/GuiRender.cpp
@@ -194,8 +194,16 @@ namespace GuiOverlay {
         ImGui::Begin("ConverterMain", nullptr, ImGuiWindowFlags_NoDecoration | ImGuiWindowFlags_NoMove | ImGuiWindowFlags_NoBackground);
 
         ImGui::BeginChild("FileListPanel", ImVec2(vp->WorkSize.x * 0.5f, vp->WorkSize.y - 150), true);
-        if (ImGui::CollapsingHeader("Preview", &appInstance->m_previewOpen, ImGuiTreeNodeFlags_DefaultOpen)) {
-            ImGui::BeginChild("PreviewArea", ImVec2(0, 220), true);
+
+        ImGuiChildFlags previewChildFlags =
+            ImGuiChildFlags_Borders |
+            ImGuiChildFlags_AlwaysUseWindowPadding;
+        ImGuiWindowFlags previewFlags =
+            ImGuiWindowFlags_NoTitleBar |
+            ImGuiWindowFlags_NoResize |
+            ImGuiWindowFlags_NoCollapse |
+            ImGuiWindowFlags_NoMove;
+        ImGui::BeginChild("PreviewArea", ImVec2(0, 220), previewChildFlags, previewFlags);
             ImVec2 innerPos = ImGui::GetWindowPos();
             ImVec2 innerSize = ImGui::GetWindowSize();
             appInstance->m_previewRect.x = (int)(innerPos.x - vp->WorkPos.x);
@@ -269,12 +277,15 @@ namespace GuiOverlay {
             std::string curTimeStr = GuiUtils::format_mm_ss(curTime);
             std::string totalTimeStr = GuiUtils::format_mm_ss(totalTime);
             ImGui::Text("%s / %s  Frame %zu / %zu", curTimeStr.c_str(), totalTimeStr.c_str(), curIdx, total);
+
+            ImVec2 avail = ImGui::GetContentRegionAvail();
+            if (appInstance->m_previewTextureSet != VK_NULL_HANDLE && avail.x > 0 && avail.y > 0)
+            {
+                ImGui::Image((ImTextureID)appInstance->m_previewTextureSet, avail, ImVec2(0,1), ImVec2(1,0));
+            }
+
             ImGui::EndChild();
             ImGui::Separator();
-        } else {
-            appInstance->m_previewRect.w = 0;
-            appInstance->m_previewRect.h = 0;
-        }
 
         if (ImGui::Button("Add")) { appInstance->triggerOpenFileViaDialog(); }
         ImGui::SameLine();


### PR DESCRIPTION
## Summary
- add descriptor for preview image and clean up at shutdown
- stop direct draw call and feed frames into ImGui texture
- lock preview panel with ImGui child flags
- fix preview window flags for newer ImGui API

## Testing
- `cmake -B build -S . -DCMAKE_BUILD_TYPE=Release`
- `cmake --build build -j $(nproc)` *(fails: libavutil/frame.h not found)*


------
https://chatgpt.com/codex/tasks/task_e_6878b788a0fc8327bd70dd5b9bd56b53