### PR TITLE
Improve converter UI layout

### DIFF
--- a/src/App/AppLoop.cpp
+++ b/src/App/AppLoop.cpp
@@ -422,15 +422,17 @@ void App::drawFrame() {
                 m_containerOrientationTag,
                 m_containerFlipped
             );
+            // Always clear to black when there is video content
             clearColorValue.color = { {0.0f, 0.0f, 0.0f, 1.0f} };
         }
         else {
-            float bg = m_firstFileLoaded ? 0.1f : (40.0f/255.0f);
+            // Clear to dark gray when no file is loaded
+            float bg = m_firstFileLoaded ? 0.0f : (40.0f/255.0f);
             clearColorValue.color = { {bg, bg, bg, 1.0f} };
         }
     }
     else {
-        float bg = m_firstFileLoaded ? 0.1f : (40.0f/255.0f);
+        float bg = m_firstFileLoaded ? 0.0f : (40.0f/255.0f);
         clearColorValue.color = { {bg, bg, bg, 1.0f} };
         if (m_inFlightStagingBufferIndices[m_currentFrame].has_value()) {
             m_availableStagingBufferIndices.push(m_inFlightStagingBufferIndices[m_currentFrame].value());
@@ -444,11 +446,11 @@ void App::drawFrame() {
     vkCmdBeginRenderPass(cmd, &rpInfo, VK_SUBPASS_CONTENTS_INLINE);
 
     if (renderContentFromPacket) {
-        int pw = m_previewRect.w > 0 ? m_previewRect.w : m_windowWidth;
-        int ph = m_previewRect.h > 0 ? m_previewRect.h : m_windowHeight;
-        int px = m_previewRect.x;
-        int py = m_previewRect.y;
-        m_rendererVk->recordDrawCommands(cmd, m_currentFrame, pw, ph, px, py);
+        m_rendererVk->recordDrawCommands(
+            cmd, m_currentFrame,
+            static_cast<int>(m_swapChainExtent.width),
+            static_cast<int>(m_swapChainExtent.height),
+            0, 0);
     }
 
     if (m_uiOpacity > 0.0f) {

--- a/src/Gui/GuiRender.cpp
+++ b/src/Gui/GuiRender.cpp
@@ -186,156 +186,107 @@ namespace GuiOverlay {
     void render(App* appInstance) {
 #ifdef MOTIONCAM_CONVERTER
         if (!appInstance) return;
-        ImGuiIO& io = ImGui::GetIO();
-        ImGuiViewport* vp = ImGui::GetMainViewport();
-        ImGui::SetNextWindowPos(vp->WorkPos);
-        ImGui::SetNextWindowSize(vp->WorkSize);
-        ImGui::SetNextWindowBgAlpha(0.f);
-        ImGui::Begin("ConverterMain", nullptr, ImGuiWindowFlags_NoDecoration | ImGuiWindowFlags_NoMove | ImGuiWindowFlags_NoBackground);
 
-        ImGui::BeginChild("FileListPanel", ImVec2(vp->WorkSize.x * 0.5f, vp->WorkSize.y - 150), true);
-        if (ImGui::CollapsingHeader("Preview", &appInstance->m_previewOpen, ImGuiTreeNodeFlags_DefaultOpen)) {
-            ImGui::BeginChild("PreviewArea", ImVec2(0, 220), true);
-            ImVec2 innerPos = ImGui::GetWindowPos();
-            ImVec2 innerSize = ImGui::GetWindowSize();
-            appInstance->m_previewRect.x = (int)(innerPos.x - vp->WorkPos.x);
-            appInstance->m_previewRect.y = (int)(innerPos.y - vp->WorkPos.y);
-            appInstance->m_previewRect.w = (int)innerSize.x;
-            appInstance->m_previewRect.h = (int)innerSize.y;
+        ImGui::SetNextWindowSize(ImVec2(350, 400), ImGuiCond_FirstUseEver);
+        ImGui::SetNextWindowPos(ImVec2(20, 20), ImGuiCond_FirstUseEver);
+        if (ImGui::Begin("Files")) {
+            if (ImGui::Button("Add", ImVec2(ImGui::GetContentRegionAvail().x * 0.33f, 0))) {
+                appInstance->triggerOpenFileViaDialog();
+            }
+            ImGui::SameLine();
+            if (ImGui::Button("Remove", ImVec2(ImGui::GetContentRegionAvail().x * 0.5f, 0))) {
+                 if (appInstance->m_selectedBatchIndex >= 0 && appInstance->m_selectedBatchIndex < (int)appInstance->m_fileList.size()) {
+                    appInstance->m_fileList.erase(appInstance->m_fileList.begin() + appInstance->m_selectedBatchIndex);
+                    if (appInstance->m_selectedBatchIndex < (int)appInstance->m_fileExportFormats.size())
+                        appInstance->m_fileExportFormats.erase(appInstance->m_fileExportFormats.begin() + appInstance->m_selectedBatchIndex);
+                    appInstance->m_selectedBatchIndex = -1;
+                }
+            }
+            ImGui::SameLine();
+            if (ImGui::Button("Clear", ImVec2(-1, 0))) {
+                appInstance->m_fileList.clear();
+                appInstance->m_fileExportFormats.clear();
+                appInstance->m_selectedBatchIndex = -1;
+            }
+            ImGui::Separator();
+
+            ImGui::BeginChild("ScrollingFileList");
+            for (int i = 0; i < (int)appInstance->m_fileList.size(); ++i) {
+                bool sel = (i == appInstance->m_selectedBatchIndex);
+                std::string name = std::filesystem::path(appInstance->m_fileList[i]).filename().string();
+                if (ImGui::Selectable(name.c_str(), sel)) {
+                    if (appInstance->m_selectedBatchIndex != i) {
+                        appInstance->m_selectedBatchIndex = i;
+                        appInstance->m_firstFileLoaded = true;
+                        appInstance->loadFileAtIndex(i);
+                    }
+                }
+            }
+            ImGui::EndChild();
+        }
+        ImGui::End();
+
+        ImGui::SetNextWindowSize(ImVec2(500, 320), ImGuiCond_FirstUseEver);
+        ImGui::SetNextWindowPos(ImVec2(400, 20), ImGuiCond_FirstUseEver);
+        if (ImGui::Begin("Controls & Export")) {
             bool paused = true;
             if (appInstance->m_playbackController_ptr)
                 paused = appInstance->m_playbackController_ptr->isPaused();
+
             if (ImGui::Button(paused ? "Play" : "Pause")) {
                 if (appInstance->m_playbackController_ptr)
                     appInstance->m_playbackController_ptr->togglePause();
             }
             ImGui::SameLine();
-            if (ImGui::Button("Stop")) {
-                if (appInstance->m_playbackController_ptr) {
-                    appInstance->m_playbackController_ptr->setPlaybackMode(PlaybackController::PlaybackMode::REALTIME);
-                    appInstance->performSeek(0);
-                    if (!appInstance->m_playbackController_ptr->isPaused())
-                        appInstance->m_playbackController_ptr->togglePause();
-                }
-            }
-            ImGui::SameLine();
-            if (ImGui::Button("Prev Clip")) {
-                if (!appInstance->m_fileList.empty()) {
-                    int newIndex = appInstance->m_selectedBatchIndex > 0 ? appInstance->m_selectedBatchIndex - 1 : 0;
-                    if (newIndex != appInstance->m_selectedBatchIndex) {
-                        bool oldFirst = appInstance->m_firstFileLoaded;
-                        appInstance->m_firstFileLoaded = true;
-                        appInstance->m_selectedBatchIndex = newIndex;
-                        appInstance->loadFileAtIndex(newIndex);
-                        appInstance->m_firstFileLoaded = oldFirst;
-                    }
-                }
-            }
-            ImGui::SameLine();
-            if (ImGui::Button("Next Clip")) {
-                if (!appInstance->m_fileList.empty()) {
-                    int newIndex = appInstance->m_selectedBatchIndex + 1;
-                    if (newIndex >= (int)appInstance->m_fileList.size()) newIndex = appInstance->m_selectedBatchIndex;
-                    if (newIndex != appInstance->m_selectedBatchIndex) {
-                        bool oldFirst = appInstance->m_firstFileLoaded;
-                        appInstance->m_firstFileLoaded = true;
-                        appInstance->m_selectedBatchIndex = newIndex;
-                        appInstance->loadFileAtIndex(newIndex);
-                        appInstance->m_firstFileLoaded = oldFirst;
-                    }
-                }
-            }
-            size_t curIdx = 0, total = 0;
+            size_t curIdx = 0, total = 1;
             if (appInstance->m_playbackController_ptr && appInstance->m_decoderWrapper_ptr && appInstance->m_decoderWrapper_ptr->getDecoder()) {
                 curIdx = appInstance->m_playbackController_ptr->getCurrentFrameIndex();
                 total = appInstance->m_decoderWrapper_ptr->getDecoder()->getFrames().size();
+                if (total == 0) total = 1;
             }
-            float prog = total ? (float)curIdx / (float)total : 0.f;
-            if (ImGui::SliderFloat("Seek", &prog, 0.f, 1.f)) {
-                if (appInstance->m_decoderWrapper_ptr) {
-                    size_t newIdx = static_cast<size_t>(prog * total);
-                    appInstance->performSeek(newIdx);
-                }
+            int current_frame_int = static_cast<int>(curIdx);
+            ImGui::PushItemWidth(-1);
+            if (ImGui::SliderInt("##Seek", &current_frame_int, 0, static_cast<int>(total) -1, "Frame %d")) {
+                appInstance->performSeek(static_cast<size_t>(current_frame_int));
             }
-            double curTime = 0.0, totalTime = 0.0;
-            if (appInstance->m_decoderWrapper_ptr && appInstance->m_decoderWrapper_ptr->getDecoder()) {
-                const auto& frames = appInstance->m_decoderWrapper_ptr->getDecoder()->getFrames();
-                if (!frames.empty()) {
-                    int64_t firstTs = frames.front();
-                    if (curIdx < frames.size()) curTime = static_cast<double>(frames[curIdx] - firstTs) * 1e-9;
-                    totalTime = static_cast<double>(frames.back() - firstTs) * 1e-9;
-                }
-            }
-            std::string curTimeStr = GuiUtils::format_mm_ss(curTime);
-            std::string totalTimeStr = GuiUtils::format_mm_ss(totalTime);
-            ImGui::Text("%s / %s  Frame %zu / %zu", curTimeStr.c_str(), totalTimeStr.c_str(), curIdx, total);
-            ImGui::EndChild();
+            ImGui::PopItemWidth();
+
             ImGui::Separator();
-        } else {
-            appInstance->m_previewRect.w = 0;
-            appInstance->m_previewRect.h = 0;
-        }
 
-        if (ImGui::Button("Add")) { appInstance->triggerOpenFileViaDialog(); }
-        ImGui::SameLine();
-        if (ImGui::Button("Remove") && appInstance->m_selectedBatchIndex >= 0 && appInstance->m_selectedBatchIndex < (int)appInstance->m_fileList.size()) {
-            appInstance->m_fileList.erase(appInstance->m_fileList.begin() + appInstance->m_selectedBatchIndex);
-            if (appInstance->m_selectedBatchIndex < (int)appInstance->m_fileExportFormats.size())
-                appInstance->m_fileExportFormats.erase(appInstance->m_fileExportFormats.begin() + appInstance->m_selectedBatchIndex);
-            appInstance->m_selectedBatchIndex = -1;
-        }
-        ImGui::SameLine();
-        if (ImGui::Button("Clear")) { appInstance->m_fileList.clear(); appInstance->m_fileExportFormats.clear(); appInstance->m_selectedBatchIndex = -1; }
-        ImGui::Separator();
-        for (int i = 0; i < (int)appInstance->m_fileList.size(); ++i) {
-            bool sel = (i == appInstance->m_selectedBatchIndex);
-            std::string name = std::filesystem::path(appInstance->m_fileList[i]).filename().string();
-            if (ImGui::Selectable(name.c_str(), sel)) {
-                appInstance->m_selectedBatchIndex = i;
-                bool oldFirst = appInstance->m_firstFileLoaded;
-                appInstance->m_firstFileLoaded = true;
-                appInstance->loadFileAtIndex(i);
-                appInstance->m_firstFileLoaded = oldFirst;
+            if (appInstance->m_selectedBatchIndex >= 0 && appInstance->m_selectedBatchIndex < (int)appInstance->m_fileExportFormats.size()) {
+                int fmt = static_cast<int>(appInstance->m_fileExportFormats[appInstance->m_selectedBatchIndex]);
+                ImGui::Text("Export Format for selected clip:");
+                ImGui::RadioButton("ProRes (CPU)", &fmt, (int)App::ExportFormat::PRORES_CPU); ImGui::SameLine();
+                ImGui::RadioButton("ProRes (GPU)", &fmt, (int)App::ExportFormat::PRORES_GPU);
+                ImGui::RadioButton("DNxHR (CPU)", &fmt, (int)App::ExportFormat::DNXHR_CPU); ImGui::SameLine();
+                ImGui::RadioButton("DNxHR (GPU)", &fmt, (int)App::ExportFormat::DNXHR_GPU);
+                ImGui::RadioButton("HEVC (GPU)", &fmt, (int)App::ExportFormat::HEVC_GPU); ImGui::SameLine();
+                ImGui::RadioButton("DNGs", &fmt, (int)App::ExportFormat::DNG);
+                appInstance->m_fileExportFormats[appInstance->m_selectedBatchIndex] = static_cast<App::ExportFormat>(fmt);
+            } else {
+                ImGui::TextDisabled("Select a file to see export options.");
+            }
+
+            ImGui::InputText("Output Folder", appInstance->m_outputFolder, IM_ARRAYSIZE(appInstance->m_outputFolder));
+            ImGui::SameLine();
+            if (ImGui::Button("Browse...")) {
+                std::string folder = appInstance->openFolderDialog();
+                if (!folder.empty()) strncpy(appInstance->m_outputFolder, folder.c_str(), sizeof(appInstance->m_outputFolder)-1);
+            }
+            if (ImGui::Button("Convert All Files in List", ImVec2(-1, 30)) && !appInstance->m_batchActive.load()) {
+                appInstance->startBatchConversion();
             }
         }
-        ImGui::EndChild();
+        ImGui::End();
 
-        ImGui::SameLine();
-
-        ImGui::BeginChild("ExportSettings", ImVec2(0, vp->WorkSize.y - 150), true);
-        if (appInstance->m_selectedBatchIndex >= 0 && appInstance->m_selectedBatchIndex < (int)appInstance->m_fileExportFormats.size()) {
-            int fmt = static_cast<int>(appInstance->m_fileExportFormats[appInstance->m_selectedBatchIndex]);
-            ImGui::Text("Export Format for selected clip:");
-            ImGui::RadioButton("ProRes (CPU)", &fmt, (int)App::ExportFormat::PRORES_CPU); ImGui::SameLine();
-            ImGui::RadioButton("ProRes (GPU)", &fmt, (int)App::ExportFormat::PRORES_GPU);
-            ImGui::RadioButton("DNxHR (CPU)", &fmt, (int)App::ExportFormat::DNXHR_CPU); ImGui::SameLine();
-            ImGui::RadioButton("DNxHR (GPU)", &fmt, (int)App::ExportFormat::DNXHR_GPU);
-            ImGui::RadioButton("HEVC (CPU)", &fmt, (int)App::ExportFormat::HEVC_CPU); ImGui::SameLine();
-            ImGui::RadioButton("HEVC (GPU)", &fmt, (int)App::ExportFormat::HEVC_GPU); ImGui::SameLine();
-            ImGui::RadioButton("DNG", &fmt, (int)App::ExportFormat::DNG);
-            appInstance->m_fileExportFormats[appInstance->m_selectedBatchIndex] = static_cast<App::ExportFormat>(fmt);
+        ImGui::SetNextWindowSize(ImVec2(500, 200), ImGuiCond_FirstUseEver);
+        ImGui::SetNextWindowPos(ImVec2(400, 350), ImGuiCond_FirstUseEver);
+        if (ImGui::Begin("Log")) {
+             ImGui::BeginChild("ScrollingLog");
+            for (const std::string& line : appInstance->m_batchLog) ImGui::TextUnformatted(line.c_str());
+            if (ImGui::GetScrollY() >= ImGui::GetScrollMaxY()) ImGui::SetScrollHereY(1.0f);
+            ImGui::EndChild();
         }
-        ImGui::InputText("Output Folder", appInstance->m_outputFolder, IM_ARRAYSIZE(appInstance->m_outputFolder));
-        ImGui::SameLine();
-        if (ImGui::Button("Browse...")) {
-            std::string folder = appInstance->openFolderDialog();
-            if (!folder.empty()) strncpy(appInstance->m_outputFolder, folder.c_str(), sizeof(appInstance->m_outputFolder)-1);
-        }
-        if (ImGui::Button("Convert All") && !appInstance->m_batchActive.load()) {
-            appInstance->startBatchConversion();
-        }
-        ImGui::EndChild();
-
-
-        ImGui::BeginChild("Log", ImVec2(0, 120), true);
-        for (const std::string& line : appInstance->m_batchLog) ImGui::TextUnformatted(line.c_str());
-        if (ImGui::GetScrollY() >= ImGui::GetScrollMaxY()) ImGui::SetScrollHereY(1.0f);
-        ImGui::EndChild();
-
-        ImGui::Separator();
-        ImGui::Text("MotionCam Converter v0.36.0 — RAW VIDEO CONVERTER");
-        ImGui::Text("www.motioncamapp.com");
-
         ImGui::End();
 #else
         if (!appInstance) return;

--- a/src/Gui/GuiSetup.cpp
+++ b/src/Gui/GuiSetup.cpp
@@ -34,6 +34,13 @@ namespace GuiOverlay {
         ImGui::CreateContext();
         ImGuiIO& io = ImGui::GetIO(); (void)io;
         io.ConfigFlags |= ImGuiConfigFlags_NavEnableKeyboard; // Enable Keyboard Controls
+#ifdef ImGuiConfigFlags_ViewportsEnable
+        io.ConfigFlags |= ImGuiConfigFlags_ViewportsEnable;  // Enable multi-viewports if available
+
+        ImGuiStyle& style = ImGui::GetStyle();
+        style.WindowRounding = 0.0f;
+        style.Colors[ImGuiCol_WindowBg].w = 1.0f;
+#endif
 
         // Explicitly set ini file location so it stays in the application folder
         g_ImGuiIniPath = (std::filesystem::path(g_AppBasePath) / "imgui.ini").string();


### PR DESCRIPTION
## Summary
- allow ImGui viewports so panels can float
- clear background consistently and draw frames fullscreen
- redesign converter interface into three resizable windows
- fix compile errors with missing function header and optional viewport flag

## Testing
- `cmake -S . -B build`
- `cmake --build build` *(fails: cannot find -lavcodec.lib and related libs)*

------
https://chatgpt.com/codex/tasks/task_e_687a0a3d62cc8327a29007635d75fd27