### PR TITLE
Fix playback initialization and transparent dockspace

### DIFF
--- a/src/Gui/GuiRender.cpp
+++ b/src/Gui/GuiRender.cpp
@@ -197,23 +197,31 @@ namespace GuiOverlay {
         ImGuiViewport* viewport = ImGui::GetMainViewport();
         ImGui::SetNextWindowPos(viewport->WorkPos);
         ImGui::SetNextWindowSize(viewport->WorkSize);
+        ImGui::SetNextWindowViewport(viewport->ID);
         ImGui::PushStyleVar(ImGuiStyleVar_WindowRounding, 0.0f);
         ImGui::PushStyleVar(ImGuiStyleVar_WindowBorderSize, 0.0f);
         ImGui::PushStyleVar(ImGuiStyleVar_WindowPadding, ImVec2(0.0f, 0.0f));
 
-        ImGuiWindowFlags window_flags = ImGuiWindowFlags_MenuBar | ImGuiWindowFlags_NoDocking;
+        ImGuiWindowFlags window_flags = ImGuiWindowFlags_NoDocking;
         window_flags |= ImGuiWindowFlags_NoTitleBar | ImGuiWindowFlags_NoCollapse | ImGuiWindowFlags_NoResize | ImGuiWindowFlags_NoMove;
         window_flags |= ImGuiWindowFlags_NoBringToFrontOnFocus | ImGuiWindowFlags_NoNavFocus;
 
+        // Transparent background for pass-through dockspace
+        ImGui::PushStyleColor(ImGuiCol_WindowBg, ImVec4(0.0f, 0.0f, 0.0f, 0.0f));
         ImGui::Begin("MainDockSpace", nullptr, window_flags);
+        ImGui::PopStyleColor();
         ImGui::PopStyleVar(3);
 
-#if IMGUI_HAS_DOCK
         ImGuiID dockspace_id = ImGui::GetID("MyDockSpace");
-        ImGui::DockSpace(dockspace_id, ImVec2(0.0f, 0.0f), ImGuiDockNodeFlags_None);
-#endif
+        ImGui::DockSpace(dockspace_id, ImVec2(0.0f, 0.0f), ImGuiDockNodeFlags_PassthruCentralNode);
 
-        // 1. Files Panel
+        if (auto* central_node = ImGui::DockBuilderGetCentralNode(dockspace_id)) {
+            appInstance->m_previewRect = {(int)central_node->Pos.x, (int)central_node->Pos.y, (int)central_node->Size.x, (int)central_node->Size.y};
+        } else {
+            appInstance->m_previewRect = {0,0,0,0};
+        }
+
+        // Files Panel
         if (ImGui::Begin("Files")) {
             if (ImGui::Button("Add")) { appInstance->triggerOpenFileViaDialog(); }
             ImGui::SameLine();
@@ -244,20 +252,8 @@ namespace GuiOverlay {
         }
         ImGui::End();
 
-        // 2. Preview Panel
-        ImGui::PushStyleVar(ImGuiStyleVar_WindowPadding, ImVec2(0, 0));
-        if (ImGui::Begin("Preview")) {
-            ImVec2 pos = ImGui::GetCursorScreenPos();
-            ImVec2 size = ImGui::GetContentRegionAvail();
-            appInstance->m_previewRect = {(int)pos.x, (int)pos.y, (int)std::max(1.0f, size.x), (int)std::max(1.0f, size.y)};
-        } else {
-            appInstance->m_previewRect = {0, 0, 0, 0};
-        }
-        ImGui::End();
-        ImGui::PopStyleVar();
-
-        // 3. Controls & Export Panel
-        if (ImGui::Begin("Controls & Export")) {
+        // Combined Controls, Export & Log Panel
+        if (ImGui::Begin("Controls, Export & Log")) {
             bool paused = appInstance->m_playbackController_ptr ? appInstance->m_playbackController_ptr->isPaused() : true;
             if (ImGui::Button(paused ? "Play" : "Pause")) {
                 if (appInstance->m_playbackController_ptr) appInstance->m_playbackController_ptr->togglePause();
@@ -292,7 +288,6 @@ namespace GuiOverlay {
                 ImGui::RadioButton("DNGs", &fmt, (int)App::ExportFormat::DNG);
                 appInstance->m_fileExportFormats[appInstance->m_selectedBatchIndex] = (App::ExportFormat)fmt;
             }
-
             ImGui::InputText("Output Folder", appInstance->m_outputFolder, sizeof(appInstance->m_outputFolder));
             ImGui::SameLine();
             if (ImGui::Button("Browse...")) {
@@ -302,11 +297,9 @@ namespace GuiOverlay {
             if (ImGui::Button("Convert All", ImVec2(-1, 0)) && !appInstance->m_batchActive.load()) {
                 appInstance->startBatchConversion();
             }
-        }
-        ImGui::End();
+            ImGui::Separator();
 
-        // 4. Log Panel
-        if (ImGui::Begin("Log")) {
+            ImGui::Text("Log:");
             ImGui::BeginChild("ScrollingLog");
             for (const auto& line : appInstance->m_batchLog) ImGui::TextUnformatted(line.c_str());
             if (ImGui::GetScrollY() >= ImGui::GetScrollMaxY()) ImGui::SetScrollHereY(1.0f);

--- a/src/Playback/PlaybackController.cpp
+++ b/src/Playback/PlaybackController.cpp
@@ -10,10 +10,10 @@
 
 double PlaybackController::s_displayFps = 0.0;
 
-PlaybackController::PlaybackController() : m_isPaused(false) {
+PlaybackController::PlaybackController() : m_isPaused(true) {
     m_fpsAvgStart = std::chrono::steady_clock::now();
     m_lastBenchmarkTime = m_fpsAvgStart;
-    LogToFile("[PlaybackController] Constructor: Initialized, paused = false.");
+    LogToFile("[PlaybackController] Constructor: Initialized, paused = true (default).");
 }
 
 void PlaybackController::handleKey(int key, GLFWwindow* /*window*/) {


### PR DESCRIPTION
## Summary
- ensure PlaybackController starts paused
- refactor converter UI dockspace to let Vulkan preview show through central node

## Testing
- `cmake -S . -B build`
- `cmake --build build -j$(nproc)` *(fails: `libavutil/frame.h` not found)*

------
https://chatgpt.com/codex/tasks/task_e_687a3543ade88327acaa47a1537dd5f9