### PR TITLE
Implement compute-based RGB preview

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -109,6 +109,7 @@ set(SHADER_FILES
     "${APP_SHADERS_SRC_DIR}/fullscreen_quad.vert"
     "${APP_SHADERS_SRC_DIR}/image_process.frag"
     "${APP_SHADERS_SRC_DIR}/raw_to_yuv422.comp"
+    "${APP_SHADERS_SRC_DIR}/raw_to_rgba.comp"
 )
 set(COMPILED_SHADER_OUTPUTS "")
 foreach(SHADER_INPUT_FILE ${SHADER_FILES})

--- a/include/Graphics/GpuYuvConverter.h
+++ b/include/Graphics/GpuYuvConverter.h
@@ -20,6 +20,12 @@ public:
 
     bool convertToFrame(const uint16_t* raw, int width, int height, AVFrame* frame,
                         const GpuColorParams& params);
+
+    static void convertRawToRgbPreview(VkCommandBuffer cmd,
+                                       Renderer_VK* renderer,
+                                       VkImage rawImage, VkImage outImage,
+                                       int width, int height,
+                                       const GpuColorParams& params);
 private:
     Renderer_VK* m_renderer;
 

--- a/include/Graphics/ImageResource.h
+++ b/include/Graphics/ImageResource.h
@@ -10,6 +10,8 @@ namespace ImageResource {
 
     bool createRawImageResources(Renderer_VK* renderer, int width, int height);
     void cleanupRawImageResources(Renderer_VK* renderer);
+    bool createPreviewImage(Renderer_VK* renderer, int width, int height);
+    void cleanupPreviewImage(Renderer_VK* renderer);
 
     void transitionImageLayout(
         VkDevice device,

--- a/include/Graphics/Renderer_VK.h
+++ b/include/Graphics/Renderer_VK.h
@@ -74,6 +74,8 @@ public:
     float getPanY() const;
     int getImageWidth() const;
     int getImageHeight() const;
+    int getPreviewWidth() const { return m_previewW; }
+    int getPreviewHeight() const { return m_previewH; }
     void resetDimensions();
     void ensureRawImageCapacity(uint32_t w, uint32_t h);
 
@@ -89,6 +91,13 @@ public:
     VmaAllocation m_rawImageAllocation = VK_NULL_HANDLE;
     VkImageView m_rawImageView = VK_NULL_HANDLE;
     VkSampler m_rawImageSampler = VK_NULL_HANDLE;
+
+    VkImage m_previewImage = VK_NULL_HANDLE;
+    VmaAllocation m_previewAllocation = VK_NULL_HANDLE;
+    VkImageView m_previewView = VK_NULL_HANDLE;
+    VkSampler m_previewSampler = VK_NULL_HANDLE;
+    int m_previewW = 0;
+    int m_previewH = 0;
 
     std::vector<VkBuffer> m_uniformBuffers;
     std::vector<VmaAllocation> m_uniformBufferAllocations;

--- a/shaders/raw_to_rgba.comp
+++ b/shaders/raw_to_rgba.comp
@@ -1,0 +1,92 @@
+#version 460
+#extension GL_EXT_shader_explicit_arithmetic_types_int64 : enable
+#extension GL_EXT_shader_16bit_storage               : require
+
+layout(set = 0, binding = 0) uniform sampler2D uRaw;
+layout(set = 0, binding = 1, rgba8) writeonly uniform image2D uOut;
+
+layout(push_constant, std430) uniform PC {
+    uint   width, height;          // RAW dimensions
+    uint   cfaType;                // 0 BGGR | 1 RGGB | 2 GBRG | 3 GRBG
+    uint   _pad0;
+    float  wbR, wbG, wbB;          // white-balance gains
+    float  _pad1;
+    mat3   colMat;                 // sensor -> BT.709 matrix
+    uint   black, white;           // raw black/white levels (inclusive)
+} pc;
+
+float readRaw(uint x, uint y){
+    return texelFetch(uRaw, ivec2(x,y), 0).r;
+}
+
+float normRaw(float r){
+    return clamp(r - float(pc.black), 0.0, float(pc.white - pc.black))
+         / float(pc.white - pc.black);
+}
+
+#define RAW(xx,yy) normRaw(readRaw(xx,yy))
+
+vec3 bayerToRGB(uint x, uint y)
+{
+    bool xe = (x & 1u) == 0u;
+    bool ye = (y & 1u) == 0u;
+    float r=0.0,g=0.0,b=0.0;
+    switch(pc.cfaType){
+    case 0u: // BGGR
+        if(ye){
+            if(xe){ b=RAW(x,y); g=(RAW(x-1,y)+RAW(x+1,y)+RAW(x,y-1)+RAW(x,y+1))*0.25; r=(RAW(x-1,y-1)+RAW(x+1,y-1)+RAW(x-1,y+1)+RAW(x+1,y+1))*0.25; }
+            else   { g=RAW(x,y); b=(RAW(x-1,y)+RAW(x+1,y))*0.5; r=(RAW(x,y-1)+RAW(x,y+1))*0.5; }
+        }else{
+            if(xe){ g=RAW(x,y); b=(RAW(x,y-1)+RAW(x,y+1))*0.5; r=(RAW(x-1,y)+RAW(x+1,y))*0.5; }
+            else   { r=RAW(x,y); g=(RAW(x-1,y)+RAW(x+1,y)+RAW(x,y-1)+RAW(x,y+1))*0.25; b=(RAW(x-1,y-1)+RAW(x+1,y-1)+RAW(x-1,y+1)+RAW(x+1,y+1))*0.25; }
+        }
+        break;
+    case 1u: // RGGB
+        if(ye){
+            if(xe){ r=RAW(x,y); g=(RAW(x-1,y)+RAW(x+1,y)+RAW(x,y-1)+RAW(x,y+1))*0.25; b=(RAW(x-1,y-1)+RAW(x+1,y-1)+RAW(x-1,y+1)+RAW(x+1,y+1))*0.25; }
+            else   { g=RAW(x,y); r=(RAW(x-1,y)+RAW(x+1,y))*0.5; b=(RAW(x,y-1)+RAW(x,y+1))*0.5; }
+        }else{
+            if(xe){ g=RAW(x,y); r=(RAW(x,y-1)+RAW(x,y+1))*0.5; b=(RAW(x-1,y)+RAW(x+1,y))*0.5; }
+            else   { b=RAW(x,y); g=(RAW(x-1,y)+RAW(x+1,y)+RAW(x,y-1)+RAW(x,y+1))*0.25; r=(RAW(x-1,y-1)+RAW(x+1,y-1)+RAW(x-1,y+1)+RAW(x+1,y+1))*0.25; }
+        }
+        break;
+    case 2u: // GBRG
+        if(ye){
+            if(xe){ g=RAW(x,y); b=(RAW(x-1,y)+RAW(x+1,y))*0.5; r=(RAW(x,y-1)+RAW(x,y+1))*0.5; }
+            else   { b=RAW(x,y); g=(RAW(x-1,y)+RAW(x+1,y)+RAW(x,y-1)+RAW(x,y+1))*0.25; r=(RAW(x-1,y-1)+RAW(x+1,y-1)+RAW(x-1,y+1)+RAW(x+1,y+1))*0.25; }
+        }else{
+            if(xe){ r=RAW(x,y); g=(RAW(x-1,y)+RAW(x+1,y)+RAW(x,y-1)+RAW(x,y+1))*0.25; b=(RAW(x-1,y-1)+RAW(x+1,y-1)+RAW(x-1,y+1)+RAW(x+1,y+1))*0.25; }
+            else   { g=RAW(x,y); r=(RAW(x-1,y)+RAW(x+1,y))*0.5; b=(RAW(x,y-1)+RAW(x,y+1))*0.5; }
+        }
+        break;
+    case 3u: // GRBG
+        if(ye){
+            if(xe){ g=RAW(x,y); r=(RAW(x-1,y)+RAW(x+1,y))*0.5; b=(RAW(x,y-1)+RAW(x,y+1))*0.5; }
+            else   { r=RAW(x,y); g=(RAW(x-1,y)+RAW(x+1,y)+RAW(x,y-1)+RAW(x,y+1))*0.25; b=(RAW(x-1,y-1)+RAW(x+1,y-1)+RAW(x-1,y+1)+RAW(x+1,y+1))*0.25; }
+        }else{
+            if(xe){ b=RAW(x,y); g=(RAW(x-1,y)+RAW(x+1,y)+RAW(x,y-1)+RAW(x,y+1))*0.25; r=(RAW(x-1,y-1)+RAW(x+1,y-1)+RAW(x-1,y+1)+RAW(x+1,y+1))*0.25; }
+            else   { g=RAW(x,y); b=(RAW(x-1,y)+RAW(x+1,y))*0.5; r=(RAW(x,y-1)+RAW(x,y+1))*0.5; }
+        }
+        break;
+    }
+    vec3 rgb = vec3(r,g,b);
+    rgb *= vec3(pc.wbR, pc.wbG, pc.wbB);
+    rgb = pc.colMat * rgb;
+    return clamp(rgb, 0.0, 1.0);
+}
+
+vec3 encodeSRGB(vec3 v){
+    vec3 lo = v * 12.92;
+    vec3 hi = 1.055 * pow(v, vec3(1.0/2.4)) - 0.055;
+    return mix(hi, lo, lessThanEqual(v, vec3(0.0031308)));
+}
+
+layout(local_size_x = 16, local_size_y = 16, local_size_z = 1) in;
+void main(){
+    uint x = gl_GlobalInvocationID.x;
+    uint y = gl_GlobalInvocationID.y;
+    if(x >= pc.width || y >= pc.height) return;
+    vec3 rgb = encodeSRGB(bayerToRGB(x,y));
+    imageStore(uOut, ivec2(x,y), vec4(rgb,1.0));
+}
+

--- a/src/App/AppInit.cpp
+++ b/src/App/AppInit.cpp
@@ -872,14 +872,14 @@ void App::initImGuiVulkan() {
     LogToFile("App::initImGuiVulkan GuiOverlay::setup() called.");
 
     m_previewTex = (ImTextureID)ImGui_ImplVulkan_AddTexture(
-        m_rendererVk->m_rawImageSampler,
-        m_rendererVk->m_rawImageView,
+        m_rendererVk->m_previewSampler,
+        m_rendererVk->m_previewView,
         VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL);
-    m_previewDesc.sampler = m_rendererVk->m_rawImageSampler;
-    m_previewDesc.imageView = m_rendererVk->m_rawImageView;
+    m_previewDesc.sampler = m_rendererVk->m_previewSampler;
+    m_previewDesc.imageView = m_rendererVk->m_previewView;
     m_previewDesc.imageLayout = VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL;
-    m_previewWidth = m_rendererVk->getImageWidth();
-    m_previewHeight = m_rendererVk->getImageHeight();
+    m_previewWidth = m_rendererVk->getPreviewWidth();
+    m_previewHeight = m_rendererVk->getPreviewHeight();
 }
 
 void App::createPersistentStagingBuffers() {

--- a/src/App/AppLoop.cpp
+++ b/src/App/AppLoop.cpp
@@ -511,13 +511,13 @@ void App::drawFrame() {
 void App::updatePreviewDescriptor() {
     if (m_previewTex == 0 || !m_rendererVk) return;
 
-    int newW = m_rendererVk->getImageWidth();
-    int newH = m_rendererVk->getImageHeight();
+    int newW = m_rendererVk->getPreviewWidth();
+    int newH = m_rendererVk->getPreviewHeight();
     if (newW == m_previewWidth && newH == m_previewHeight)
         return;
 
-    m_previewDesc.sampler = m_rendererVk->m_rawImageSampler;
-    m_previewDesc.imageView = m_rendererVk->m_rawImageView;
+    m_previewDesc.sampler = m_rendererVk->m_previewSampler;
+    m_previewDesc.imageView = m_rendererVk->m_previewView;
     m_previewDesc.imageLayout = VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL;
 
     VkWriteDescriptorSet write{};

--- a/src/Graphics/Descriptor.cpp
+++ b/src/Graphics/Descriptor.cpp
@@ -207,8 +207,8 @@ namespace Descriptor {
             LogToFile("[Descriptor::updateDescriptorSetsWithNewRawImage] No descriptor sets to update.");
             return;
         }
-        if (renderer->m_rawImageView == VK_NULL_HANDLE || renderer->m_rawImageSampler == VK_NULL_HANDLE) {
-            LogToFile("[Descriptor::updateDescriptorSetsWithNewRawImage] ERROR: Cannot update. Raw image view or sampler is invalid.");
+        if (renderer->m_previewView == VK_NULL_HANDLE || renderer->m_previewSampler == VK_NULL_HANDLE) {
+            LogToFile("[Descriptor::updateDescriptorSetsWithNewRawImage] ERROR: Cannot update. Preview image view or sampler is invalid.");
             return;
         }
         LogToFile(std::string("[Descriptor::updateDescriptorSetsWithNewRawImage] Updating ") + std::to_string(renderer->m_descriptorSets.size()) + " descriptor sets.");
@@ -228,8 +228,8 @@ namespace Descriptor {
 
             VkDescriptorImageInfo imageInfo{};
             imageInfo.imageLayout = VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL;
-            imageInfo.imageView = renderer->m_rawImageView;
-            imageInfo.sampler = renderer->m_rawImageSampler;
+            imageInfo.imageView = renderer->m_previewView;
+            imageInfo.sampler = renderer->m_previewSampler;
 
             VkDescriptorBufferInfo bufferInfo{};
             bufferInfo.buffer = renderer->m_uniformBuffers[i];

--- a/src/Graphics/GpuYuvConverter.cpp
+++ b/src/Graphics/GpuYuvConverter.cpp
@@ -458,3 +458,96 @@ bool GpuYuvConverter::convertToFrame(const uint16_t* raw, int width, int height,
     vmaDestroyBuffer(m_renderer->m_allocator_p, readbackBuf, readbackAlloc);
     return true;
 }
+
+void GpuYuvConverter::convertRawToRgbPreview(VkCommandBuffer cmd,
+                                             Renderer_VK* renderer,
+                                             VkImage rawImage, VkImage outImage,
+                                             int width, int height,
+                                             const GpuColorParams& params) {
+    struct PCData {
+        uint32_t width, height, cfaType, pad0;
+        float wbR, wbG, wbB, pad1;
+        float colMat[12];
+        uint32_t black, white;
+    };
+
+    static VkPipeline pipeline = VK_NULL_HANDLE;
+    static VkPipelineLayout layout = VK_NULL_HANDLE;
+    static VkDescriptorSetLayout dsl = VK_NULL_HANDLE;
+    static VkDescriptorPool pool = VK_NULL_HANDLE;
+    static VkDescriptorSet set = VK_NULL_HANDLE;
+
+    if (pipeline == VK_NULL_HANDLE) {
+        namespace fs = std::filesystem;
+        fs::path shaderPath = fs::path(g_AppBasePath) / "shaders_spv" / "raw_to_rgba.comp.spv";
+        auto code = VulkanHelpers::readFile(shaderPath.string());
+        VkShaderModule module = VulkanHelpers::createShaderModule(renderer->m_device_p, code);
+
+        VkDescriptorSetLayoutBinding b[2]{};
+        b[0].binding = 0; b[0].descriptorType = VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER; b[0].descriptorCount = 1; b[0].stageFlags = VK_SHADER_STAGE_COMPUTE_BIT;
+        b[1].binding = 1; b[1].descriptorType = VK_DESCRIPTOR_TYPE_STORAGE_IMAGE; b[1].descriptorCount = 1; b[1].stageFlags = VK_SHADER_STAGE_COMPUTE_BIT;
+        VkDescriptorSetLayoutCreateInfo dslci{ VK_STRUCTURE_TYPE_DESCRIPTOR_SET_LAYOUT_CREATE_INFO };
+        dslci.bindingCount = 2; dslci.pBindings = b;
+        VK_CHECK_RENDERER(vkCreateDescriptorSetLayout(renderer->m_device_p, &dslci, nullptr, &dsl));
+
+        VkPushConstantRange pc{ VK_SHADER_STAGE_COMPUTE_BIT, 0, sizeof(PCData) };
+        VkPipelineLayoutCreateInfo plci{ VK_STRUCTURE_TYPE_PIPELINE_LAYOUT_CREATE_INFO };
+        plci.setLayoutCount = 1; plci.pSetLayouts = &dsl; plci.pushConstantRangeCount = 1; plci.pPushConstantRanges = &pc;
+        VK_CHECK_RENDERER(vkCreatePipelineLayout(renderer->m_device_p, &plci, nullptr, &layout));
+
+        VkPipelineShaderStageCreateInfo stage{ VK_STRUCTURE_TYPE_PIPELINE_SHADER_STAGE_CREATE_INFO };
+        stage.stage = VK_SHADER_STAGE_COMPUTE_BIT; stage.module = module; stage.pName = "main";
+
+        VkComputePipelineCreateInfo ci{ VK_STRUCTURE_TYPE_COMPUTE_PIPELINE_CREATE_INFO };
+        ci.stage = stage; ci.layout = layout;
+        VK_CHECK_RENDERER(vkCreateComputePipelines(renderer->m_device_p, VK_NULL_HANDLE, 1, &ci, nullptr, &pipeline));
+        vkDestroyShaderModule(renderer->m_device_p, module, nullptr);
+
+        VkDescriptorPoolSize ps[2]{};
+        ps[0].type = VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER; ps[0].descriptorCount = 1;
+        ps[1].type = VK_DESCRIPTOR_TYPE_STORAGE_IMAGE; ps[1].descriptorCount = 1;
+        VkDescriptorPoolCreateInfo pci{ VK_STRUCTURE_TYPE_DESCRIPTOR_POOL_CREATE_INFO };
+        pci.maxSets = 1; pci.poolSizeCount = 2; pci.pPoolSizes = ps;
+        VK_CHECK_RENDERER(vkCreateDescriptorPool(renderer->m_device_p, &pci, nullptr, &pool));
+
+        VkDescriptorSetAllocateInfo ai{ VK_STRUCTURE_TYPE_DESCRIPTOR_SET_ALLOCATE_INFO };
+        ai.descriptorPool = pool; ai.descriptorSetCount = 1; ai.pSetLayouts = &dsl;
+        VK_CHECK_RENDERER(vkAllocateDescriptorSets(renderer->m_device_p, &ai, &set));
+    }
+
+    VkDescriptorImageInfo inInfo{ renderer->m_rawImageSampler, renderer->m_rawImageView, VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL };
+    VkDescriptorImageInfo outInfo{ nullptr, renderer->m_previewView, VK_IMAGE_LAYOUT_GENERAL };
+    VkWriteDescriptorSet writes[2]{};
+    writes[0].sType = VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET; writes[0].dstSet = set; writes[0].dstBinding = 0; writes[0].descriptorCount = 1; writes[0].descriptorType = VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER; writes[0].pImageInfo = &inInfo;
+    writes[1].sType = VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET; writes[1].dstSet = set; writes[1].dstBinding = 1; writes[1].descriptorCount = 1; writes[1].descriptorType = VK_DESCRIPTOR_TYPE_STORAGE_IMAGE; writes[1].pImageInfo = &outInfo;
+    vkUpdateDescriptorSets(renderer->m_device_p, 2, writes, 0, nullptr);
+
+    VkImageMemoryBarrier pre{ VK_STRUCTURE_TYPE_IMAGE_MEMORY_BARRIER };
+    pre.oldLayout = VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL;
+    pre.newLayout = VK_IMAGE_LAYOUT_GENERAL;
+    pre.srcQueueFamilyIndex = VK_QUEUE_FAMILY_IGNORED;
+    pre.dstQueueFamilyIndex = VK_QUEUE_FAMILY_IGNORED;
+    pre.image = outImage;
+    pre.subresourceRange = { VK_IMAGE_ASPECT_COLOR_BIT,0,1,0,1 };
+    pre.srcAccessMask = 0; pre.dstAccessMask = VK_ACCESS_SHADER_WRITE_BIT;
+    vkCmdPipelineBarrier(cmd, VK_PIPELINE_STAGE_TOP_OF_PIPE_BIT, VK_PIPELINE_STAGE_COMPUTE_SHADER_BIT, 0,0,nullptr,0,nullptr,1,&pre);
+
+    vkCmdBindPipeline(cmd, VK_PIPELINE_BIND_POINT_COMPUTE, pipeline);
+    vkCmdBindDescriptorSets(cmd, VK_PIPELINE_BIND_POINT_COMPUTE, layout, 0, 1, &set, 0, nullptr);
+
+    PCData pc{};
+    pc.width = width; pc.height = height; pc.cfaType = params.cfaType; pc.pad0 = 0;
+    pc.wbR = params.wbR; pc.wbG = params.wbG; pc.wbB = params.wbB; pc.pad1 = 0.0f;
+    for(int c=0;c<3;++c){ for(int r=0;r<3;++r){ pc.colMat[c*4+r] = params.colorMatrix[c*3+r]; } pc.colMat[c*4+3]=0.0f; }
+    pc.black = params.black; pc.white = params.white;
+
+    vkCmdPushConstants(cmd, layout, VK_SHADER_STAGE_COMPUTE_BIT, 0, sizeof(PCData), &pc);
+    vkCmdDispatch(cmd, (uint32_t)((width+15)/16), (uint32_t)((height+15)/16), 1);
+
+    VkImageMemoryBarrier post{ VK_STRUCTURE_TYPE_IMAGE_MEMORY_BARRIER };
+    post.oldLayout = VK_IMAGE_LAYOUT_GENERAL; post.newLayout = VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL;
+    post.srcQueueFamilyIndex = VK_QUEUE_FAMILY_IGNORED; post.dstQueueFamilyIndex = VK_QUEUE_FAMILY_IGNORED;
+    post.image = outImage; post.subresourceRange = { VK_IMAGE_ASPECT_COLOR_BIT,0,1,0,1 };
+    post.srcAccessMask = VK_ACCESS_SHADER_WRITE_BIT; post.dstAccessMask = VK_ACCESS_SHADER_READ_BIT;
+    vkCmdPipelineBarrier(cmd, VK_PIPELINE_STAGE_COMPUTE_SHADER_BIT, VK_PIPELINE_STAGE_FRAGMENT_SHADER_BIT,0,0,nullptr,0,nullptr,1,&post);
+}

--- a/src/Graphics/ImageResource.cpp
+++ b/src/Graphics/ImageResource.cpp
@@ -143,10 +143,10 @@ namespace ImageResource {
         viewInfo.image = renderer->m_rawImage;
         viewInfo.viewType = VK_IMAGE_VIEW_TYPE_2D;
         viewInfo.format = VK_FORMAT_R16_UNORM;
-        viewInfo.components.r = VK_COMPONENT_SWIZZLE_R;
-        viewInfo.components.g = VK_COMPONENT_SWIZZLE_R;
-        viewInfo.components.b = VK_COMPONENT_SWIZZLE_R;
-        viewInfo.components.a = VK_COMPONENT_SWIZZLE_R;
+        viewInfo.components.r = VK_COMPONENT_SWIZZLE_IDENTITY;
+        viewInfo.components.g = VK_COMPONENT_SWIZZLE_IDENTITY;
+        viewInfo.components.b = VK_COMPONENT_SWIZZLE_IDENTITY;
+        viewInfo.components.a = VK_COMPONENT_SWIZZLE_IDENTITY;
         viewInfo.subresourceRange.aspectMask = VK_IMAGE_ASPECT_COLOR_BIT;
         viewInfo.subresourceRange.baseMipLevel = 0;
         viewInfo.subresourceRange.levelCount = 1;
@@ -199,6 +199,81 @@ namespace ImageResource {
             renderer->m_rawImage = VK_NULL_HANDLE;
             renderer->m_rawImageAllocation = VK_NULL_HANDLE;
         }
+    }
+
+    bool createPreviewImage(Renderer_VK* renderer, int width, int height) {
+        cleanupPreviewImage(renderer);
+
+        VkImageCreateInfo info{ VK_STRUCTURE_TYPE_IMAGE_CREATE_INFO };
+        info.imageType = VK_IMAGE_TYPE_2D;
+        info.extent = { static_cast<uint32_t>(width), static_cast<uint32_t>(height), 1 };
+        info.mipLevels = 1;
+        info.arrayLayers = 1;
+        info.format = VK_FORMAT_R8G8B8A8_UNORM;
+        info.tiling = VK_IMAGE_TILING_OPTIMAL;
+        info.initialLayout = VK_IMAGE_LAYOUT_UNDEFINED;
+        info.usage = VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT |
+                     VK_IMAGE_USAGE_STORAGE_BIT |
+                     VK_IMAGE_USAGE_SAMPLED_BIT;
+        info.sharingMode = VK_SHARING_MODE_EXCLUSIVE;
+        info.samples = VK_SAMPLE_COUNT_1_BIT;
+
+        VmaAllocationCreateInfo ai{};
+        ai.usage = VMA_MEMORY_USAGE_AUTO_PREFER_DEVICE;
+        VK_CHECK_RENDERER(vmaCreateImage(renderer->m_allocator_p, &info, &ai,
+                                         &renderer->m_previewImage,
+                                         &renderer->m_previewAllocation, nullptr));
+
+        VkImageViewCreateInfo vi{ VK_STRUCTURE_TYPE_IMAGE_VIEW_CREATE_INFO };
+        vi.image = renderer->m_previewImage;
+        vi.viewType = VK_IMAGE_VIEW_TYPE_2D;
+        vi.format = VK_FORMAT_R8G8B8A8_UNORM;
+        vi.subresourceRange.aspectMask = VK_IMAGE_ASPECT_COLOR_BIT;
+        vi.subresourceRange.baseMipLevel = 0;
+        vi.subresourceRange.levelCount = 1;
+        vi.subresourceRange.baseArrayLayer = 0;
+        vi.subresourceRange.layerCount = 1;
+        VK_CHECK_RENDERER(vkCreateImageView(renderer->m_device_p, &vi, nullptr,
+                                            &renderer->m_previewView));
+
+        VkSamplerCreateInfo si{ VK_STRUCTURE_TYPE_SAMPLER_CREATE_INFO };
+        si.magFilter = VK_FILTER_NEAREST;
+        si.minFilter = VK_FILTER_NEAREST;
+        si.addressModeU = VK_SAMPLER_ADDRESS_MODE_CLAMP_TO_EDGE;
+        si.addressModeV = VK_SAMPLER_ADDRESS_MODE_CLAMP_TO_EDGE;
+        si.addressModeW = VK_SAMPLER_ADDRESS_MODE_CLAMP_TO_EDGE;
+        si.mipmapMode = VK_SAMPLER_MIPMAP_MODE_NEAREST;
+        VK_CHECK_RENDERER(vkCreateSampler(renderer->m_device_p, &si, nullptr,
+                                          &renderer->m_previewSampler));
+
+        transitionImageLayout(
+            renderer->m_device_p,
+            renderer->m_hostSiteCommandPool_p,
+            renderer->m_graphicsQueue_p,
+            renderer->m_previewImage,
+            VK_IMAGE_LAYOUT_UNDEFINED,
+            VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL);
+        renderer->m_previewW = width;
+        renderer->m_previewH = height;
+        return true;
+    }
+
+    void cleanupPreviewImage(Renderer_VK* renderer) {
+        if (renderer->m_previewSampler != VK_NULL_HANDLE) {
+            vkDestroySampler(renderer->m_device_p, renderer->m_previewSampler, nullptr);
+            renderer->m_previewSampler = VK_NULL_HANDLE;
+        }
+        if (renderer->m_previewView != VK_NULL_HANDLE) {
+            vkDestroyImageView(renderer->m_device_p, renderer->m_previewView, nullptr);
+            renderer->m_previewView = VK_NULL_HANDLE;
+        }
+        if (renderer->m_previewImage != VK_NULL_HANDLE && renderer->m_allocator_p != VK_NULL_HANDLE) {
+            vmaDestroyImage(renderer->m_allocator_p, renderer->m_previewImage, renderer->m_previewAllocation);
+            renderer->m_previewImage = VK_NULL_HANDLE;
+            renderer->m_previewAllocation = VK_NULL_HANDLE;
+        }
+        renderer->m_previewW = 0;
+        renderer->m_previewH = 0;
     }
 
 }

--- a/src/Graphics/Renderer_VK.cpp
+++ b/src/Graphics/Renderer_VK.cpp
@@ -6,6 +6,9 @@
 #include "Graphics/Pipeline.h"
 #include "Graphics/Descriptor.h"
 #include "Graphics/VulkanHelpers.h"
+#include "Graphics/GpuYuvConverter.h"
+#include "Graphics/GpuColorParams.h"
+#include "Graphics/GpuColorParams.h"
 #include "Utils/DebugLog.h"
 #include "Utils/RawFrameBuffer.h"
 #include "Utils/OrientationUtils.h"
@@ -54,6 +57,7 @@ bool Renderer_VK::init(VkRenderPass renderPass, uint32_t swapChainImageCount) {
 
     if (!ImageResource::createRawImageResources(this, 1, 1)) { LogToFile("[Renderer_VK::init] ERROR: Failed to create initial raw image resources."); return false; }
     LogToFile("[Renderer_VK::init] Initial raw image resources created.");
+    if (!ImageResource::createPreviewImage(this, 1, 1)) { LogToFile("[Renderer_VK::init] ERROR: Failed to create initial preview image."); return false; }
 
     onSwapChainRecreated(renderPass, swapChainImageCount);
 
@@ -65,6 +69,7 @@ void Renderer_VK::cleanup() {
     LogToFile("[Renderer_VK::cleanup] Starting cleanup...");
     Pipeline::cleanupSwapChainResources(this);
     ImageResource::cleanupRawImageResources(this);
+    ImageResource::cleanupPreviewImage(this);
 
     if (m_descriptorSetLayout != VK_NULL_HANDLE) {
         LogToFile("[Renderer_VK::cleanup] Destroying descriptor set layout.");
@@ -258,6 +263,21 @@ void Renderer_VK::prepareAndUploadFrameData(
     m_currentOrientationDegrees = ubo.orientationDegrees;
 
     updateUniformBuffer(uboBindingIndex, ubo);
+
+    bool previewSizeChanged = (m_previewImage == VK_NULL_HANDLE || frameWidth != m_previewW || frameHeight != m_previewH);
+    if (previewSizeChanged) {
+        ImageResource::createPreviewImage(this, frameWidth, frameHeight);
+    }
+
+    GpuColorParams p{};
+    p.wbR = ubo.gainR; p.wbG = ubo.gainG; p.wbB = ubo.gainB;
+    for(int c=0;c<3;++c) for(int r=0;r<3;++r) p.colorMatrix[c*3+r] = ccm3x3_glm[r][c];
+    p.cfaType = cfaTypeOverride;
+    p.black = static_cast<unsigned int>(ubo.blackLevel);
+    p.white = static_cast<unsigned int>(ubo.whiteLevel);
+    GpuYuvConverter::convertRawToRgbPreview(commandBuffer, this,
+                                            m_rawImage, m_previewImage,
+                                            frameWidth, frameHeight, p);
 }
 
 void Renderer_VK::recordDrawCommands(

--- a/src/Gui/GuiRender.cpp
+++ b/src/Gui/GuiRender.cpp
@@ -198,27 +198,15 @@ namespace GuiOverlay {
 
         ImGui::BeginChild("FileListPanel", ImVec2(vp->WorkSize.x * 0.5f, vp->WorkSize.y - 150), true);
 
-        ImGuiChildFlags previewChildFlags =
-            ImGuiChildFlags_AlwaysUseWindowPadding;
-        ImGuiWindowFlags previewFlags =
-            ImGuiWindowFlags_NoTitleBar |
-            ImGuiWindowFlags_NoResize |
-            ImGuiWindowFlags_NoMove |
-            ImGuiWindowFlags_NoCollapse |
-            ImGuiWindowFlags_NoScrollbar;
-
-        ImGui::PushStyleColor(ImGuiCol_ChildBg, ImVec4(0.1f, 0.1f, 0.1f, 1.0f));
-        ImGui::BeginChild("PreviewArea", ImVec2(0, 0), previewChildFlags, previewFlags);
-            ImVec2 innerPos  = ImGui::GetWindowPos();
-            ImVec2 avail     = ImGui::GetContentRegionAvail();
-            appInstance->m_previewRect.x = (int)(innerPos.x - vp->WorkPos.x);
-            appInstance->m_previewRect.y = (int)(innerPos.y - vp->WorkPos.y);
-            appInstance->m_previewRect.w = (int)avail.x;
-            appInstance->m_previewRect.h = (int)avail.y;
-            if (appInstance->m_previewTex)
-                ImGui::Image(appInstance->m_previewTex, avail, ImVec2(0,1), ImVec2(1,0));
+        ImGui::BeginChild("Preview", ImVec2(0, 240), true,
+                       ImGuiWindowFlags_NoTitleBar | ImGuiWindowFlags_NoResize |
+                       ImGuiWindowFlags_NoMove | ImGuiWindowFlags_NoCollapse |
+                       ImGuiWindowFlags_AlwaysUseWindowPadding);
+        if (appInstance->m_previewTex)
+            ImGui::Image(appInstance->m_previewTex,
+                         ImGui::GetContentRegionAvail(),
+                         ImVec2(0,1), ImVec2(1,0));
         ImGui::EndChild();
-        ImGui::PopStyleColor();
         ImGui::Separator();
 
         if (ImGui::Button("Add")) { appInstance->triggerOpenFileViaDialog(); }


### PR DESCRIPTION
## Summary
- allocate dedicated RGBA preview image resources
- create `raw_to_rgba` shader and compile via CMake
- add compute dispatch to convert RAW frames for preview
- hook preview texture into ImGui
- simplify preview panel UI

## Testing
- `cmake --build . -j$(nproc)` *(fails: cannot find -lavcodec.lib)*

------
https://chatgpt.com/codex/tasks/task_e_6879eb72058883278dff85871e5d83bb