### PR TITLE
Implement compute-preview pipeline

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -109,6 +109,7 @@ set(SHADER_FILES
     "${APP_SHADERS_SRC_DIR}/fullscreen_quad.vert"
     "${APP_SHADERS_SRC_DIR}/image_process.frag"
     "${APP_SHADERS_SRC_DIR}/raw_to_yuv422.comp"
+    "${APP_SHADERS_SRC_DIR}/raw_to_rgba.comp"
 )
 set(COMPILED_SHADER_OUTPUTS "")
 foreach(SHADER_INPUT_FILE ${SHADER_FILES})

--- a/include/App/App.h
+++ b/include/App/App.h
@@ -129,9 +129,11 @@ public:
     void showActionMessage(const std::string& msg);
 
 #ifdef MOTIONCAM_CONVERTER
-    ImTextureID  m_previewTex   = 0;
-    int          m_previewWidth = 0;
-    int          m_previewHeight = 0;
+    ImTextureID  m_previewTexID   = 0;
+    int          m_previewWidth   = 0;
+    int          m_previewHeight  = 0;
+    VkSampler    m_previewSampler = VK_NULL_HANDLE;
+    VkImageView  m_previewView    = VK_NULL_HANDLE;
     enum class ExportFormat {
         PRORES_CPU,
         PRORES_GPU,

--- a/include/Graphics/ImageResource.h
+++ b/include/Graphics/ImageResource.h
@@ -10,6 +10,8 @@ namespace ImageResource {
 
     bool createRawImageResources(Renderer_VK* renderer, int width, int height);
     void cleanupRawImageResources(Renderer_VK* renderer);
+    bool createPreviewImage(Renderer_VK* renderer, int width, int height);
+    void cleanupPreviewImage(Renderer_VK* renderer);
 
     void transitionImageLayout(
         VkDevice device,

--- a/include/Graphics/Renderer_VK.h
+++ b/include/Graphics/Renderer_VK.h
@@ -76,6 +76,9 @@ public:
     int getImageHeight() const;
     void resetDimensions();
     void ensureRawImageCapacity(uint32_t w, uint32_t h);
+    void runPreviewCompute(VkCommandBuffer cmd, int width, int height,
+                           float black, float white, const glm::mat3& ccm,
+                           float wbR, float wbG, float wbB, int cfa);
 
     // Public members needed by helper namespaces (e.g., ImageResource, Pipeline, Descriptor)
     // These allow the namespaced functions to operate on Renderer_VK's state.
@@ -90,6 +93,11 @@ public:
     VkImageView m_rawImageView = VK_NULL_HANDLE;
     VkSampler m_rawImageSampler = VK_NULL_HANDLE;
 
+    VkImage m_previewImage = VK_NULL_HANDLE;
+    VmaAllocation m_previewImageAlloc = VK_NULL_HANDLE;
+    VkImageView m_previewView = VK_NULL_HANDLE;
+    VkSampler m_previewSampler = VK_NULL_HANDLE;
+
     std::vector<VkBuffer> m_uniformBuffers;
     std::vector<VmaAllocation> m_uniformBufferAllocations;
     std::vector<void*> m_uniformBuffersMapped;
@@ -99,6 +107,12 @@ public:
     VkPipeline m_graphicsPipeline = VK_NULL_HANDLE;
     std::vector<VkDescriptorSet> m_descriptorSets;
     VkDescriptorPool m_descriptorPool = VK_NULL_HANDLE;
+
+    VkPipeline m_previewPipeline = VK_NULL_HANDLE;
+    VkPipelineLayout m_previewPipelineLayout = VK_NULL_HANDLE;
+    VkDescriptorSetLayout m_previewSetLayout = VK_NULL_HANDLE;
+    VkDescriptorPool m_previewDescPool = VK_NULL_HANDLE;
+    VkDescriptorSet m_previewDescSet = VK_NULL_HANDLE;
 
     uint32_t m_swapChainImageCount = 0; // Needed by Descriptor helpers
 
@@ -147,6 +161,8 @@ private:
     friend void Descriptor::updateDescriptorSetsWithNewRawImage(Renderer_VK* renderer);
     friend bool Descriptor::createUniformBuffers(Renderer_VK* renderer);
     friend void Descriptor::cleanupUniformBuffers(Renderer_VK* renderer);
+    friend bool ImageResource::createPreviewImage(Renderer_VK* renderer, int width, int height);
+    friend void ImageResource::cleanupPreviewImage(Renderer_VK* renderer);
 };
 
 #endif // RENDERER_VK_H

--- a/shaders/image_process.frag
+++ b/shaders/image_process.frag
@@ -11,8 +11,5 @@ layout(location = 0) in vec2 inTexCoord;
 layout(location = 0) out vec4 outColor;
 
 void main() {
-    float rawNorm = texture(u_tex, inTexCoord).r;
-    float l = (rawNorm - pc.blackNorm) / (pc.whiteNorm - pc.blackNorm);
-    l = clamp(l, 0.0, 1.0);
-    outColor = vec4(l, l, l, 1.0);
+    outColor = texture(u_tex, inTexCoord);
 }

--- a/shaders/raw_to_rgba.comp
+++ b/shaders/raw_to_rgba.comp
@@ -1,0 +1,89 @@
+#version 460
+#extension GL_EXT_shader_explicit_arithmetic_types_int64 : enable
+#extension GL_EXT_shader_16bit_storage               : require
+
+layout(set = 0, binding = 0, r16ui   ) readonly  uniform uimage2D  rawImg;
+layout(set = 0, binding = 1, rgba8  ) writeonly uniform image2D  outImg;
+
+layout(push_constant, std430) uniform PC {
+    uint   width, height;
+    uint   cfaType;
+    float  wbR, wbG, wbB;
+    mat3   colMat;
+    uint   black, white;
+} pc;
+
+uint readRaw(uint x, uint y) { return imageLoad(rawImg, ivec2(x, y)).r; }
+
+float normRaw(uint r){
+    return clamp(float(r) - float(pc.black), 0.0, float(pc.white - pc.black))
+         / float(pc.white - pc.black);
+}
+
+#define RAW(xx,yy) normRaw(readRaw(xx,yy))
+
+vec3 bayerToRGB(uint x, uint y)
+{
+    bool xe = (x & 1u) == 0u;
+    bool ye = (y & 1u) == 0u;
+    float r = 0.0, g = 0.0, b = 0.0;
+
+    switch(pc.cfaType)
+    {
+    case 0u:
+        if(ye){
+            if(xe){ b=RAW(x,y); g=(RAW(x-1,y)+RAW(x+1,y)+RAW(x,y-1)+RAW(x,y+1))*0.25; r=(RAW(x-1,y-1)+RAW(x+1,y-1)+RAW(x-1,y+1)+RAW(x+1,y+1))*0.25; }
+            else   { g=RAW(x,y); b=(RAW(x-1,y)+RAW(x+1,y))*0.5; r=(RAW(x,y-1)+RAW(x,y+1))*0.5; }
+        }else{
+            if(xe){ g=RAW(x,y); b=(RAW(x,y-1)+RAW(x,y+1))*0.5; r=(RAW(x-1,y)+RAW(x+1,y))*0.5; }
+            else   { r=RAW(x,y); g=(RAW(x-1,y)+RAW(x+1,y)+RAW(x,y-1)+RAW(x,y+1))*0.25; b=(RAW(x-1,y-1)+RAW(x+1,y-1)+RAW(x-1,y+1)+RAW(x+1,y+1))*0.25; }
+        }
+        break;
+    case 1u:
+        if(ye){
+            if(xe){ r=RAW(x,y); g=(RAW(x-1,y)+RAW(x+1,y)+RAW(x,y-1)+RAW(x,y+1))*0.25; b=(RAW(x-1,y-1)+RAW(x+1,y-1)+RAW(x-1,y+1)+RAW(x+1,y+1))*0.25; }
+            else   { g=RAW(x,y); r=(RAW(x-1,y)+RAW(x+1,y))*0.5; b=(RAW(x,y-1)+RAW(x,y+1))*0.5; }
+        }else{
+            if(xe){ g=RAW(x,y); r=(RAW(x,y-1)+RAW(x,y+1))*0.5; b=(RAW(x-1,y)+RAW(x+1,y))*0.5; }
+            else   { b=RAW(x,y); g=(RAW(x-1,y)+RAW(x+1,y)+RAW(x,y-1)+RAW(x,y+1))*0.25; r=(RAW(x-1,y-1)+RAW(x+1,y-1)+RAW(x-1,y+1)+RAW(x+1,y+1))*0.25; }
+        }
+        break;
+    case 2u:
+        if(ye){
+            if(xe){ g=RAW(x,y); b=(RAW(x-1,y)+RAW(x+1,y))*0.5; r=(RAW(x,y-1)+RAW(x,y+1))*0.5; }
+            else   { b=RAW(x,y); g=(RAW(x-1,y)+RAW(x+1,y)+RAW(x,y-1)+RAW(x,y+1))*0.25; r=(RAW(x-1,y-1)+RAW(x+1,y-1)+RAW(x-1,y+1)+RAW(x+1,y+1))*0.25; }
+        }else{
+            if(xe){ r=RAW(x,y); g=(RAW(x-1,y)+RAW(x+1,y)+RAW(x,y-1)+RAW(x,y+1))*0.25; b=(RAW(x-1,y-1)+RAW(x+1,y-1)+RAW(x-1,y+1)+RAW(x+1,y+1))*0.25; }
+            else   { g=RAW(x,y); r=(RAW(x-1,y)+RAW(x+1,y))*0.5; b=(RAW(x,y-1)+RAW(x,y+1))*0.5; }
+        }
+        break;
+    default:
+        if(ye){
+            if(xe){ g=RAW(x,y); r=(RAW(x-1,y)+RAW(x+1,y))*0.5; b=(RAW(x,y-1)+RAW(x,y+1))*0.5; }
+            else   { r=RAW(x,y); g=(RAW(x-1,y)+RAW(x+1,y)+RAW(x,y-1)+RAW(x,y+1))*0.25; b=(RAW(x-1,y-1)+RAW(x+1,y-1)+RAW(x-1,y+1)+RAW(x+1,y+1))*0.25; }
+        }else{
+            if(xe){ b=RAW(x,y); g=(RAW(x-1,y)+RAW(x+1,y)+RAW(x,y-1)+RAW(x,y+1))*0.25; r=(RAW(x-1,y-1)+RAW(x+1,y-1)+RAW(x-1,y+1)+RAW(x+1,y+1))*0.25; }
+            else   { g=RAW(x,y); b=(RAW(x-1,y)+RAW(x+1,y))*0.5; r=(RAW(x,y-1)+RAW(x,y+1))*0.5; }
+        }
+        break;
+    }
+
+    vec3 rgb = vec3(r,g,b);
+    rgb *= vec3(pc.wbR, pc.wbG, pc.wbB);
+    rgb  = pc.colMat * rgb;
+    return clamp(rgb, 0.0, 1.0);
+}
+
+vec3 encodeSRGB(vec3 v){
+    vec3 lo = v * 12.92;
+    vec3 hi = 1.055 * pow(v, vec3(1.0/2.4)) - 0.055;
+    return mix(hi, lo, lessThanEqual(v, vec3(0.0031308)));
+}
+
+layout(local_size_x = 16, local_size_y = 16, local_size_z = 1) in;
+void main(){
+    uvec2 gid = gl_GlobalInvocationID.xy;
+    if(gid.x >= pc.width || gid.y >= pc.height) return;
+    vec3 rgb = encodeSRGB(bayerToRGB(gid.x, gid.y));
+    imageStore(outImg, ivec2(gid), vec4(rgb,1.0));
+}

--- a/src/App/AppCleanup.cpp
+++ b/src/App/AppCleanup.cpp
@@ -211,10 +211,12 @@ void App::cleanupVulkan() {
     LogToFile("[App::cleanupVulkan] Cleaning up GuiOverlay (ImGui shutdown)...");
     GuiOverlay::cleanup();
 
-    if (m_previewTex != 0) {
-        ImGui_ImplVulkan_RemoveTexture((VkDescriptorSet)m_previewTex);
-        m_previewTex = 0;
+    if (m_previewTexID) {
+        ImGui_ImplVulkan_RemoveTexture((VkDescriptorSet)m_previewTexID);
+        m_previewTexID = 0;
     }
+    m_previewSampler = VK_NULL_HANDLE;
+    m_previewView = VK_NULL_HANDLE;
 
     if (m_imguiDescriptorPool != VK_NULL_HANDLE) {
         LogToFile("[App::cleanupVulkan] Destroying ImGui descriptor pool...");

--- a/src/App/AppInit.cpp
+++ b/src/App/AppInit.cpp
@@ -871,14 +871,14 @@ void App::initImGuiVulkan() {
     GuiOverlay::setup(m_window, this);
     LogToFile("App::initImGuiVulkan GuiOverlay::setup() called.");
 
-    m_previewTex = (ImTextureID)ImGui_ImplVulkan_AddTexture(
-        m_rendererVk->m_rawImageSampler,
-        m_rendererVk->m_rawImageView,
+    m_previewTexID = (ImTextureID)ImGui_ImplVulkan_AddTexture(
+        m_rendererVk->m_previewSampler,
+        m_rendererVk->m_previewView,
         VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL);
-    m_previewDesc.sampler = m_rendererVk->m_rawImageSampler;
-    m_previewDesc.imageView = m_rendererVk->m_rawImageView;
+    m_previewSampler = m_rendererVk->m_previewSampler;
+    m_previewView    = m_rendererVk->m_previewView;
     m_previewDesc.imageLayout = VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL;
-    m_previewWidth = m_rendererVk->getImageWidth();
+    m_previewWidth  = m_rendererVk->getImageWidth();
     m_previewHeight = m_rendererVk->getImageHeight();
 }
 

--- a/src/App/AppLoop.cpp
+++ b/src/App/AppLoop.cpp
@@ -509,20 +509,20 @@ void App::drawFrame() {
 }
 
 void App::updatePreviewDescriptor() {
-    if (m_previewTex == 0 || !m_rendererVk) return;
+    if (m_previewTexID == 0 || !m_rendererVk) return;
 
     int newW = m_rendererVk->getImageWidth();
     int newH = m_rendererVk->getImageHeight();
     if (newW == m_previewWidth && newH == m_previewHeight)
         return;
 
-    m_previewDesc.sampler = m_rendererVk->m_rawImageSampler;
-    m_previewDesc.imageView = m_rendererVk->m_rawImageView;
+    m_previewDesc.sampler = m_rendererVk->m_previewSampler;
+    m_previewDesc.imageView = m_rendererVk->m_previewView;
     m_previewDesc.imageLayout = VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL;
 
     VkWriteDescriptorSet write{};
     write.sType = VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET;
-    write.dstSet = (VkDescriptorSet)m_previewTex;
+    write.dstSet = (VkDescriptorSet)m_previewTexID;
     write.descriptorCount = 1;
     write.descriptorType = VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER;
     write.pImageInfo = &m_previewDesc;

--- a/src/Graphics/Descriptor.cpp
+++ b/src/Graphics/Descriptor.cpp
@@ -207,8 +207,8 @@ namespace Descriptor {
             LogToFile("[Descriptor::updateDescriptorSetsWithNewRawImage] No descriptor sets to update.");
             return;
         }
-        if (renderer->m_rawImageView == VK_NULL_HANDLE || renderer->m_rawImageSampler == VK_NULL_HANDLE) {
-            LogToFile("[Descriptor::updateDescriptorSetsWithNewRawImage] ERROR: Cannot update. Raw image view or sampler is invalid.");
+        if (renderer->m_previewView == VK_NULL_HANDLE || renderer->m_previewSampler == VK_NULL_HANDLE) {
+            LogToFile("[Descriptor::updateDescriptorSetsWithNewRawImage] ERROR: Cannot update. Preview view or sampler is invalid.");
             return;
         }
         LogToFile(std::string("[Descriptor::updateDescriptorSetsWithNewRawImage] Updating ") + std::to_string(renderer->m_descriptorSets.size()) + " descriptor sets.");
@@ -228,8 +228,8 @@ namespace Descriptor {
 
             VkDescriptorImageInfo imageInfo{};
             imageInfo.imageLayout = VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL;
-            imageInfo.imageView = renderer->m_rawImageView;
-            imageInfo.sampler = renderer->m_rawImageSampler;
+            imageInfo.imageView = renderer->m_previewView;
+            imageInfo.sampler = renderer->m_previewSampler;
 
             VkDescriptorBufferInfo bufferInfo{};
             bufferInfo.buffer = renderer->m_uniformBuffers[i];

--- a/src/Graphics/ImageResource.cpp
+++ b/src/Graphics/ImageResource.cpp
@@ -201,4 +201,83 @@ namespace ImageResource {
         }
     }
 
+    bool createPreviewImage(Renderer_VK* renderer, int width, int height) {
+        if (!renderer) return false;
+
+        cleanupPreviewImage(renderer);
+
+        VkImageCreateInfo info{ VK_STRUCTURE_TYPE_IMAGE_CREATE_INFO };
+        info.imageType = VK_IMAGE_TYPE_2D;
+        info.extent.width = static_cast<uint32_t>(width);
+        info.extent.height = static_cast<uint32_t>(height);
+        info.extent.depth = 1;
+        info.mipLevels = 1;
+        info.arrayLayers = 1;
+        info.format = VK_FORMAT_R8G8B8A8_UNORM;
+        info.tiling = VK_IMAGE_TILING_OPTIMAL;
+        info.initialLayout = VK_IMAGE_LAYOUT_UNDEFINED;
+        info.usage = VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT |
+                     VK_IMAGE_USAGE_STORAGE_BIT |
+                     VK_IMAGE_USAGE_SAMPLED_BIT;
+        info.sharingMode = VK_SHARING_MODE_EXCLUSIVE;
+        info.samples = VK_SAMPLE_COUNT_1_BIT;
+
+        VmaAllocationCreateInfo ainfo{};
+        ainfo.usage = VMA_MEMORY_USAGE_AUTO_PREFER_DEVICE;
+
+        VK_CHECK_RENDERER(vmaCreateImage(renderer->m_allocator_p, &info, &ainfo,
+                                         &renderer->m_previewImage,
+                                         &renderer->m_previewImageAlloc,
+                                         nullptr));
+
+        VkImageViewCreateInfo vci{ VK_STRUCTURE_TYPE_IMAGE_VIEW_CREATE_INFO };
+        vci.image = renderer->m_previewImage;
+        vci.viewType = VK_IMAGE_VIEW_TYPE_2D;
+        vci.format = VK_FORMAT_R8G8B8A8_UNORM;
+        vci.subresourceRange.aspectMask = VK_IMAGE_ASPECT_COLOR_BIT;
+        vci.subresourceRange.baseMipLevel = 0;
+        vci.subresourceRange.levelCount = 1;
+        vci.subresourceRange.baseArrayLayer = 0;
+        vci.subresourceRange.layerCount = 1;
+        VK_CHECK_RENDERER(vkCreateImageView(renderer->m_device_p, &vci, nullptr,
+                                            &renderer->m_previewView));
+
+        VkSamplerCreateInfo sci{ VK_STRUCTURE_TYPE_SAMPLER_CREATE_INFO };
+        sci.magFilter = VK_FILTER_NEAREST;
+        sci.minFilter = VK_FILTER_NEAREST;
+        sci.addressModeU = VK_SAMPLER_ADDRESS_MODE_CLAMP_TO_EDGE;
+        sci.addressModeV = VK_SAMPLER_ADDRESS_MODE_CLAMP_TO_EDGE;
+        sci.addressModeW = VK_SAMPLER_ADDRESS_MODE_CLAMP_TO_EDGE;
+        sci.mipmapMode = VK_SAMPLER_MIPMAP_MODE_NEAREST;
+        VK_CHECK_RENDERER(vkCreateSampler(renderer->m_device_p, &sci, nullptr,
+                                          &renderer->m_previewSampler));
+
+        transitionImageLayout(
+            renderer->m_device_p,
+            renderer->m_hostSiteCommandPool_p,
+            renderer->m_graphicsQueue_p,
+            renderer->m_previewImage,
+            VK_IMAGE_LAYOUT_UNDEFINED,
+            VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL);
+
+        return true;
+    }
+
+    void cleanupPreviewImage(Renderer_VK* renderer) {
+        if (!renderer) return;
+        if (renderer->m_previewSampler != VK_NULL_HANDLE) {
+            vkDestroySampler(renderer->m_device_p, renderer->m_previewSampler, nullptr);
+            renderer->m_previewSampler = VK_NULL_HANDLE;
+        }
+        if (renderer->m_previewView != VK_NULL_HANDLE) {
+            vkDestroyImageView(renderer->m_device_p, renderer->m_previewView, nullptr);
+            renderer->m_previewView = VK_NULL_HANDLE;
+        }
+        if (renderer->m_previewImage != VK_NULL_HANDLE) {
+            vmaDestroyImage(renderer->m_allocator_p, renderer->m_previewImage, renderer->m_previewImageAlloc);
+            renderer->m_previewImage = VK_NULL_HANDLE;
+            renderer->m_previewImageAlloc = VK_NULL_HANDLE;
+        }
+    }
+
 }

--- a/src/Graphics/Renderer_VK.cpp
+++ b/src/Graphics/Renderer_VK.cpp
@@ -16,7 +16,11 @@
 #include <iostream>
 #include <fstream>
 #include <algorithm>
+#include <filesystem>
 #include <glm/gtc/matrix_transform.hpp>
+#include <filesystem>
+
+extern std::string g_AppBasePath;
 
 
 Renderer_VK::Renderer_VK(VkPhysicalDevice physicalDevice, VkDevice device, VmaAllocator allocator, VkQueue graphicsQueue, VkCommandPool commandPool)
@@ -33,6 +37,11 @@ Renderer_VK::Renderer_VK(VkPhysicalDevice physicalDevice, VkDevice device, VmaAl
     m_pipelineLayout(VK_NULL_HANDLE),
     m_graphicsPipeline(VK_NULL_HANDLE),
     m_descriptorPool(VK_NULL_HANDLE),
+    m_previewPipeline(VK_NULL_HANDLE),
+    m_previewPipelineLayout(VK_NULL_HANDLE),
+    m_previewSetLayout(VK_NULL_HANDLE),
+    m_previewDescPool(VK_NULL_HANDLE),
+    m_previewDescSet(VK_NULL_HANDLE),
     m_currentRawW(0), m_currentRawH(0),
     m_zoomNativePixels(false),
     m_panX(0.0f), m_panY(0.0f),
@@ -54,6 +63,70 @@ bool Renderer_VK::init(VkRenderPass renderPass, uint32_t swapChainImageCount) {
 
     if (!ImageResource::createRawImageResources(this, 1, 1)) { LogToFile("[Renderer_VK::init] ERROR: Failed to create initial raw image resources."); return false; }
     LogToFile("[Renderer_VK::init] Initial raw image resources created.");
+    if (!ImageResource::createPreviewImage(this, 1, 1)) { LogToFile("[Renderer_VK::init] ERROR: Failed to create preview image."); return false; }
+    LogToFile("[Renderer_VK::init] Preview image created.");
+
+    {
+        namespace fs = std::filesystem;
+        fs::path spv = fs::path(g_AppBasePath) / "shaders_spv" / "raw_to_rgba.comp.spv";
+        auto code = VulkanHelpers::readFile(spv.string());
+        VkShaderModule mod = VulkanHelpers::createShaderModule(m_device_p, code);
+
+        VkDescriptorSetLayoutBinding binds[2]{};
+        binds[0].binding = 0;
+        binds[0].descriptorType = VK_DESCRIPTOR_TYPE_STORAGE_IMAGE;
+        binds[0].descriptorCount = 1;
+        binds[0].stageFlags = VK_SHADER_STAGE_COMPUTE_BIT;
+        binds[1].binding = 1;
+        binds[1].descriptorType = VK_DESCRIPTOR_TYPE_STORAGE_IMAGE;
+        binds[1].descriptorCount = 1;
+        binds[1].stageFlags = VK_SHADER_STAGE_COMPUTE_BIT;
+
+        VkDescriptorSetLayoutCreateInfo lci{ VK_STRUCTURE_TYPE_DESCRIPTOR_SET_LAYOUT_CREATE_INFO };
+        lci.bindingCount = 2;
+        lci.pBindings = binds;
+        VK_CHECK_RENDERER(vkCreateDescriptorSetLayout(m_device_p, &lci, nullptr, &m_previewSetLayout));
+
+        VkPushConstantRange pcr{};
+        pcr.stageFlags = VK_SHADER_STAGE_COMPUTE_BIT;
+        pcr.offset = 0;
+        pcr.size = 80;
+
+        VkPipelineLayoutCreateInfo pli{ VK_STRUCTURE_TYPE_PIPELINE_LAYOUT_CREATE_INFO };
+        pli.setLayoutCount = 1;
+        pli.pSetLayouts = &m_previewSetLayout;
+        pli.pushConstantRangeCount = 1;
+        pli.pPushConstantRanges = &pcr;
+        VK_CHECK_RENDERER(vkCreatePipelineLayout(m_device_p, &pli, nullptr, &m_previewPipelineLayout));
+
+        VkPipelineShaderStageCreateInfo stage{ VK_STRUCTURE_TYPE_PIPELINE_SHADER_STAGE_CREATE_INFO };
+        stage.stage = VK_SHADER_STAGE_COMPUTE_BIT;
+        stage.module = mod;
+        stage.pName = "main";
+
+        VkComputePipelineCreateInfo cpi{ VK_STRUCTURE_TYPE_COMPUTE_PIPELINE_CREATE_INFO };
+        cpi.stage = stage;
+        cpi.layout = m_previewPipelineLayout;
+        VK_CHECK_RENDERER(vkCreateComputePipelines(m_device_p, VK_NULL_HANDLE, 1, &cpi, nullptr, &m_previewPipeline));
+        vkDestroyShaderModule(m_device_p, mod, nullptr);
+
+        VkDescriptorPoolSize ps[2]{};
+        ps[0].type = VK_DESCRIPTOR_TYPE_STORAGE_IMAGE;
+        ps[0].descriptorCount = 1;
+        ps[1].type = VK_DESCRIPTOR_TYPE_STORAGE_IMAGE;
+        ps[1].descriptorCount = 1;
+        VkDescriptorPoolCreateInfo pci{ VK_STRUCTURE_TYPE_DESCRIPTOR_POOL_CREATE_INFO };
+        pci.maxSets = 1;
+        pci.poolSizeCount = 2;
+        pci.pPoolSizes = ps;
+        VK_CHECK_RENDERER(vkCreateDescriptorPool(m_device_p, &pci, nullptr, &m_previewDescPool));
+
+        VkDescriptorSetAllocateInfo ai{ VK_STRUCTURE_TYPE_DESCRIPTOR_SET_ALLOCATE_INFO };
+        ai.descriptorPool = m_previewDescPool;
+        ai.descriptorSetCount = 1;
+        ai.pSetLayouts = &m_previewSetLayout;
+        VK_CHECK_RENDERER(vkAllocateDescriptorSets(m_device_p, &ai, &m_previewDescSet));
+    }
 
     onSwapChainRecreated(renderPass, swapChainImageCount);
 
@@ -65,11 +138,29 @@ void Renderer_VK::cleanup() {
     LogToFile("[Renderer_VK::cleanup] Starting cleanup...");
     Pipeline::cleanupSwapChainResources(this);
     ImageResource::cleanupRawImageResources(this);
+    ImageResource::cleanupPreviewImage(this);
 
     if (m_descriptorSetLayout != VK_NULL_HANDLE) {
         LogToFile("[Renderer_VK::cleanup] Destroying descriptor set layout.");
         vkDestroyDescriptorSetLayout(m_device_p, m_descriptorSetLayout, nullptr);
         m_descriptorSetLayout = VK_NULL_HANDLE;
+    }
+
+    if (m_previewPipeline != VK_NULL_HANDLE) {
+        vkDestroyPipeline(m_device_p, m_previewPipeline, nullptr);
+        m_previewPipeline = VK_NULL_HANDLE;
+    }
+    if (m_previewPipelineLayout != VK_NULL_HANDLE) {
+        vkDestroyPipelineLayout(m_device_p, m_previewPipelineLayout, nullptr);
+        m_previewPipelineLayout = VK_NULL_HANDLE;
+    }
+    if (m_previewSetLayout != VK_NULL_HANDLE) {
+        vkDestroyDescriptorSetLayout(m_device_p, m_previewSetLayout, nullptr);
+        m_previewSetLayout = VK_NULL_HANDLE;
+    }
+    if (m_previewDescPool != VK_NULL_HANDLE) {
+        vkDestroyDescriptorPool(m_device_p, m_previewDescPool, nullptr);
+        m_previewDescPool = VK_NULL_HANDLE;
     }
     LogToFile("[Renderer_VK::cleanup] Cleanup complete.");
 }
@@ -258,6 +349,11 @@ void Renderer_VK::prepareAndUploadFrameData(
     m_currentOrientationDegrees = ubo.orientationDegrees;
 
     updateUniformBuffer(uboBindingIndex, ubo);
+
+    runPreviewCompute(commandBuffer, frameWidth, frameHeight,
+                      blackLvl, whiteLvl, ccm3x3_glm,
+                      ubo.gainR, ubo.gainG, ubo.gainB,
+                      cfaTypeOverride);
 }
 
 void Renderer_VK::recordDrawCommands(
@@ -377,4 +473,78 @@ void Renderer_VK::ensureRawImageCapacity(uint32_t w, uint32_t h)
         LogToFile("[Renderer_VK::ensureRawImageCapacity] ERROR: Failed to recreate raw image resources for new capacity.");
         throw std::runtime_error("Failed to ensure raw image capacity by recreating resources.");
     }
+    ImageResource::createPreviewImage(this, static_cast<int>(w), static_cast<int>(h));
+}
+
+void Renderer_VK::runPreviewCompute(VkCommandBuffer cmd, int width, int height,
+                                    float black, float white,
+                                    const glm::mat3& ccm,
+                                    float wbR, float wbG, float wbB,
+                                    int cfa)
+{
+    VkDescriptorImageInfo inInfo{};
+    inInfo.imageLayout = VK_IMAGE_LAYOUT_GENERAL;
+    inInfo.imageView = m_rawImageView;
+
+    VkDescriptorImageInfo outInfo{};
+    outInfo.imageLayout = VK_IMAGE_LAYOUT_GENERAL;
+    outInfo.imageView = m_previewView;
+
+    VkWriteDescriptorSet wr[2]{};
+    wr[0].sType = VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET;
+    wr[0].dstSet = m_previewDescSet;
+    wr[0].dstBinding = 0;
+    wr[0].descriptorType = VK_DESCRIPTOR_TYPE_STORAGE_IMAGE;
+    wr[0].descriptorCount = 1;
+    wr[0].pImageInfo = &inInfo;
+    wr[1].sType = VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET;
+    wr[1].dstSet = m_previewDescSet;
+    wr[1].dstBinding = 1;
+    wr[1].descriptorType = VK_DESCRIPTOR_TYPE_STORAGE_IMAGE;
+    wr[1].descriptorCount = 1;
+    wr[1].pImageInfo = &outInfo;
+    vkUpdateDescriptorSets(m_device_p, 2, wr, 0, nullptr);
+
+    VkImageMemoryBarrier barriers[2]{};
+    barriers[0].sType = VK_STRUCTURE_TYPE_IMAGE_MEMORY_BARRIER;
+    barriers[0].oldLayout = VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL;
+    barriers[0].newLayout = VK_IMAGE_LAYOUT_GENERAL;
+    barriers[0].srcQueueFamilyIndex = VK_QUEUE_FAMILY_IGNORED;
+    barriers[0].dstQueueFamilyIndex = VK_QUEUE_FAMILY_IGNORED;
+    barriers[0].image = m_rawImage;
+    barriers[0].subresourceRange.aspectMask = VK_IMAGE_ASPECT_COLOR_BIT;
+    barriers[0].subresourceRange.levelCount = 1;
+    barriers[0].subresourceRange.layerCount = 1;
+    barriers[0].srcAccessMask = VK_ACCESS_SHADER_READ_BIT;
+    barriers[0].dstAccessMask = VK_ACCESS_SHADER_READ_BIT;
+
+    barriers[1] = barriers[0];
+    barriers[1].image = m_previewImage;
+    barriers[1].oldLayout = VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL;
+
+    vkCmdPipelineBarrier(cmd, VK_PIPELINE_STAGE_FRAGMENT_SHADER_BIT,
+                         VK_PIPELINE_STAGE_COMPUTE_SHADER_BIT,
+                         0, 0, nullptr, 0, nullptr, 2, barriers);
+
+    vkCmdBindPipeline(cmd, VK_PIPELINE_BIND_POINT_COMPUTE, m_previewPipeline);
+    vkCmdBindDescriptorSets(cmd, VK_PIPELINE_BIND_POINT_COMPUTE, m_previewPipelineLayout,
+                            0, 1, &m_previewDescSet, 0, nullptr);
+
+    struct PC {
+        uint32_t w, h, cfa;
+        float wbR, wbG, wbB;
+        glm::mat3 ccm;
+        uint32_t black, white;
+    } pc{ (uint32_t)width,(uint32_t)height,(uint32_t)cfa, wbR, wbG, wbB, ccm, (uint32_t)black, (uint32_t)white };
+
+    vkCmdPushConstants(cmd, m_previewPipelineLayout, VK_SHADER_STAGE_COMPUTE_BIT, 0, sizeof(PC), &pc);
+    vkCmdDispatch(cmd, (uint32_t)((width + 15)/16), (uint32_t)((height + 15)/16), 1);
+
+    barriers[1].oldLayout = VK_IMAGE_LAYOUT_GENERAL;
+    barriers[1].newLayout = VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL;
+    barriers[1].srcAccessMask = VK_ACCESS_SHADER_WRITE_BIT;
+    barriers[1].dstAccessMask = VK_ACCESS_SHADER_READ_BIT;
+    vkCmdPipelineBarrier(cmd, VK_PIPELINE_STAGE_COMPUTE_SHADER_BIT,
+                         VK_PIPELINE_STAGE_FRAGMENT_SHADER_BIT,
+                         0, 0,nullptr,0,nullptr,1,&barriers[1]);
 }

--- a/src/Gui/GuiRender.cpp
+++ b/src/Gui/GuiRender.cpp
@@ -215,8 +215,8 @@ namespace GuiOverlay {
             appInstance->m_previewRect.y = (int)(innerPos.y - vp->WorkPos.y);
             appInstance->m_previewRect.w = (int)avail.x;
             appInstance->m_previewRect.h = (int)avail.y;
-            if (appInstance->m_previewTex)
-                ImGui::Image(appInstance->m_previewTex, avail, ImVec2(0,1), ImVec2(1,0));
+            if (appInstance->m_previewTexID)
+                ImGui::Image(appInstance->m_previewTexID, avail, ImVec2(0,1), ImVec2(1,0));
         ImGui::EndChild();
         ImGui::PopStyleColor();
         ImGui::Separator();


### PR DESCRIPTION
## Summary
- add preview RGBA compute shader and resource creation helpers
- wire preview image into descriptors and GUI
- create compute pipeline for preview conversion

## Testing
- `cmake -DCMAKE_BUILD_TYPE=Debug ..`
- `cmake --build . --config Debug` *(fails: `cannot find -lavcodec.lib`)*
- `cmake .. -DCMAKE_BUILD_TYPE=Release`
- `cmake --build . --config Release` *(fails: linker can't find FFmpeg libs)*

------
https://chatgpt.com/codex/tasks/task_e_6879eb72058883278dff85871e5d83bb