### PR TITLE
Embed preview pane

### DIFF
--- a/include/App/App.h
+++ b/include/App/App.h
@@ -68,7 +68,7 @@ public:
     VkQueue m_graphicsQueue = VK_NULL_HANDLE;
     VkQueue m_presentQueue = VK_NULL_HANDLE;
     VkDescriptorPool m_imguiDescriptorPool = VK_NULL_HANDLE;
-    ImTextureID m_previewTextureSet = 0;
+    VkDescriptorImageInfo m_previewDesc{};
     VkCommandPool m_commandPool = VK_NULL_HANDLE;
     VkRenderPass m_renderPass = VK_NULL_HANDLE;
 
@@ -90,8 +90,6 @@ public:
 
     int m_decodedWidth = 0;
     int m_decodedHeight = 0;
-    int m_previewImageW = 0;
-    int m_previewImageH = 0;
 
     PlaybackController* m_playbackController_ptr = nullptr;
     DecoderWrapper* m_decoderWrapper_ptr = nullptr;
@@ -122,6 +120,8 @@ public:
     void exportCurrentClipToHEVC_AMD(const std::string& outputPath = "");
     void convertCurrentClipToHEVC_AMD(const std::string& outputPath = "");
     void performSeek(size_t new_frame_index);
+    void play();
+    void stop();
     void triggerOpenFileViaDialog();
     std::vector<std::string> openMultipleMcrawDialog();
     void loadFileForExport(const std::string& path);
@@ -129,6 +129,9 @@ public:
     void showActionMessage(const std::string& msg);
 
 #ifdef MOTIONCAM_CONVERTER
+    ImTextureID  m_previewTex   = 0;
+    int          m_previewWidth = 0;
+    int          m_previewHeight = 0;
     enum class ExportFormat {
         PRORES_CPU,
         PRORES_GPU,
@@ -312,7 +315,7 @@ private:
     void cleanupSwapChain();
     void recreateSwapChain();
 
-    void refreshPreviewTextureDescriptor();
+    void updatePreviewDescriptor();
 
     void drawFrame();
 

--- a/include/Graphics/Descriptor.h
+++ b/include/Graphics/Descriptor.h
@@ -4,13 +4,12 @@
 #include <vulkan/vulkan.h>
 
 class Renderer_VK; // Forward declaration
-
 namespace Descriptor {
 
-	bool createDescriptorSetLayout(Renderer_VK* renderer);
-	bool createDescriptorPool(Renderer_VK* renderer);
-	bool createDescriptorSets(Renderer_VK* renderer);
-	void updateDescriptorSetsWithNewRawImage(Renderer_VK* renderer);
+        bool createDescriptorSetLayout(Renderer_VK* renderer);
+        bool createDescriptorPool(Renderer_VK* renderer);
+        bool createDescriptorSets(Renderer_VK* renderer);
+        void updateDescriptorSetsWithNewRawImage(Renderer_VK* renderer);
 
 	// Uniform buffer functions are closely related to descriptors
 	bool createUniformBuffers(Renderer_VK* renderer);

--- a/src/App/AppCleanup.cpp
+++ b/src/App/AppCleanup.cpp
@@ -211,9 +211,9 @@ void App::cleanupVulkan() {
     LogToFile("[App::cleanupVulkan] Cleaning up GuiOverlay (ImGui shutdown)...");
     GuiOverlay::cleanup();
 
-    if (m_previewTextureSet != 0) {
-        ImGui_ImplVulkan_RemoveTexture((VkDescriptorSet)m_previewTextureSet);
-        m_previewTextureSet = 0;
+    if (m_previewTex != 0) {
+        ImGui_ImplVulkan_RemoveTexture((VkDescriptorSet)m_previewTex);
+        m_previewTex = 0;
     }
 
     if (m_imguiDescriptorPool != VK_NULL_HANDLE) {

--- a/src/App/AppIO.cpp
+++ b/src/App/AppIO.cpp
@@ -2735,6 +2735,21 @@ void App::setPlaybackMode(PlaybackController::PlaybackMode mode) {
         " to " + std::to_string(static_cast<int>(mode)));
 }
 
+void App::play() {
+    if (m_playbackController_ptr && m_playbackController_ptr->isPaused()) {
+        m_playbackController_ptr->togglePause();
+    }
+}
+
+void App::stop() {
+    if (m_playbackController_ptr) {
+        m_playbackController_ptr->setPlaybackMode(PlaybackController::PlaybackMode::REALTIME);
+        performSeek(0);
+        if (!m_playbackController_ptr->isPaused())
+            m_playbackController_ptr->togglePause();
+    }
+}
+
 void App::loadFileForExport(const std::string& path) {
     using namespace std::chrono;
     namespace fs = std::filesystem;

--- a/src/App/AppInit.cpp
+++ b/src/App/AppInit.cpp
@@ -870,7 +870,16 @@ void App::initImGuiVulkan() {
 
     GuiOverlay::setup(m_window, this);
     LogToFile("App::initImGuiVulkan GuiOverlay::setup() called.");
-    refreshPreviewTextureDescriptor();
+
+    m_previewTex = (ImTextureID)ImGui_ImplVulkan_AddTexture(
+        m_rendererVk->m_rawImageSampler,
+        m_rendererVk->m_rawImageView,
+        VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL);
+    m_previewDesc.sampler = m_rendererVk->m_rawImageSampler;
+    m_previewDesc.imageView = m_rendererVk->m_rawImageView;
+    m_previewDesc.imageLayout = VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL;
+    m_previewWidth = m_rendererVk->getImageWidth();
+    m_previewHeight = m_rendererVk->getImageHeight();
 }
 
 void App::createPersistentStagingBuffers() {

--- a/src/App/AppLoop.cpp
+++ b/src/App/AppLoop.cpp
@@ -423,12 +423,7 @@ void App::drawFrame() {
                 m_containerOrientationTag,
                 m_containerFlipped
             );
-            if (m_rendererVk->getImageWidth() != m_previewImageW ||
-                m_rendererVk->getImageHeight() != m_previewImageH ||
-                m_previewTextureSet == 0)
-            {
-                refreshPreviewTextureDescriptor();
-            }
+            updatePreviewDescriptor();
             clearColorValue.color = { {0.0f, 0.0f, 0.0f, 1.0f} };
         }
         else {
@@ -457,7 +452,9 @@ void App::drawFrame() {
         int py = m_previewRect.y;
         float blackNorm = static_cast<float>(m_staticBlack) / 65535.0f;
         float whiteNorm = static_cast<float>(m_staticWhite) / 65535.0f;
+#ifndef MOTIONCAM_CONVERTER
         m_rendererVk->recordDrawCommands(cmd, m_currentFrame, pw, ph, px, py, blackNorm, whiteNorm);
+#endif
     }
 
     if (m_uiOpacity > 0.0f) {
@@ -511,17 +508,26 @@ void App::drawFrame() {
     m_currentFrame = (m_currentFrame + 1) % MAX_FRAMES_IN_FLIGHT;
 }
 
-void App::refreshPreviewTextureDescriptor() {
-    if (m_previewTextureSet != 0) {
-        ImGui_ImplVulkan_RemoveTexture((VkDescriptorSet)m_previewTextureSet);
-        m_previewTextureSet = 0;
-    }
-    if (m_rendererVk) {
-        m_previewTextureSet = (ImTextureID)ImGui_ImplVulkan_AddTexture(
-            m_rendererVk->m_rawImageSampler,
-            m_rendererVk->m_rawImageView,
-            VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL);
-        m_previewImageW = m_rendererVk->getImageWidth();
-        m_previewImageH = m_rendererVk->getImageHeight();
-    }
+void App::updatePreviewDescriptor() {
+    if (m_previewTex == 0 || !m_rendererVk) return;
+
+    int newW = m_rendererVk->getImageWidth();
+    int newH = m_rendererVk->getImageHeight();
+    if (newW == m_previewWidth && newH == m_previewHeight)
+        return;
+
+    m_previewDesc.sampler = m_rendererVk->m_rawImageSampler;
+    m_previewDesc.imageView = m_rendererVk->m_rawImageView;
+    m_previewDesc.imageLayout = VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL;
+
+    VkWriteDescriptorSet write{};
+    write.sType = VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET;
+    write.dstSet = (VkDescriptorSet)m_previewTex;
+    write.descriptorCount = 1;
+    write.descriptorType = VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER;
+    write.pImageInfo = &m_previewDesc;
+    vkUpdateDescriptorSets(m_device, 1, &write, 0, nullptr);
+
+    m_previewWidth = newW;
+    m_previewHeight = newH;
 }

--- a/src/Graphics/Descriptor.cpp
+++ b/src/Graphics/Descriptor.cpp
@@ -3,6 +3,7 @@
 #include "Graphics/VulkanHelpers.h" // For VK_CHECK_RENDERER
 #include "Utils/DebugLog.h"
 
+
 #include <array> // For std::array
 
 namespace Descriptor {

--- a/src/Gui/GuiRender.cpp
+++ b/src/Gui/GuiRender.cpp
@@ -191,18 +191,23 @@ namespace GuiOverlay {
         ImGui::SetNextWindowPos(vp->WorkPos);
         ImGui::SetNextWindowSize(vp->WorkSize);
         ImGui::SetNextWindowBgAlpha(0.f);
-        ImGui::Begin("ConverterMain", nullptr, ImGuiWindowFlags_NoDecoration | ImGuiWindowFlags_NoMove | ImGuiWindowFlags_NoBackground);
+        ImGui::Begin("ConverterMain", nullptr,
+                    ImGuiWindowFlags_NoDecoration |
+                    ImGuiWindowFlags_NoMove |
+                    ImGuiWindowFlags_NoBackground);
 
         ImGui::BeginChild("FileListPanel", ImVec2(vp->WorkSize.x * 0.5f, vp->WorkSize.y - 150), true);
 
         ImGuiChildFlags previewChildFlags =
-            ImGuiChildFlags_Borders |
             ImGuiChildFlags_AlwaysUseWindowPadding;
         ImGuiWindowFlags previewFlags =
             ImGuiWindowFlags_NoTitleBar |
             ImGuiWindowFlags_NoResize |
+            ImGuiWindowFlags_NoMove |
             ImGuiWindowFlags_NoCollapse |
-            ImGuiWindowFlags_NoMove;
+            ImGuiWindowFlags_NoScrollbar;
+
+        ImGui::PushStyleColor(ImGuiCol_ChildBg, ImVec4(0.1f, 0.1f, 0.1f, 1.0f));
         ImGui::BeginChild("PreviewArea", ImVec2(0, 300), previewChildFlags, previewFlags);
             ImVec2 innerPos = ImGui::GetWindowPos();
             ImVec2 innerSize = ImGui::GetWindowSize();
@@ -210,84 +215,12 @@ namespace GuiOverlay {
             appInstance->m_previewRect.y = (int)(innerPos.y - vp->WorkPos.y);
             appInstance->m_previewRect.w = (int)innerSize.x;
             appInstance->m_previewRect.h = (int)innerSize.y;
-            bool paused = true;
-            if (appInstance->m_playbackController_ptr)
-                paused = appInstance->m_playbackController_ptr->isPaused();
-            if (ImGui::Button(paused ? "Play" : "Pause")) {
-                if (appInstance->m_playbackController_ptr)
-                    appInstance->m_playbackController_ptr->togglePause();
-            }
-            ImGui::SameLine();
-            if (ImGui::Button("Stop")) {
-                if (appInstance->m_playbackController_ptr) {
-                    appInstance->m_playbackController_ptr->setPlaybackMode(PlaybackController::PlaybackMode::REALTIME);
-                    appInstance->performSeek(0);
-                    if (!appInstance->m_playbackController_ptr->isPaused())
-                        appInstance->m_playbackController_ptr->togglePause();
-                }
-            }
-            ImGui::SameLine();
-            if (ImGui::Button("Prev Clip")) {
-                if (!appInstance->m_fileList.empty()) {
-                    int newIndex = appInstance->m_selectedBatchIndex > 0 ? appInstance->m_selectedBatchIndex - 1 : 0;
-                    if (newIndex != appInstance->m_selectedBatchIndex) {
-                        bool oldFirst = appInstance->m_firstFileLoaded;
-                        appInstance->m_firstFileLoaded = true;
-                        appInstance->m_selectedBatchIndex = newIndex;
-                        appInstance->loadFileAtIndex(newIndex);
-                        appInstance->m_firstFileLoaded = oldFirst;
-                    }
-                }
-            }
-            ImGui::SameLine();
-            if (ImGui::Button("Next Clip")) {
-                if (!appInstance->m_fileList.empty()) {
-                    int newIndex = appInstance->m_selectedBatchIndex + 1;
-                    if (newIndex >= (int)appInstance->m_fileList.size()) newIndex = appInstance->m_selectedBatchIndex;
-                    if (newIndex != appInstance->m_selectedBatchIndex) {
-                        bool oldFirst = appInstance->m_firstFileLoaded;
-                        appInstance->m_firstFileLoaded = true;
-                        appInstance->m_selectedBatchIndex = newIndex;
-                        appInstance->loadFileAtIndex(newIndex);
-                        appInstance->m_firstFileLoaded = oldFirst;
-                    }
-                }
-            }
-            size_t curIdx = 0, total = 0;
-            if (appInstance->m_playbackController_ptr && appInstance->m_decoderWrapper_ptr && appInstance->m_decoderWrapper_ptr->getDecoder()) {
-                curIdx = appInstance->m_playbackController_ptr->getCurrentFrameIndex();
-                total = appInstance->m_decoderWrapper_ptr->getDecoder()->getFrames().size();
-            }
-            float prog = total ? (float)curIdx / (float)total : 0.f;
-            if (ImGui::SliderFloat("Seek", &prog, 0.f, 1.f)) {
-                if (appInstance->m_decoderWrapper_ptr) {
-                    size_t newIdx = static_cast<size_t>(prog * total);
-                    appInstance->performSeek(newIdx);
-                }
-            }
-            double curTime = 0.0, totalTime = 0.0;
-            if (appInstance->m_decoderWrapper_ptr && appInstance->m_decoderWrapper_ptr->getDecoder()) {
-                const auto& frames = appInstance->m_decoderWrapper_ptr->getDecoder()->getFrames();
-                if (!frames.empty()) {
-                    int64_t firstTs = frames.front();
-                    if (curIdx < frames.size()) curTime = static_cast<double>(frames[curIdx] - firstTs) * 1e-9;
-                    totalTime = static_cast<double>(frames.back() - firstTs) * 1e-9;
-                }
-            }
-            std::string curTimeStr = GuiUtils::format_mm_ss(curTime);
-            std::string totalTimeStr = GuiUtils::format_mm_ss(totalTime);
-            ImGui::Text("%s / %s  Frame %zu / %zu", curTimeStr.c_str(), totalTimeStr.c_str(), curIdx, total);
-
             ImVec2 avail = ImGui::GetContentRegionAvail();
-            if (appInstance->m_previewTextureSet != 0 && avail.x > 0 && avail.y > 0)
-            {
-                ImGui::Image(appInstance->m_previewTextureSet,
-                             avail,
-                             ImVec2(0,1), ImVec2(1,0));
-            }
-
-            ImGui::EndChild();
-            ImGui::Separator();
+            if (appInstance->m_previewTex && avail.x > 0 && avail.y > 0)
+                ImGui::Image(appInstance->m_previewTex, avail, ImVec2(0,1), ImVec2(1,0));
+        ImGui::EndChild();
+        ImGui::PopStyleColor();
+        ImGui::Separator();
 
         if (ImGui::Button("Add")) { appInstance->triggerOpenFileViaDialog(); }
         ImGui::SameLine();


### PR DESCRIPTION
## Summary
- keep preview texture handle and dimensions in App
- update preview descriptor only when image size changes
- remove ImGui texture reallocations and fullscreen draws
- simplify preview pane layout and anchor in Converter main window

## Testing
- `cmake -S . -B build`
- `cmake --build build -j4` *(fails: libavutil/frame.h missing)*

------
https://chatgpt.com/codex/tasks/task_e_6879131aa624832788df0c6c31337192