### PR TITLE
Fix preview dockspace rendering

### DIFF
--- a/src/App/AppLoop.cpp
+++ b/src/App/AppLoop.cpp
@@ -448,9 +448,10 @@ void App::drawFrame() {
     if (renderContentFromPacket) {
         m_rendererVk->recordDrawCommands(
             cmd, m_currentFrame,
-            static_cast<int>(m_swapChainExtent.width),
-            static_cast<int>(m_swapChainExtent.height),
-            0, 0);
+            m_previewRect.w,
+            m_previewRect.h,
+            m_previewRect.x,
+            m_previewRect.y);
     }
 
     if (m_uiOpacity > 0.0f) {

--- a/src/Gui/GuiRender.cpp
+++ b/src/Gui/GuiRender.cpp
@@ -210,7 +210,21 @@ namespace GuiOverlay {
 
 #if IMGUI_HAS_DOCK
         ImGuiID dockspace_id = ImGui::GetID("MyDockSpace");
+        ImGui::DockSpace(dockspace_id, ImVec2(0.0f, 0.0f), ImGuiDockNodeFlags_PassthruCentralNode);
+        if (ImGuiDockNode* central_node = ImGui::DockBuilderGetCentralNode(dockspace_id)) {
+            ImVec2 pos = central_node->Pos;
+            ImVec2 size = central_node->Size;
+            appInstance->m_previewRect = {
+                (int)pos.x, (int)pos.y,
+                (int)std::max(1.0f, size.x), (int)std::max(1.0f, size.y)
+            };
+        } else {
+            appInstance->m_previewRect = {0, 0, 0, 0};
+        }
+#else
+        ImGuiID dockspace_id = ImGui::GetID("MyDockSpace");
         ImGui::DockSpace(dockspace_id, ImVec2(0.0f, 0.0f), ImGuiDockNodeFlags_None);
+        appInstance->m_previewRect = {0, 0, 0, 0};
 #endif
 
         // 1. Files Panel
@@ -244,17 +258,7 @@ namespace GuiOverlay {
         }
         ImGui::End();
 
-        // 2. Preview Panel
-        ImGui::PushStyleVar(ImGuiStyleVar_WindowPadding, ImVec2(0, 0));
-        if (ImGui::Begin("Preview")) {
-            ImVec2 pos = ImGui::GetCursorScreenPos();
-            ImVec2 size = ImGui::GetContentRegionAvail();
-            appInstance->m_previewRect = {(int)pos.x, (int)pos.y, (int)std::max(1.0f, size.x), (int)std::max(1.0f, size.y)};
-        } else {
-            appInstance->m_previewRect = {0, 0, 0, 0};
-        }
-        ImGui::End();
-        ImGui::PopStyleVar();
+
 
         // 3. Controls & Export Panel
         if (ImGui::Begin("Controls & Export")) {


### PR DESCRIPTION
## Summary
- create transparent central dockspace for Vulkan preview
- track dockspace position and size each frame
- draw video only inside the preview rectangle

## Testing
- `cmake -S . -B build`
- `cmake --build build -j$(nproc)` *(fails: libavutil/frame.h missing)*

------
https://chatgpt.com/codex/tasks/task_e_687dd57923388327af1e54a853e3cb29