### PR TITLE
Add default docking layout

### DIFF
--- a/src/Gui/GuiRender.cpp
+++ b/src/Gui/GuiRender.cpp
@@ -193,6 +193,29 @@ namespace GuiOverlay {
         return data;
     }
 
+    // Helper function to programmatically define the default docked layout.
+    // This is called only once when the layout is not yet configured.
+    void SubmitDockspaceLayout(ImGuiID dockspace_id) {
+        // Reset the layout to a known state
+        ImGui::DockBuilderRemoveNode(dockspace_id);
+        ImGui::DockBuilderAddNode(dockspace_id, ImGuiDockNodeFlags_DockSpace);
+        ImGui::DockBuilderSetNodeSize(dockspace_id, ImGui::GetMainViewport()->Size);
+
+        // Split the main dockspace into a left column for files and a right area for everything else.
+        ImGuiID dock_main_id = dockspace_id;
+        ImGuiID dock_id_left = ImGui::DockBuilderSplitNode(dock_main_id, ImGuiDir_Left, 0.25f, nullptr, &dock_main_id);
+
+        // Split the right area into a top part for the preview and a bottom part for controls/log.
+        ImGuiID dock_id_right_top = ImGui::DockBuilderSplitNode(dock_main_id, ImGuiDir_Up, 0.65f, nullptr, &dock_main_id);
+
+        // Assign our windows to the created dock nodes
+        ImGui::DockBuilderDockWindow("Files", dock_id_left);
+        ImGui::DockBuilderDockWindow("Preview", dock_id_right_top);
+        ImGui::DockBuilderDockWindow("Controls & Log", dock_main_id); // The remaining bottom-right area
+
+        ImGui::DockBuilderFinish(dockspace_id);
+    }
+
 
     void render(App* appInstance) {
 #ifdef MOTIONCAM_CONVERTER
@@ -201,6 +224,7 @@ namespace GuiOverlay {
         ImGuiViewport* viewport = ImGui::GetMainViewport();
         ImGui::SetNextWindowPos(viewport->WorkPos);
         ImGui::SetNextWindowSize(viewport->WorkSize);
+        ImGui::SetNextWindowViewport(viewport->ID);
         ImGui::PushStyleVar(ImGuiStyleVar_WindowRounding, 0.0f);
         ImGui::PushStyleVar(ImGuiStyleVar_WindowBorderSize, 0.0f);
         ImGui::PushStyleVar(ImGuiStyleVar_WindowPadding, ImVec2(0.0f, 0.0f));
@@ -212,13 +236,18 @@ namespace GuiOverlay {
         ImGui::Begin("MainDockSpace", nullptr, window_flags);
         ImGui::PopStyleVar(3);
 
-#if IMGUI_HAS_DOCK
+        // Create the dockspace and apply the default layout if it's the first time
         ImGuiID dockspace_id = ImGui::GetID("MyDockSpace");
+        if (!ImGui::DockBuilderGetNode(dockspace_id)) {
+            SubmitDockspaceLayout(dockspace_id);
+        }
         ImGui::DockSpace(dockspace_id, ImVec2(0.0f, 0.0f), ImGuiDockNodeFlags_None);
-#endif
+
+        // --- UI Panels ---
 
         // 1. Files Panel
         if (ImGui::Begin("Files")) {
+            // File management controls
             if (ImGui::Button("Add")) { appInstance->triggerOpenFileViaDialog(); }
             ImGui::SameLine();
             if (ImGui::Button("Remove") && appInstance->m_selectedBatchIndex != -1) {
@@ -248,20 +277,21 @@ namespace GuiOverlay {
         }
         ImGui::End();
 
-        // 2. Preview Panel - display the rendered texture
+        // 2. Preview Panel - Now it ONLY displays the image.
         ImGui::PushStyleVar(ImGuiStyleVar_WindowPadding, ImVec2(0, 0));
-        ImGuiWindowFlags preview_flags = ImGuiWindowFlags_NoScrollbar | ImGuiWindowFlags_NoScrollWithMouse | ImGuiWindowFlags_NoBackground;
-        if (ImGui::Begin("Preview", nullptr, preview_flags)) {
-            ImVec2 size = ImGui::GetContentRegionAvail();
+        ImGui::Begin("Preview");
+        if (appInstance->getRenderer()) {
             ImTextureID texID = (ImTextureID)appInstance->getRenderer()->getPreviewDescriptorSet();
-            if (texID)
+            if (texID) {
+                ImVec2 size = ImGui::GetContentRegionAvail();
                 ImGui::Image(texID, size);
+            }
         }
         ImGui::End();
         ImGui::PopStyleVar();
 
-        // 3. Controls & Export Panel
-        if (ImGui::Begin("Controls & Export")) {
+        // 3. Controls & Log Panel
+        if (ImGui::Begin("Controls & Log")) {
             bool paused = appInstance->m_playbackController_ptr ? appInstance->m_playbackController_ptr->isPaused() : true;
             if (ImGui::Button(paused ? "Play" : "Pause")) {
                 if (appInstance->m_playbackController_ptr) appInstance->m_playbackController_ptr->togglePause();
@@ -282,28 +312,30 @@ namespace GuiOverlay {
             }
             ImGui::PopItemWidth();
             ImGui::Separator();
-            if (appInstance->m_selectedBatchIndex != -1) {
-                int fmt = (int)appInstance->m_fileExportFormats[appInstance->m_selectedBatchIndex];
-                ImGui::Text("Export Format:");
-                ImGui::RadioButton("ProRes (CPU)", &fmt, (int)App::ExportFormat::PRORES_CPU); ImGui::SameLine();
-                ImGui::RadioButton("ProRes (GPU)", &fmt, (int)App::ExportFormat::PRORES_GPU);
-                ImGui::RadioButton("DNxHR (CPU)", &fmt, (int)App::ExportFormat::DNXHR_CPU); ImGui::SameLine();
-                ImGui::RadioButton("DNxHR (GPU)", &fmt, (int)App::ExportFormat::DNXHR_GPU);
-                ImGui::RadioButton("HEVC (GPU)", &fmt, (int)App::ExportFormat::HEVC_GPU); ImGui::SameLine();
-                ImGui::RadioButton("DNGs", &fmt, (int)App::ExportFormat::DNG);
-                appInstance->m_fileExportFormats[appInstance->m_selectedBatchIndex] = (App::ExportFormat)fmt;
-            }
-            ImGui::InputText("Output Folder", appInstance->m_outputFolder, sizeof(appInstance->m_outputFolder));
-            ImGui::SameLine();
-            if (ImGui::Button("Browse...")) {
-                std::string folder = appInstance->openFolderDialog();
-                if (!folder.empty()) strncpy(appInstance->m_outputFolder, folder.c_str(), sizeof(appInstance->m_outputFolder)-1);
-            }
-            if (ImGui::Button("Convert All", ImVec2(-1, 0)) && !appInstance->m_batchActive.load()) {
-                appInstance->startBatchConversion();
+            if (ImGui::CollapsingHeader("Export Settings", ImGuiTreeNodeFlags_DefaultOpen)) {
+                 if (appInstance->m_selectedBatchIndex != -1) {
+                    int fmt = (int)appInstance->m_fileExportFormats[appInstance->m_selectedBatchIndex];
+                    ImGui::Text("Export Format:");
+                    ImGui::RadioButton("ProRes (CPU)", &fmt, (int)App::ExportFormat::PRORES_CPU); ImGui::SameLine();
+                    ImGui::RadioButton("ProRes (GPU)", &fmt, (int)App::ExportFormat::PRORES_GPU);
+                    ImGui::RadioButton("DNxHR (CPU)", &fmt, (int)App::ExportFormat::DNXHR_CPU); ImGui::SameLine();
+                    ImGui::RadioButton("DNxHR (GPU)", &fmt, (int)App::ExportFormat::DNXHR_GPU);
+                    ImGui::RadioButton("HEVC (GPU)", &fmt, (int)App::ExportFormat::HEVC_GPU); ImGui::SameLine();
+                    ImGui::RadioButton("DNGs", &fmt, (int)App::ExportFormat::DNG);
+                    appInstance->m_fileExportFormats[appInstance->m_selectedBatchIndex] = (App::ExportFormat)fmt;
+                }
+                ImGui::InputText("Output Folder", appInstance->m_outputFolder, sizeof(appInstance->m_outputFolder));
+                ImGui::SameLine();
+                if (ImGui::Button("Browse...")) {
+                    std::string folder = appInstance->openFolderDialog();
+                    if (!folder.empty()) strncpy(appInstance->m_outputFolder, folder.c_str(), sizeof(appInstance->m_outputFolder)-1);
+                }
+                if (ImGui::Button("Convert All", ImVec2(-1, 0)) && !appInstance->m_batchActive.load()) {
+                    appInstance->startBatchConversion();
+                }
             }
             ImGui::Separator();
-            if (ImGui::CollapsingHeader("Log")) {
+            if (ImGui::CollapsingHeader("Log", ImGuiTreeNodeFlags_DefaultOpen)) {
                 ImGui::BeginChild("LogScrollingRegion");
                 for (const auto& line : appInstance->m_batchLog) ImGui::TextUnformatted(line.c_str());
                 if (ImGui::GetScrollY() >= ImGui::GetScrollMaxY()) ImGui::SetScrollHereY(1.0f);


### PR DESCRIPTION
## Summary
- add helper to build docking layout on first run
- clean up Preview and Controls windows
- keep existing player UI intact

## Testing
- `cmake ..`
- `cmake --build .` *(fails: libavutil/frame.h: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_687e00a85a14832788710ff4bca2fcc1