### PR TITLE
Render video in dock preview panel

### DIFF
--- a/src/App/AppLoop.cpp
+++ b/src/App/AppLoop.cpp
@@ -446,11 +446,14 @@ void App::drawFrame() {
     vkCmdBeginRenderPass(cmd, &rpInfo, VK_SUBPASS_CONTENTS_INLINE);
 
     if (renderContentFromPacket) {
-        m_rendererVk->recordDrawCommands(
-            cmd, m_currentFrame,
-            static_cast<int>(m_swapChainExtent.width),
-            static_cast<int>(m_swapChainExtent.height),
-            0, 0);
+        if (m_previewRect.w > 0 && m_previewRect.h > 0) {
+            m_rendererVk->recordDrawCommands(
+                cmd, m_currentFrame,
+                m_previewRect.w,
+                m_previewRect.h,
+                m_previewRect.x,
+                m_previewRect.y);
+        }
     }
 
     if (m_uiOpacity > 0.0f) {

--- a/src/Gui/GuiRender.cpp
+++ b/src/Gui/GuiRender.cpp
@@ -210,7 +210,24 @@ namespace GuiOverlay {
 
 #if IMGUI_HAS_DOCK
         ImGuiID dockspace_id = ImGui::GetID("MyDockSpace");
-        ImGui::DockSpace(dockspace_id, ImVec2(0.0f, 0.0f), ImGuiDockNodeFlags_None);
+        ImGui::DockSpace(dockspace_id, ImVec2(0.0f, 0.0f), ImGuiDockNodeFlags_PassthruCentralNode);
+
+        if (ImGuiDockNode* central = ImGui::DockBuilderGetCentralNode(dockspace_id)) {
+            appInstance->m_previewRect = {(int)central->Pos.x,
+                                         (int)central->Pos.y,
+                                         (int)central->Size.x,
+                                         (int)central->Size.y};
+        } else {
+            appInstance->m_previewRect = {(int)viewport->WorkPos.x,
+                                         (int)viewport->WorkPos.y,
+                                         (int)viewport->WorkSize.x,
+                                         (int)viewport->WorkSize.y};
+        }
+#else
+        appInstance->m_previewRect = {(int)viewport->WorkPos.x,
+                                     (int)viewport->WorkPos.y,
+                                     (int)viewport->WorkSize.x,
+                                     (int)viewport->WorkSize.y};
 #endif
 
         // 1. Files Panel
@@ -244,17 +261,7 @@ namespace GuiOverlay {
         }
         ImGui::End();
 
-        // 2. Preview Panel
-        ImGui::PushStyleVar(ImGuiStyleVar_WindowPadding, ImVec2(0, 0));
-        if (ImGui::Begin("Preview")) {
-            ImVec2 pos = ImGui::GetCursorScreenPos();
-            ImVec2 size = ImGui::GetContentRegionAvail();
-            appInstance->m_previewRect = {(int)pos.x, (int)pos.y, (int)std::max(1.0f, size.x), (int)std::max(1.0f, size.y)};
-        } else {
-            appInstance->m_previewRect = {0, 0, 0, 0};
-        }
-        ImGui::End();
-        ImGui::PopStyleVar();
+
 
         // 3. Controls & Export Panel
         if (ImGui::Begin("Controls & Export")) {


### PR DESCRIPTION
## Summary
- punch a hole in the dockspace so the Vulkan preview shows through
- track the dockspace central node to update `m_previewRect`
- draw video only inside that rect

## Testing
- `git diff --stat`


------
https://chatgpt.com/codex/tasks/task_e_687dd57aee4c83279e9a6ccffb564036