### PR TITLE
Update preview dock rendering

### DIFF
--- a/src/App/AppLoop.cpp
+++ b/src/App/AppLoop.cpp
@@ -446,11 +446,20 @@ void App::drawFrame() {
     vkCmdBeginRenderPass(cmd, &rpInfo, VK_SUBPASS_CONTENTS_INLINE);
 
     if (renderContentFromPacket) {
+#ifdef MOTIONCAM_CONVERTER
+        m_rendererVk->recordDrawCommands(
+            cmd, m_currentFrame,
+            m_previewRect.w,
+            m_previewRect.h,
+            m_previewRect.x,
+            m_previewRect.y);
+#else
         m_rendererVk->recordDrawCommands(
             cmd, m_currentFrame,
             static_cast<int>(m_swapChainExtent.width),
             static_cast<int>(m_swapChainExtent.height),
             0, 0);
+#endif
     }
 
     if (m_uiOpacity > 0.0f) {

--- a/src/Gui/GuiRender.cpp
+++ b/src/Gui/GuiRender.cpp
@@ -210,7 +210,13 @@ namespace GuiOverlay {
 
 #if IMGUI_HAS_DOCK
         ImGuiID dockspace_id = ImGui::GetID("MyDockSpace");
-        ImGui::DockSpace(dockspace_id, ImVec2(0.0f, 0.0f), ImGuiDockNodeFlags_None);
+        ImGuiDockNodeFlags dockspace_flags = ImGuiDockNodeFlags_None | ImGuiDockNodeFlags_PassthruCentralNode;
+        ImGui::DockSpace(dockspace_id, ImVec2(0.0f, 0.0f), dockspace_flags);
+        if (ImGuiDockNode* central = ImGui::DockBuilderGetCentralNode(dockspace_id)) {
+            appInstance->m_previewRect = { (int)central->Pos.x, (int)central->Pos.y, (int)central->Size.x, (int)central->Size.y };
+        } else {
+            appInstance->m_previewRect = {0, 0, 0, 0};
+        }
 #endif
 
         // 1. Files Panel
@@ -243,18 +249,6 @@ namespace GuiOverlay {
             ImGui::EndChild();
         }
         ImGui::End();
-
-        // 2. Preview Panel
-        ImGui::PushStyleVar(ImGuiStyleVar_WindowPadding, ImVec2(0, 0));
-        if (ImGui::Begin("Preview")) {
-            ImVec2 pos = ImGui::GetCursorScreenPos();
-            ImVec2 size = ImGui::GetContentRegionAvail();
-            appInstance->m_previewRect = {(int)pos.x, (int)pos.y, (int)std::max(1.0f, size.x), (int)std::max(1.0f, size.y)};
-        } else {
-            appInstance->m_previewRect = {0, 0, 0, 0};
-        }
-        ImGui::End();
-        ImGui::PopStyleVar();
 
         // 3. Controls & Export Panel
         if (ImGui::Begin("Controls & Export")) {


### PR DESCRIPTION
## Summary
- enable passthrough central docking area
- remove the old preview ImGui window
- draw the video only inside the dock's central area

## Testing
- `cmake -S . -B build -DCMAKE_BUILD_TYPE=Release`
- `cmake --build build -j4` *(fails: libavutil/frame.h: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_687dd57d07b88327ad2b84f74ee9c32b