### PR TITLE
Embed preview playback in panel

### DIFF
--- a/include/App/App.h
+++ b/include/App/App.h
@@ -27,6 +27,7 @@
 #include <GLFW/glfw3.h>
 #include <glm/glm.hpp>
 #include <vulkan/vulkan.h>
+#include <imgui.h>
 #include "Utils/vma_usage.h"
 
 #include "App/AppConfig.h"
@@ -67,6 +68,7 @@ public:
     VkQueue m_graphicsQueue = VK_NULL_HANDLE;
     VkQueue m_presentQueue = VK_NULL_HANDLE;
     VkDescriptorPool m_imguiDescriptorPool = VK_NULL_HANDLE;
+    ImTextureID m_previewTextureSet = 0;
     VkCommandPool m_commandPool = VK_NULL_HANDLE;
     VkRenderPass m_renderPass = VK_NULL_HANDLE;
 
@@ -88,6 +90,8 @@ public:
 
     int m_decodedWidth = 0;
     int m_decodedHeight = 0;
+    int m_previewImageW = 0;
+    int m_previewImageH = 0;
 
     PlaybackController* m_playbackController_ptr = nullptr;
     DecoderWrapper* m_decoderWrapper_ptr = nullptr;
@@ -141,7 +145,6 @@ public:
     int m_selectedBatchIndex = -1;
     char m_outputFolder[1024] = "";
     std::vector<ExportFormat> m_fileExportFormats;
-    bool m_previewOpen = true;
     struct PreviewRect {
         int x = 0;
         int y = 0;
@@ -308,6 +311,8 @@ private:
     void cleanupVulkan();
     void cleanupSwapChain();
     void recreateSwapChain();
+
+    void refreshPreviewTextureDescriptor();
 
     void drawFrame();
 

--- a/src/App/AppCleanup.cpp
+++ b/src/App/AppCleanup.cpp
@@ -6,6 +6,7 @@
 #include "Graphics/Renderer_VK.h"
 #include "Utils/DebugLog.h"
 #include "Gui/GuiOverlay.h"
+#include <imgui_impl_vulkan.h>
 
 #include <iostream>
 #include <stdexcept>
@@ -209,6 +210,11 @@ void App::cleanupVulkan() {
 
     LogToFile("[App::cleanupVulkan] Cleaning up GuiOverlay (ImGui shutdown)...");
     GuiOverlay::cleanup();
+
+    if (m_previewTextureSet != 0) {
+        ImGui_ImplVulkan_RemoveTexture((VkDescriptorSet)m_previewTextureSet);
+        m_previewTextureSet = 0;
+    }
 
     if (m_imguiDescriptorPool != VK_NULL_HANDLE) {
         LogToFile("[App::cleanupVulkan] Destroying ImGui descriptor pool...");

--- a/src/App/AppInit.cpp
+++ b/src/App/AppInit.cpp
@@ -25,6 +25,7 @@
 #include "Utils/RawFrameBuffer.h"
 
 #include <imgui.h>
+#include <imgui_impl_vulkan.h>
 #include <nlohmann/json.hpp>
 #include <filesystem>
 #include <iostream>
@@ -869,6 +870,7 @@ void App::initImGuiVulkan() {
 
     GuiOverlay::setup(m_window, this);
     LogToFile("App::initImGuiVulkan GuiOverlay::setup() called.");
+    refreshPreviewTextureDescriptor();
 }
 
 void App::createPersistentStagingBuffers() {
@@ -883,7 +885,8 @@ void App::createPersistentStagingBuffers() {
 
 #ifndef NDEBUG
     LogToFile(std::string("App::createPersistentStagingBuffers Staging buffer individual size: ") + std::to_string(bufferSize) +
-        " bytes (for max " + std::to_string(MAX_EXPECTED_WIDTH) + "x" + std::to_string(MAX_EXPECTED_HEIGHT) + " R16_UINT images).");
+        " bytes (for max " + std::to_string(MAX_EXPECTED_WIDTH) + "x" + std::to_string(MAX_EXPECTED_HEIGHT) +
+        " R16_UNORM images).");
 #endif
 
     if (kNumPersistentStagingBuffers == 0) {

--- a/src/App/AppLoop.cpp
+++ b/src/App/AppLoop.cpp
@@ -6,6 +6,7 @@
 #include "Graphics/Renderer_VK.h"
 #include "Utils/DebugLog.h"
 #include "Gui/GuiOverlay.h"
+#include <imgui_impl_vulkan.h>
 
 #include <chrono>
 #include <thread>
@@ -422,6 +423,12 @@ void App::drawFrame() {
                 m_containerOrientationTag,
                 m_containerFlipped
             );
+            if (m_rendererVk->getImageWidth() != m_previewImageW ||
+                m_rendererVk->getImageHeight() != m_previewImageH ||
+                m_previewTextureSet == 0)
+            {
+                refreshPreviewTextureDescriptor();
+            }
             clearColorValue.color = { {0.0f, 0.0f, 0.0f, 1.0f} };
         }
         else {
@@ -448,7 +455,8 @@ void App::drawFrame() {
         int ph = m_previewRect.h > 0 ? m_previewRect.h : m_windowHeight;
         int px = m_previewRect.x;
         int py = m_previewRect.y;
-        m_rendererVk->recordDrawCommands(cmd, m_currentFrame, pw, ph, px, py);
+        // Video rendering now handled via ImGui texture
+        (void)pw; (void)ph; (void)px; (void)py; // prevent unused warnings
     }
 
     if (m_uiOpacity > 0.0f) {
@@ -500,4 +508,19 @@ void App::drawFrame() {
     }
 
     m_currentFrame = (m_currentFrame + 1) % MAX_FRAMES_IN_FLIGHT;
+}
+
+void App::refreshPreviewTextureDescriptor() {
+    if (m_previewTextureSet != 0) {
+        ImGui_ImplVulkan_RemoveTexture((VkDescriptorSet)m_previewTextureSet);
+        m_previewTextureSet = 0;
+    }
+    if (m_rendererVk) {
+        m_previewTextureSet = (ImTextureID)ImGui_ImplVulkan_AddTexture(
+            m_rendererVk->m_rawImageSampler,
+            m_rendererVk->m_rawImageView,
+            VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL);
+        m_previewImageW = m_rendererVk->getImageWidth();
+        m_previewImageH = m_rendererVk->getImageHeight();
+    }
 }

--- a/src/Graphics/ImageResource.cpp
+++ b/src/Graphics/ImageResource.cpp
@@ -124,10 +124,13 @@ namespace ImageResource {
         imageInfo.extent.depth = 1;
         imageInfo.mipLevels = 1;
         imageInfo.arrayLayers = 1;
-        imageInfo.format = VK_FORMAT_R16_UINT;
+        // Use a single-channel normalized 16-bit format for preview frames
+        imageInfo.format = VK_FORMAT_R16_UNORM;
         imageInfo.tiling = VK_IMAGE_TILING_OPTIMAL;
         imageInfo.initialLayout = VK_IMAGE_LAYOUT_UNDEFINED;
-        imageInfo.usage = VK_IMAGE_USAGE_TRANSFER_DST_BIT | VK_IMAGE_USAGE_SAMPLED_BIT;
+        imageInfo.usage = VK_IMAGE_USAGE_TRANSFER_DST_BIT |
+                          VK_IMAGE_USAGE_SAMPLED_BIT |
+                          VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT;
         imageInfo.sharingMode = VK_SHARING_MODE_EXCLUSIVE;
         imageInfo.samples = VK_SAMPLE_COUNT_1_BIT;
 
@@ -140,7 +143,11 @@ namespace ImageResource {
         viewInfo.sType = VK_STRUCTURE_TYPE_IMAGE_VIEW_CREATE_INFO;
         viewInfo.image = renderer->m_rawImage;
         viewInfo.viewType = VK_IMAGE_VIEW_TYPE_2D;
-        viewInfo.format = VK_FORMAT_R16_UINT;
+        viewInfo.format = VK_FORMAT_R16_UNORM;
+        viewInfo.components.r = VK_COMPONENT_SWIZZLE_R;
+        viewInfo.components.g = VK_COMPONENT_SWIZZLE_R;
+        viewInfo.components.b = VK_COMPONENT_SWIZZLE_R;
+        viewInfo.components.a = VK_COMPONENT_SWIZZLE_R;
         viewInfo.subresourceRange.aspectMask = VK_IMAGE_ASPECT_COLOR_BIT;
         viewInfo.subresourceRange.baseMipLevel = 0;
         viewInfo.subresourceRange.levelCount = 1;

--- a/src/Gui/GuiRender.cpp
+++ b/src/Gui/GuiRender.cpp
@@ -194,8 +194,16 @@ namespace GuiOverlay {
         ImGui::Begin("ConverterMain", nullptr, ImGuiWindowFlags_NoDecoration | ImGuiWindowFlags_NoMove | ImGuiWindowFlags_NoBackground);
 
         ImGui::BeginChild("FileListPanel", ImVec2(vp->WorkSize.x * 0.5f, vp->WorkSize.y - 150), true);
-        if (ImGui::CollapsingHeader("Preview", &appInstance->m_previewOpen, ImGuiTreeNodeFlags_DefaultOpen)) {
-            ImGui::BeginChild("PreviewArea", ImVec2(0, 220), true);
+
+        ImGuiChildFlags previewChildFlags =
+            ImGuiChildFlags_Borders |
+            ImGuiChildFlags_AlwaysUseWindowPadding;
+        ImGuiWindowFlags previewFlags =
+            ImGuiWindowFlags_NoTitleBar |
+            ImGuiWindowFlags_NoResize |
+            ImGuiWindowFlags_NoCollapse |
+            ImGuiWindowFlags_NoMove;
+        ImGui::BeginChild("PreviewArea", ImVec2(0, 300), previewChildFlags, previewFlags);
             ImVec2 innerPos = ImGui::GetWindowPos();
             ImVec2 innerSize = ImGui::GetWindowSize();
             appInstance->m_previewRect.x = (int)(innerPos.x - vp->WorkPos.x);
@@ -269,12 +277,17 @@ namespace GuiOverlay {
             std::string curTimeStr = GuiUtils::format_mm_ss(curTime);
             std::string totalTimeStr = GuiUtils::format_mm_ss(totalTime);
             ImGui::Text("%s / %s  Frame %zu / %zu", curTimeStr.c_str(), totalTimeStr.c_str(), curIdx, total);
+
+            ImVec2 avail = ImGui::GetContentRegionAvail();
+            if (appInstance->m_previewTextureSet != 0 && avail.x > 0 && avail.y > 0)
+            {
+                ImGui::Image(appInstance->m_previewTextureSet, avail,
+                             ImVec2(0,1), ImVec2(1,0),
+                             ImVec4(16.0f, 16.0f, 16.0f, 1.0f));
+            }
+
             ImGui::EndChild();
             ImGui::Separator();
-        } else {
-            appInstance->m_previewRect.w = 0;
-            appInstance->m_previewRect.h = 0;
-        }
 
         if (ImGui::Button("Add")) { appInstance->triggerOpenFileViaDialog(); }
         ImGui::SameLine();


### PR DESCRIPTION
## Summary
- create preview image as R16_UNORM and swizzle R into all channels
- log staging buffer size for R16_UNORM preview images
- brighten preview image by applying tint when drawing in ImGui

## Testing
- `cmake -B build -S . -DCMAKE_BUILD_TYPE=Release`
- `cmake --build build -j $(nproc)` *(fails: libavutil/frame.h missing)*

------
https://chatgpt.com/codex/tasks/task_e_6878b788a0fc8327bd70dd5b9bd56b53