### PR TITLE
Add preview fullscreen toggle

### DIFF
--- a/include/App/App.h
+++ b/include/App/App.h
@@ -232,6 +232,7 @@ private:
     std::chrono::steady_clock::time_point m_pauseBegan;
 
     bool m_showUI = true;
+    bool m_previewFullscreen = false;
     bool m_isPanning = false;
     double m_lastMouseX = 0.0;
     double m_lastMouseY = 0.0;

--- a/src/App/AppInit.cpp
+++ b/src/App/AppInit.cpp
@@ -132,7 +132,7 @@ App::App(const std::string& filePath) :
     m_renderPrepTimeMs(0.0), m_guiRenderTimeMs(0.0), m_vkSubmitPresentTimeMs(0.0),
     m_appLogicTimeMs(0.0), m_sleepTimeMs(0.0), m_totalLoopTimeMs(0.0),
     m_decodedWidth(0), m_decodedHeight(0),
-    m_showUI(true), m_isPanning(false), m_lastMouseX(0.0), m_lastMouseY(0.0),
+    m_showUI(true), m_previewFullscreen(false), m_isPanning(false), m_lastMouseX(0.0), m_lastMouseY(0.0),
     m_firstFileLoaded(false),
     m_lastTitleUpdateTime(std::chrono::steady_clock::time_point::min()),
 #ifdef _WIN32

--- a/src/App/AppInput.cpp
+++ b/src/App/AppInput.cpp
@@ -255,6 +255,12 @@ void App::handleKey(int key, int mods) {
         m_cfaOverride = key - GLFW_KEY_1;
         LogToFile(std::string("[App::handleKey] ") + std::to_string(key - GLFW_KEY_0) + " pressed. CFA override set to: " + std::to_string(m_cfaOverride.value()));
     }
+    else if (key == GLFW_KEY_ENTER || key == GLFW_KEY_KP_ENTER) {
+        keyHandledByAppLogic = true;
+        m_previewFullscreen = !m_previewFullscreen;
+        LogToFile(std::string("[App::handleKey] Enter pressed. Preview fullscreen toggled: ") + (m_previewFullscreen ? "ON" : "OFF"));
+        showActionMessage(m_previewFullscreen ? "Preview Fullscreen" : "Preview Windowed");
+    }
     else if (key == GLFW_KEY_F || key == GLFW_KEY_F11) {
         keyHandledByAppLogic = true;
         LogToFile(std::string("[App::handleKey] F/F11 pressed. Toggling fullscreen. Was: ") + (m_isFullscreen ? "ON" : "OFF"));
@@ -305,7 +311,12 @@ void App::handleKey(int key, int mods) {
     }
     else if (key == GLFW_KEY_ESCAPE) {
         keyHandledByAppLogic = true;
-        if (m_isFullscreen) {
+        if (m_previewFullscreen) {
+            LogToFile("[App::handleKey] ESC pressed. Exiting preview fullscreen.");
+            m_previewFullscreen = false;
+            showActionMessage("Preview Windowed");
+        }
+        else if (m_isFullscreen) {
             LogToFile("[App::handleKey] ESC pressed. Exiting fullscreen.");
             glfwSetWindowMonitor(m_window, nullptr, m_storedWindowedPosX, m_storedWindowedPosY, m_storedWindowedWidth, m_storedWindowedHeight, 0);
             m_isFullscreen = false;

--- a/src/Gui/GuiRender.cpp
+++ b/src/Gui/GuiRender.cpp
@@ -200,6 +200,22 @@ namespace GuiOverlay {
         ImVec2 vp = viewport->WorkPos;
         ImVec2 vs = viewport->WorkSize;
 
+        if (appInstance->m_previewFullscreen) {
+            ImGuiWindowFlags fs_flags = ImGuiWindowFlags_NoMove | ImGuiWindowFlags_NoResize |
+                ImGuiWindowFlags_NoCollapse | ImGuiWindowFlags_NoTitleBar | ImGuiWindowFlags_NoScrollbar;
+            ImGui::SetNextWindowPos(vp);
+            ImGui::SetNextWindowSize(vs);
+            ImGui::Begin("PreviewFullscreen", nullptr, fs_flags);
+            {
+                ImVec2 size = ImGui::GetContentRegionAvail();
+                ImTextureID texID = (ImTextureID)appInstance->getRenderer()->getPreviewDescriptorSet();
+                if (texID)
+                    ImGui::Image(texID, size);
+            }
+            ImGui::End();
+            return;
+        }
+
         // Layout constants
         const float rightPanelWidth = 340.0f; // Fixed width for side panels
         const float filesPanelHeight = 260.0f; // Fixed height for Files panel


### PR DESCRIPTION
## Summary
- track preview fullscreen state in App
- initialize preview fullscreen state
- toggle preview fullscreen with Enter key and exit with Esc
- show preview-only GUI when preview fullscreen is active
- support keypad Enter

## Testing
- `cmake -S . -B build`
- `cmake --build build -j4` *(fails: cannot find -lavcodec.lib etc.)*

------
https://chatgpt.com/codex/tasks/task_e_687f584dc2d88327b6d12e2d1aa5c05d