### PR TITLE
Add compute-based RGB preview infrastructure

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -109,6 +109,7 @@ set(SHADER_FILES
     "${APP_SHADERS_SRC_DIR}/fullscreen_quad.vert"
     "${APP_SHADERS_SRC_DIR}/image_process.frag"
     "${APP_SHADERS_SRC_DIR}/raw_to_yuv422.comp"
+    "${APP_SHADERS_SRC_DIR}/raw_to_rgba.comp"
 )
 set(COMPILED_SHADER_OUTPUTS "")
 foreach(SHADER_INPUT_FILE ${SHADER_FILES})

--- a/include/App/App.h
+++ b/include/App/App.h
@@ -68,7 +68,9 @@ public:
     VkQueue m_graphicsQueue = VK_NULL_HANDLE;
     VkQueue m_presentQueue = VK_NULL_HANDLE;
     VkDescriptorPool m_imguiDescriptorPool = VK_NULL_HANDLE;
-    ImTextureID m_previewTextureSet = 0;
+    ImTextureID m_previewTexID = 0;
+    VkSampler m_previewSampler = VK_NULL_HANDLE;
+    VkImageView m_previewView = VK_NULL_HANDLE;
     VkCommandPool m_commandPool = VK_NULL_HANDLE;
     VkRenderPass m_renderPass = VK_NULL_HANDLE;
 

--- a/include/Graphics/GpuYuvConverter.h
+++ b/include/Graphics/GpuYuvConverter.h
@@ -20,6 +20,21 @@ public:
 
     bool convertToFrame(const uint16_t* raw, int width, int height, AVFrame* frame,
                         const GpuColorParams& params);
+
+    static void convertRawToRgbPreview(
+        VkDevice device,
+        VkCommandBuffer cmd,
+        VkDescriptorSet descSet,
+        VkPipeline pipeline,
+        VkPipelineLayout layout,
+        VkImageView rawView,
+        VkImageView outView,
+        uint32_t width,
+        uint32_t height,
+        uint32_t cfa,
+        uint32_t black,
+        uint32_t white,
+        const float* colMat);
 private:
     Renderer_VK* m_renderer;
 

--- a/include/Graphics/ImageResource.h
+++ b/include/Graphics/ImageResource.h
@@ -10,6 +10,8 @@ namespace ImageResource {
 
     bool createRawImageResources(Renderer_VK* renderer, int width, int height);
     void cleanupRawImageResources(Renderer_VK* renderer);
+    bool createPreviewImage(Renderer_VK* renderer, int width, int height);
+    void cleanupPreviewImage(Renderer_VK* renderer);
 
     void transitionImageLayout(
         VkDevice device,

--- a/include/Graphics/Renderer_VK.h
+++ b/include/Graphics/Renderer_VK.h
@@ -90,6 +90,11 @@ public:
     VkImageView m_rawImageView = VK_NULL_HANDLE;
     VkSampler m_rawImageSampler = VK_NULL_HANDLE;
 
+    VkImage m_previewImage = VK_NULL_HANDLE;
+    VmaAllocation m_previewImageAllocation = VK_NULL_HANDLE;
+    VkImageView m_previewImageView = VK_NULL_HANDLE;
+    VkSampler m_previewSampler = VK_NULL_HANDLE;
+
     std::vector<VkBuffer> m_uniformBuffers;
     std::vector<VmaAllocation> m_uniformBufferAllocations;
     std::vector<void*> m_uniformBuffersMapped;
@@ -139,6 +144,8 @@ private:
     // or make members they need public (as done above with _p suffix).
     friend bool ImageResource::createRawImageResources(Renderer_VK* renderer, int width, int height);
     friend void ImageResource::cleanupRawImageResources(Renderer_VK* renderer);
+    friend bool ImageResource::createPreviewImage(Renderer_VK* renderer, int width, int height);
+    friend void ImageResource::cleanupPreviewImage(Renderer_VK* renderer);
     friend bool Pipeline::createGraphicsPipeline(Renderer_VK* renderer, VkRenderPass renderPass);
     friend void Pipeline::cleanupSwapChainResources(Renderer_VK* renderer);
     friend bool Descriptor::createDescriptorSetLayout(Renderer_VK* renderer);

--- a/shaders/raw_to_rgba.comp
+++ b/shaders/raw_to_rgba.comp
@@ -1,0 +1,83 @@
+#version 460
+#extension GL_EXT_shader_explicit_arithmetic_types_int64 : enable
+#extension GL_EXT_shader_16bit_storage               : require
+
+layout(set=0,binding=0) uniform sampler2D uRaw;          // R16_UNORM
+layout(set=0,binding=1, rgba8) writeonly uniform image2D uOut; // RGBA8_UNORM
+
+layout(push_constant) uniform PC {
+    uint   width;
+    uint   height;
+    uint   cfaType;           // 0 BGGR |1 RGGB |2 GBRG |3 GRBG
+    uint   _pad0;
+    mat3   colMat;            // sensor -> RGB
+    uint   black;
+    uint   white;
+} pc;
+
+float normRaw(uint x, uint y){
+    float v = texelFetch(uRaw, ivec2(x,y), 0).r * 65535.0;
+    return clamp( (v - float(pc.black)) / float(max(pc.white - pc.black,1u)), 0.0, 1.0);
+}
+
+vec3 bayerToRGB(uint x, uint y){
+    bool xe = (x & 1u) == 0u;
+    bool ye = (y & 1u) == 0u;
+    float r=0.0,g=0.0,b=0.0;
+    switch(pc.cfaType){
+    case 0u:
+        if(ye){
+            if(xe){ b=normRaw(x,y); g=(normRaw(x-1,y)+normRaw(x+1,y)+normRaw(x,y-1)+normRaw(x,y+1))*0.25; r=(normRaw(x-1,y-1)+normRaw(x+1,y-1)+normRaw(x-1,y+1)+normRaw(x+1,y+1))*0.25; }
+            else   { g=normRaw(x,y); b=(normRaw(x-1,y)+normRaw(x+1,y))*0.5; r=(normRaw(x,y-1)+normRaw(x,y+1))*0.5; }
+        }else{
+            if(xe){ g=normRaw(x,y); b=(normRaw(x,y-1)+normRaw(x,y+1))*0.5; r=(normRaw(x-1,y)+normRaw(x+1,y))*0.5; }
+            else   { r=normRaw(x,y); g=(normRaw(x-1,y)+normRaw(x+1,y)+normRaw(x,y-1)+normRaw(x,y+1))*0.25; b=(normRaw(x-1,y-1)+normRaw(x+1,y-1)+normRaw(x-1,y+1)+normRaw(x+1,y+1))*0.25; }
+        }
+        break;
+    case 1u:
+        if(ye){
+            if(xe){ r=normRaw(x,y); g=(normRaw(x-1,y)+normRaw(x+1,y)+normRaw(x,y-1)+normRaw(x,y+1))*0.25; b=(normRaw(x-1,y-1)+normRaw(x+1,y-1)+normRaw(x-1,y+1)+normRaw(x+1,y+1))*0.25; }
+            else   { g=normRaw(x,y); r=(normRaw(x-1,y)+normRaw(x+1,y))*0.5; b=(normRaw(x,y-1)+normRaw(x,y+1))*0.5; }
+        }else{
+            if(xe){ g=normRaw(x,y); r=(normRaw(x,y-1)+normRaw(x,y+1))*0.5; b=(normRaw(x-1,y)+normRaw(x+1,y))*0.5; }
+            else   { b=normRaw(x,y); g=(normRaw(x-1,y)+normRaw(x+1,y)+normRaw(x,y-1)+normRaw(x,y+1))*0.25; r=(normRaw(x-1,y-1)+normRaw(x+1,y-1)+normRaw(x-1,y+1)+normRaw(x+1,y+1))*0.25; }
+        }
+        break;
+    case 2u:
+        if(ye){
+            if(xe){ g=normRaw(x,y); b=(normRaw(x-1,y)+normRaw(x+1,y))*0.5; r=(normRaw(x,y-1)+normRaw(x,y+1))*0.5; }
+            else   { b=normRaw(x,y); g=(normRaw(x-1,y)+normRaw(x+1,y)+normRaw(x,y-1)+normRaw(x,y+1))*0.25; r=(normRaw(x-1,y-1)+normRaw(x+1,y-1)+normRaw(x-1,y+1)+normRaw(x+1,y+1))*0.25; }
+        }else{
+            if(xe){ r=normRaw(x,y); g=(normRaw(x-1,y)+normRaw(x+1,y)+normRaw(x,y-1)+normRaw(x,y+1))*0.25; b=(normRaw(x-1,y-1)+normRaw(x+1,y-1)+normRaw(x-1,y+1)+normRaw(x+1,y+1))*0.25; }
+            else   { g=normRaw(x,y); r=(normRaw(x-1,y)+normRaw(x+1,y))*0.5; b=(normRaw(x,y-1)+normRaw(x,y+1))*0.5; }
+        }
+        break;
+    case 3u:
+        if(ye){
+            if(xe){ g=normRaw(x,y); r=(normRaw(x-1,y)+normRaw(x+1,y))*0.5; b=(normRaw(x,y-1)+normRaw(x,y+1))*0.5; }
+            else   { r=normRaw(x,y); g=(normRaw(x-1,y)+normRaw(x+1,y)+normRaw(x,y-1)+normRaw(x,y+1))*0.25; b=(normRaw(x-1,y-1)+normRaw(x+1,y-1)+normRaw(x-1,y+1)+normRaw(x+1,y+1))*0.25; }
+        }else{
+            if(xe){ b=normRaw(x,y); g=(normRaw(x-1,y)+normRaw(x+1,y)+normRaw(x,y-1)+normRaw(x,y+1))*0.25; r=(normRaw(x-1,y-1)+normRaw(x+1,y-1)+normRaw(x-1,y+1)+normRaw(x+1,y+1))*0.25; }
+            else   { g=normRaw(x,y); b=(normRaw(x-1,y)+normRaw(x+1,y))*0.5; r=(normRaw(x,y-1)+normRaw(x,y+1))*0.5; }
+        }
+        break;
+    }
+    vec3 rgb = vec3(r,g,b);
+    rgb = pc.colMat * rgb;
+    return clamp(rgb,0.0,1.0);
+}
+
+vec3 encodeSRGB(vec3 v){
+    vec3 lo = v*12.92;
+    vec3 hi = 1.055*pow(v,vec3(1.0/2.4)) - 0.055;
+    return mix(hi,lo,lessThanEqual(v,vec3(0.0031308)));
+}
+
+layout(local_size_x=16, local_size_y=16, local_size_z=1) in;
+void main(){
+    uvec2 gid = gl_GlobalInvocationID.xy;
+    if(gid.x>=pc.width || gid.y>=pc.height) return;
+    vec3 rgb = encodeSRGB(bayerToRGB(gid.x, gid.y));
+    imageStore(uOut, ivec2(gid), vec4(rgb,1.0));
+}
+

--- a/src/App/AppCleanup.cpp
+++ b/src/App/AppCleanup.cpp
@@ -211,9 +211,9 @@ void App::cleanupVulkan() {
     LogToFile("[App::cleanupVulkan] Cleaning up GuiOverlay (ImGui shutdown)...");
     GuiOverlay::cleanup();
 
-    if (m_previewTextureSet != 0) {
-        ImGui_ImplVulkan_RemoveTexture((VkDescriptorSet)m_previewTextureSet);
-        m_previewTextureSet = 0;
+    if (m_previewTexID != 0) {
+        ImGui_ImplVulkan_RemoveTexture((VkDescriptorSet)m_previewTexID);
+        m_previewTexID = 0;
     }
 
     if (m_imguiDescriptorPool != VK_NULL_HANDLE) {

--- a/src/App/AppInit.cpp
+++ b/src/App/AppInit.cpp
@@ -870,7 +870,10 @@ void App::initImGuiVulkan() {
 
     GuiOverlay::setup(m_window, this);
     LogToFile("App::initImGuiVulkan GuiOverlay::setup() called.");
-    refreshPreviewTextureDescriptor();
+    m_previewTexID = (ImTextureID)ImGui_ImplVulkan_AddTexture(
+        m_rendererVk->m_previewSampler,
+        m_rendererVk->m_previewImageView,
+        VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL);
 }
 
 void App::createPersistentStagingBuffers() {

--- a/src/App/AppLoop.cpp
+++ b/src/App/AppLoop.cpp
@@ -425,7 +425,7 @@ void App::drawFrame() {
             );
             if (m_rendererVk->getImageWidth() != m_previewImageW ||
                 m_rendererVk->getImageHeight() != m_previewImageH ||
-                m_previewTextureSet == 0)
+                m_previewTexID == 0)
             {
                 refreshPreviewTextureDescriptor();
             }
@@ -512,14 +512,14 @@ void App::drawFrame() {
 }
 
 void App::refreshPreviewTextureDescriptor() {
-    if (m_previewTextureSet != 0) {
-        ImGui_ImplVulkan_RemoveTexture((VkDescriptorSet)m_previewTextureSet);
-        m_previewTextureSet = 0;
+    if (m_previewTexID != 0) {
+        ImGui_ImplVulkan_RemoveTexture((VkDescriptorSet)m_previewTexID);
+        m_previewTexID = 0;
     }
     if (m_rendererVk) {
-        m_previewTextureSet = (ImTextureID)ImGui_ImplVulkan_AddTexture(
-            m_rendererVk->m_rawImageSampler,
-            m_rendererVk->m_rawImageView,
+        m_previewTexID = (ImTextureID)ImGui_ImplVulkan_AddTexture(
+            m_rendererVk->m_previewSampler,
+            m_rendererVk->m_previewImageView,
             VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL);
         m_previewImageW = m_rendererVk->getImageWidth();
         m_previewImageH = m_rendererVk->getImageHeight();

--- a/src/Graphics/GpuYuvConverter.cpp
+++ b/src/Graphics/GpuYuvConverter.cpp
@@ -458,3 +458,56 @@ bool GpuYuvConverter::convertToFrame(const uint16_t* raw, int width, int height,
     vmaDestroyBuffer(m_renderer->m_allocator_p, readbackBuf, readbackAlloc);
     return true;
 }
+
+void GpuYuvConverter::convertRawToRgbPreview(
+    VkDevice device,
+    VkCommandBuffer cmd,
+    VkDescriptorSet descSet,
+    VkPipeline pipeline,
+    VkPipelineLayout layout,
+    VkImageView rawView,
+    VkImageView outView,
+    uint32_t width,
+    uint32_t height,
+    uint32_t cfa,
+    uint32_t black,
+    uint32_t white,
+    const float* colMat)
+{
+    VkDescriptorImageInfo inInfo{};
+    inInfo.imageView = rawView;
+    inInfo.imageLayout = VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL;
+
+    VkDescriptorImageInfo outInfo{};
+    outInfo.imageView = outView;
+    outInfo.imageLayout = VK_IMAGE_LAYOUT_GENERAL;
+
+    VkWriteDescriptorSet writes[2]{};
+    writes[0].sType = VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET;
+    writes[0].dstSet = descSet;
+    writes[0].dstBinding = 0;
+    writes[0].descriptorCount = 1;
+    writes[0].descriptorType = VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER;
+    writes[0].pImageInfo = &inInfo;
+    writes[1].sType = VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET;
+    writes[1].dstSet = descSet;
+    writes[1].dstBinding = 1;
+    writes[1].descriptorCount = 1;
+    writes[1].descriptorType = VK_DESCRIPTOR_TYPE_STORAGE_IMAGE;
+    writes[1].pImageInfo = &outInfo;
+    vkUpdateDescriptorSets(device, 2, writes, 0, nullptr);
+
+    vkCmdBindPipeline(cmd, VK_PIPELINE_BIND_POINT_COMPUTE, pipeline);
+    vkCmdBindDescriptorSets(cmd, VK_PIPELINE_BIND_POINT_COMPUTE, layout, 0, 1, &descSet, 0, nullptr);
+
+    struct PC {
+        uint32_t width, height, cfa, pad;
+        float colMat[12];
+        uint32_t black, white;
+    } pc{};
+    pc.width = width; pc.height = height; pc.cfa = cfa; pc.black = black; pc.white = white;
+    for(int c=0;c<3;++c){ for(int r=0;r<3;++r){ pc.colMat[c*4+r]=colMat[c*3+r]; } pc.colMat[c*4+3]=0.0f; }
+
+    vkCmdPushConstants(cmd, layout, VK_SHADER_STAGE_COMPUTE_BIT, 0, sizeof(PC), &pc);
+    vkCmdDispatch(cmd, (width+15)/16, (height+15)/16, 1);
+}

--- a/src/Graphics/ImageResource.cpp
+++ b/src/Graphics/ImageResource.cpp
@@ -201,4 +201,81 @@ namespace ImageResource {
         }
     }
 
+    bool createPreviewImage(Renderer_VK* renderer, int width, int height) {
+        cleanupPreviewImage(renderer);
+
+        VkImageCreateInfo imageInfo{ VK_STRUCTURE_TYPE_IMAGE_CREATE_INFO };
+        imageInfo.imageType = VK_IMAGE_TYPE_2D;
+        imageInfo.extent.width = static_cast<uint32_t>(width);
+        imageInfo.extent.height = static_cast<uint32_t>(height);
+        imageInfo.extent.depth = 1;
+        imageInfo.mipLevels = 1;
+        imageInfo.arrayLayers = 1;
+        imageInfo.format = VK_FORMAT_R8G8B8A8_UNORM;
+        imageInfo.tiling = VK_IMAGE_TILING_OPTIMAL;
+        imageInfo.initialLayout = VK_IMAGE_LAYOUT_UNDEFINED;
+        imageInfo.usage = VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT |
+                          VK_IMAGE_USAGE_STORAGE_BIT |
+                          VK_IMAGE_USAGE_SAMPLED_BIT;
+        imageInfo.sharingMode = VK_SHARING_MODE_EXCLUSIVE;
+        imageInfo.samples = VK_SAMPLE_COUNT_1_BIT;
+
+        VmaAllocationCreateInfo allocInfo{};
+        allocInfo.usage = VMA_MEMORY_USAGE_AUTO_PREFER_DEVICE;
+
+        VK_CHECK_RENDERER(vmaCreateImage(renderer->m_allocator_p, &imageInfo, &allocInfo,
+                                         &renderer->m_previewImage, &renderer->m_previewImageAllocation, nullptr));
+
+        VkImageViewCreateInfo viewInfo{ VK_STRUCTURE_TYPE_IMAGE_VIEW_CREATE_INFO };
+        viewInfo.image = renderer->m_previewImage;
+        viewInfo.viewType = VK_IMAGE_VIEW_TYPE_2D;
+        viewInfo.format = VK_FORMAT_R8G8B8A8_UNORM;
+        viewInfo.subresourceRange.aspectMask = VK_IMAGE_ASPECT_COLOR_BIT;
+        viewInfo.subresourceRange.baseMipLevel = 0;
+        viewInfo.subresourceRange.levelCount = 1;
+        viewInfo.subresourceRange.baseArrayLayer = 0;
+        viewInfo.subresourceRange.layerCount = 1;
+        VK_CHECK_RENDERER(vkCreateImageView(renderer->m_device_p, &viewInfo, nullptr, &renderer->m_previewImageView));
+
+        VkSamplerCreateInfo samplerInfo{ VK_STRUCTURE_TYPE_SAMPLER_CREATE_INFO };
+        samplerInfo.magFilter = VK_FILTER_NEAREST;
+        samplerInfo.minFilter = VK_FILTER_NEAREST;
+        samplerInfo.addressModeU = VK_SAMPLER_ADDRESS_MODE_CLAMP_TO_EDGE;
+        samplerInfo.addressModeV = VK_SAMPLER_ADDRESS_MODE_CLAMP_TO_EDGE;
+        samplerInfo.addressModeW = VK_SAMPLER_ADDRESS_MODE_CLAMP_TO_EDGE;
+        samplerInfo.anisotropyEnable = VK_FALSE;
+        samplerInfo.maxAnisotropy = 1.0f;
+        samplerInfo.borderColor = VK_BORDER_COLOR_INT_OPAQUE_BLACK;
+        samplerInfo.unnormalizedCoordinates = VK_FALSE;
+        samplerInfo.compareEnable = VK_FALSE;
+        samplerInfo.compareOp = VK_COMPARE_OP_ALWAYS;
+        samplerInfo.mipmapMode = VK_SAMPLER_MIPMAP_MODE_NEAREST;
+        VK_CHECK_RENDERER(vkCreateSampler(renderer->m_device_p, &samplerInfo, nullptr, &renderer->m_previewSampler));
+
+        transitionImageLayout(
+            renderer->m_device_p,
+            renderer->m_hostSiteCommandPool_p,
+            renderer->m_graphicsQueue_p,
+            renderer->m_previewImage,
+            VK_IMAGE_LAYOUT_UNDEFINED,
+            VK_IMAGE_LAYOUT_GENERAL);
+        return true;
+    }
+
+    void cleanupPreviewImage(Renderer_VK* renderer) {
+        if (renderer->m_previewSampler != VK_NULL_HANDLE) {
+            vkDestroySampler(renderer->m_device_p, renderer->m_previewSampler, nullptr);
+            renderer->m_previewSampler = VK_NULL_HANDLE;
+        }
+        if (renderer->m_previewImageView != VK_NULL_HANDLE) {
+            vkDestroyImageView(renderer->m_device_p, renderer->m_previewImageView, nullptr);
+            renderer->m_previewImageView = VK_NULL_HANDLE;
+        }
+        if (renderer->m_previewImage != VK_NULL_HANDLE && renderer->m_allocator_p != VK_NULL_HANDLE) {
+            vmaDestroyImage(renderer->m_allocator_p, renderer->m_previewImage, renderer->m_previewImageAllocation);
+            renderer->m_previewImage = VK_NULL_HANDLE;
+            renderer->m_previewImageAllocation = VK_NULL_HANDLE;
+        }
+    }
+
 }

--- a/src/Graphics/Renderer_VK.cpp
+++ b/src/Graphics/Renderer_VK.cpp
@@ -54,6 +54,8 @@ bool Renderer_VK::init(VkRenderPass renderPass, uint32_t swapChainImageCount) {
 
     if (!ImageResource::createRawImageResources(this, 1, 1)) { LogToFile("[Renderer_VK::init] ERROR: Failed to create initial raw image resources."); return false; }
     LogToFile("[Renderer_VK::init] Initial raw image resources created.");
+    if (!ImageResource::createPreviewImage(this, 1, 1)) { LogToFile("[Renderer_VK::init] ERROR: Failed to create preview image."); return false; }
+    LogToFile("[Renderer_VK::init] Preview image created.");
 
     onSwapChainRecreated(renderPass, swapChainImageCount);
 
@@ -65,6 +67,7 @@ void Renderer_VK::cleanup() {
     LogToFile("[Renderer_VK::cleanup] Starting cleanup...");
     Pipeline::cleanupSwapChainResources(this);
     ImageResource::cleanupRawImageResources(this);
+    ImageResource::cleanupPreviewImage(this);
 
     if (m_descriptorSetLayout != VK_NULL_HANDLE) {
         LogToFile("[Renderer_VK::cleanup] Destroying descriptor set layout.");
@@ -377,4 +380,5 @@ void Renderer_VK::ensureRawImageCapacity(uint32_t w, uint32_t h)
         LogToFile("[Renderer_VK::ensureRawImageCapacity] ERROR: Failed to recreate raw image resources for new capacity.");
         throw std::runtime_error("Failed to ensure raw image capacity by recreating resources.");
     }
+    ImageResource::createPreviewImage(this, static_cast<int>(w), static_cast<int>(h));
 }

--- a/src/Gui/GuiRender.cpp
+++ b/src/Gui/GuiRender.cpp
@@ -279,9 +279,9 @@ namespace GuiOverlay {
             ImGui::Text("%s / %s  Frame %zu / %zu", curTimeStr.c_str(), totalTimeStr.c_str(), curIdx, total);
 
             ImVec2 avail = ImGui::GetContentRegionAvail();
-            if (appInstance->m_previewTextureSet != 0 && avail.x > 0 && avail.y > 0)
+            if (appInstance->m_previewTexID != 0 && avail.x > 0 && avail.y > 0)
             {
-                ImGui::Image(appInstance->m_previewTextureSet,
+                ImGui::Image(appInstance->m_previewTexID,
                              avail,
                              ImVec2(0,1), ImVec2(1,0));
             }


### PR DESCRIPTION
## Summary
- compile new shader `raw_to_rgba.comp`
- create preview images in `ImageResource`
- register a dedicated preview texture
- refactor preview texture descriptor usage
- wire up Vulkan object cleanup

## Testing
- `cmake -S . -B build -DCMAKE_BUILD_TYPE=Debug`
- `cmake --build build` *(fails: `libavutil/frame.h` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6879f462e3c0832782e2e09ecb080d15