### PR TITLE
Fix preview area flags and Y offset

### DIFF
--- a/src/App/AppLoop.cpp
+++ b/src/App/AppLoop.cpp
@@ -449,7 +449,8 @@ void App::drawFrame() {
         int pw = m_previewRect.w > 0 ? m_previewRect.w : m_windowWidth;
         int ph = m_previewRect.h > 0 ? m_previewRect.h : m_windowHeight;
         int px = m_previewRect.x;
-        int py = m_previewRect.y;
+        int py_top = m_previewRect.y;
+        int py = m_windowHeight - (py_top + ph);
         float blackNorm = static_cast<float>(m_staticBlack) / 65535.0f;
         float whiteNorm = static_cast<float>(m_staticWhite) / 65535.0f;
 #ifndef MOTIONCAM_CONVERTER

--- a/src/Gui/GuiRender.cpp
+++ b/src/Gui/GuiRender.cpp
@@ -199,6 +199,7 @@ namespace GuiOverlay {
         ImGui::BeginChild("FileListPanel", ImVec2(vp->WorkSize.x * 0.5f, vp->WorkSize.y - 150), true);
 
         ImGuiChildFlags previewChildFlags =
+            ImGuiChildFlags_Borders |
             ImGuiChildFlags_AlwaysUseWindowPadding;
         ImGuiWindowFlags previewFlags =
             ImGuiWindowFlags_NoTitleBar |


### PR DESCRIPTION
## Summary
- ensure preview child window has borders enabled
- draw video quad using Vulkan coordinates by flipping Y offset

## Testing
- `cmake -S . -B build -DCMAKE_BUILD_TYPE=Release`
- `cmake --build build -j $(nproc)` *(fails: libavutil/frame.h missing)*

------
https://chatgpt.com/codex/tasks/task_e_6879ea6413308327aee3820af6384ecd