### PR TITLE
UI and conversion improvements

### DIFF
--- a/include/App/App.h
+++ b/include/App/App.h
@@ -151,7 +151,19 @@ public:
     char m_outputFolder[1024] = "";
     std::vector<ExportFormat> m_fileExportFormats;
     bool m_previewOpen = true;
+    std::atomic<bool> m_singleExportActive{ false };
+    std::atomic<bool> m_cancelExportRequested{ false };
+    std::chrono::steady_clock::time_point m_exportStartTime{};
+    std::chrono::steady_clock::time_point m_currentFileExportStartTime{};
+    int m_batchCompletedFiles{ 0 };
+    std::string m_currentExportingFileName;
 #endif
+
+    void startSingleConversion(int fileIndex);
+    void stopAllExports();
+    double calculateTimeRemaining() const;
+    double getCurrentFileProgress() const;
+    double getBatchProgress() const;
 
     std::vector<VkImage> m_swapChainImages;
     std::atomic<size_t> m_activeFileLoadID{ 0 };

--- a/src/App/AppIO.cpp
+++ b/src/App/AppIO.cpp
@@ -15,6 +15,7 @@
 #ifndef TINY_DNG_WRITER_IMPLEMENTATION
 #define TINY_DNG_WRITER_IMPLEMENTATION
 #endif
+
 #include <tinydng/tiny_dng_writer.h>
 
 
@@ -1004,6 +1005,7 @@ App::DngExportResult App::convertCurrentFileToDngs() {
     }
 
     for (size_t i = 0; i < frameTimestamps.size(); ++i) {
+        if (m_cancelExportRequested.load()) { result.firstError = "cancelled"; break; }
         if (m_window && glfwWindowShouldClose(m_window)) {
             LogToFile("[App::convertCurrentFileToDngs] DNG export interrupted by window close request.");
             if (result.firstError.empty()) {
@@ -1563,6 +1565,7 @@ void App::exportCurrentClipToProRes(const std::string& outputPathOverride) {
         std::vector<uint8_t> rgbBuf;
         int64_t pts = 0;
         for (size_t idx = 0; idx < frames.size(); ++idx) {
+            if (m_cancelExportRequested.load()) { m_proResStatus.errorMsg = "cancelled"; break; }
             RawBytes raw;
             nlohmann::json metaTmp;
             auto t0 = std::chrono::steady_clock::now();
@@ -1624,6 +1627,7 @@ void App::exportCurrentClipToProRes(const std::string& outputPathOverride) {
             motioncam::AudioChunk chunk;
             int64_t audioPts = 0;
             while (loader && loader->next(chunk)) {
+                if (m_cancelExportRequested.load()) { m_proResStatus.errorMsg = "cancelled"; break; }
                 if (chunk.second.empty()) break;
                 AVFrame* af = av_frame_alloc();
                 af->format = actx->sample_fmt;
@@ -2103,6 +2107,7 @@ void App::exportCurrentClipToDNxHR(const std::string& outputPathOverride) {
         std::vector<uint8_t> rgbBuf;
         int64_t pts = 0;
         for (size_t idx = 0; idx < frames.size(); ++idx) {
+            if (m_cancelExportRequested.load()) { m_dnxhrStatus.errorMsg = "cancelled"; break; }
             RawBytes raw;
             nlohmann::json metaTmp;
             auto t0 = std::chrono::steady_clock::now();
@@ -2178,6 +2183,7 @@ void App::exportCurrentClipToDNxHR(const std::string& outputPathOverride) {
             motioncam::AudioChunk chunk;
             int64_t audioPts = 0;
             while (loader && loader->next(chunk)) {
+                if (m_cancelExportRequested.load()) { m_dnxhrStatus.errorMsg = "cancelled"; break; }
                 if (chunk.second.empty()) break;
                 AVFrame* af = av_frame_alloc();
                 af->format = actx->sample_fmt;
@@ -2639,6 +2645,7 @@ void App::exportCurrentClipToHEVC_AMD(const std::string& outputPathOverride) {
         int framesEncoded = 0;
 
         for (size_t idx = 0; idx < frames.size(); ++idx) {
+            if (m_cancelExportRequested.load()) { m_hevcStatus.errorMsg = "cancelled"; break; }
             try { dec->loadFrame(frames[idx], raw, meta); }
             catch (...) { m_hevcStatus.errorMsg = "Frame read error"; break; }
 
@@ -2686,6 +2693,7 @@ void App::exportCurrentClipToHEVC_AMD(const std::string& outputPathOverride) {
             motioncam::AudioChunk chunk;
             int64_t audioPts = 0;
             while (loader && loader->next(chunk)) {
+                if (m_cancelExportRequested.load()) { m_hevcStatus.errorMsg = "cancelled"; break; }
                 if (chunk.second.empty()) break;
                 AVFrame* af = av_frame_alloc();
                 af->format = actx->sample_fmt;
@@ -2804,9 +2812,12 @@ void App::loadFileForExport(const std::string& path) {
 
 #ifdef MOTIONCAM_CONVERTER
 void App::startBatchConversion() {
-    if (m_batchActive.load()) return;
+    if (m_batchActive.load() || m_singleExportActive.load()) return;
     m_batchActive.store(true);
+    m_cancelExportRequested.store(false);
     m_batchLog.clear();
+    m_exportStartTime = std::chrono::steady_clock::now();
+    m_batchCompletedFiles = 0;
     namespace fs = std::filesystem;
     fs::path logDir = fs::path(getLogDirectory());
     std::error_code ec;
@@ -2816,8 +2827,11 @@ void App::startBatchConversion() {
     m_batchThread = std::thread([this, logFile = std::move(logFile)]() mutable {
         namespace fs = std::filesystem;
         for (size_t i = 0; i < m_fileList.size(); ++i) {
+            if (m_cancelExportRequested.load()) break;
             if (m_window && glfwWindowShouldClose(m_window)) break;
             const std::string& path = m_fileList[i];
+            m_currentFileExportStartTime = std::chrono::steady_clock::now();
+            m_currentExportingFileName = fs::path(path).filename().string();
             m_batchLog.push_back(std::string("Converting ") + fs::path(path).filename().string() + "...");
             if (logFile.is_open()) logFile << "[start] " << fs::path(path).filename().string() << std::endl;
             m_currentFileIndex = static_cast<int>(i);
@@ -2906,10 +2920,92 @@ void App::startBatchConversion() {
                 break;
             }
             if (logFile.is_open()) logFile << "[end] " << fs::path(path).filename().string() << std::endl;
+            if (!m_cancelExportRequested.load()) ++m_batchCompletedFiles;
         }
         m_batchLog.push_back("Batch finished");
         if (logFile.is_open()) logFile << "[summary] total=" << m_fileList.size() << std::endl;
-        m_batchActive.store(false);
+    m_batchActive.store(false);
     });
 }
 #endif
+
+void App::startSingleConversion(int fileIndex) {
+#ifdef MOTIONCAM_CONVERTER
+    if (m_batchActive.load() || m_singleExportActive.load()) return;
+    if (fileIndex < 0 || fileIndex >= static_cast<int>(m_fileList.size())) return;
+    m_singleExportActive.store(true);
+    m_cancelExportRequested.store(false);
+    m_exportStartTime = std::chrono::steady_clock::now();
+    m_batchCompletedFiles = 0;
+    namespace fs = std::filesystem;
+    std::string path = m_fileList[fileIndex];
+    m_currentExportingFileName = fs::path(path).filename().string();
+    ExportFormat fmt = ExportFormat::PRORES_CPU;
+    if (fileIndex < m_fileExportFormats.size()) fmt = m_fileExportFormats[fileIndex];
+    m_batchThread = std::thread([this, path, fmt]() {
+        namespace fs = std::filesystem;
+        m_currentFileExportStartTime = std::chrono::steady_clock::now();
+        loadFileForExport(path);
+        std::string outFolder = m_outputFolder[0] ? std::string(m_outputFolder) : fs::path(path).parent_path().string();
+        std::string stem = fs::path(path).stem().string();
+        std::string outPath;
+        switch (fmt) {
+        case ExportFormat::PRORES_CPU: outPath = (fs::path(outFolder) / (stem + ".mov")).string(); exportCurrentClipToProRes(outPath); break;
+        case ExportFormat::PRORES_GPU: outPath = (fs::path(outFolder) / (stem + ".mov")).string(); convertCurrentClipToProRes(outPath); break;
+        case ExportFormat::DNXHR_CPU: outPath = (fs::path(outFolder) / (stem + ".mov")).string(); exportCurrentClipToDNxHR(outPath); break;
+        case ExportFormat::DNXHR_GPU: outPath = (fs::path(outFolder) / (stem + ".mov")).string(); convertCurrentClipToDNxHR(outPath); break;
+        case ExportFormat::HEVC_CPU: outPath = (fs::path(outFolder) / (stem + ".mp4")).string(); exportCurrentClipToHEVC_AMD(outPath); break;
+        case ExportFormat::HEVC_GPU: outPath = (fs::path(outFolder) / (stem + ".mp4")).string(); convertCurrentClipToHEVC_AMD(outPath); break;
+        case ExportFormat::DNG: convertCurrentFileToDngs(); break;
+        }
+        m_batchCompletedFiles = 1;
+        m_singleExportActive.store(false);
+    });
+#endif
+}
+
+void App::stopAllExports() {
+#ifdef MOTIONCAM_CONVERTER
+    m_cancelExportRequested.store(true);
+#ifdef ENABLE_PRORES_EXPORT
+    if (m_proResThread.joinable()) m_proResThread.join();
+    if (m_dnxhrThread.joinable()) m_dnxhrThread.join();
+    if (m_hevcThread.joinable()) m_hevcThread.join();
+#endif
+    if (m_batchThread.joinable()) m_batchThread.join();
+    m_batchActive.store(false);
+    m_singleExportActive.store(false);
+    m_cancelExportRequested.store(false);
+#endif
+}
+
+double App::getCurrentFileProgress() const {
+#ifdef ENABLE_PRORES_EXPORT
+    if (m_proResStatus.active.load()) return (double)m_proResStatus.currentFrame.load() / std::max(1, m_proResStatus.totalFrames);
+    if (m_dnxhrStatus.active.load()) return (double)m_dnxhrStatus.currentFrame.load() / std::max(1, m_dnxhrStatus.totalFrames);
+    if (m_hevcStatus.active.load()) return (double)m_hevcStatus.currentFrame.load() / std::max(1, m_hevcStatus.totalFrames);
+#endif
+    return 0.0;
+}
+
+double App::getBatchProgress() const {
+#ifdef MOTIONCAM_CONVERTER
+    double cur = getCurrentFileProgress();
+    size_t total = m_singleExportActive.load() ? 1 : m_fileList.size();
+    if (total == 0) return 0.0;
+    return (m_batchCompletedFiles + cur) / (double)total;
+#else
+    return 0.0;
+#endif
+}
+
+double App::calculateTimeRemaining() const {
+#ifdef MOTIONCAM_CONVERTER
+    double progress = getBatchProgress();
+    if (progress <= 0.0) return 0.0;
+    auto elapsed = std::chrono::duration<double>(std::chrono::steady_clock::now() - m_exportStartTime).count();
+    return elapsed * (1.0 - progress) / progress;
+#else
+    return 0.0;
+#endif
+}

--- a/src/App/AppLoop.cpp
+++ b/src/App/AppLoop.cpp
@@ -163,33 +163,11 @@ bool App::run() {
         loopEndTime = steady_clock::now();
         m_totalLoopTimeMs = std::chrono::duration<double, std::milli>(loopEndTime - loopStartTime).count();
 
-        // Update UI auto-hide and fade. Keep UI visible while exporting.
+        // UI auto-hide disabled, keep UI always visible
         {
-            bool exporting = false;
-#ifdef ENABLE_PRORES_EXPORT
-            exporting = m_proResStatus.active.load();
-#endif
-            if (!exporting) {
-                steady_clock::time_point now = steady_clock::now();
-                double idleSec = std::chrono::duration<double>(now - m_lastInteractionTime).count();
-                if (m_showUI && !m_uiAutoHidden && idleSec >= m_uiAutoHideDelaySec) {
-                    m_uiAutoHidden = true;
-                }
-
-                float dt = std::chrono::duration<float>(now - m_lastUiFadeUpdate).count();
-                m_lastUiFadeUpdate = now;
-                float targetAlpha = (m_showUI && !m_uiAutoHidden) ? 1.0f : 0.0f;
-                if (m_uiOpacity < targetAlpha) {
-                    m_uiOpacity = std::min(targetAlpha, m_uiOpacity + dt * m_uiFadeSpeed);
-                } else if (m_uiOpacity > targetAlpha) {
-                    m_uiOpacity = std::max(targetAlpha, m_uiOpacity - dt * m_uiFadeSpeed);
-                }
-            } else {
-                // Force UI fully visible during export
-                m_uiAutoHidden = false;
-                m_uiOpacity = 1.0f;
-                m_lastUiFadeUpdate = steady_clock::now();
-            }
+            m_uiAutoHidden = false;
+            m_uiOpacity = 1.0f;
+            m_lastUiFadeUpdate = steady_clock::now();
         }
 
         {

--- a/src/Gui/GuiRender.cpp
+++ b/src/Gui/GuiRender.cpp
@@ -235,8 +235,20 @@ namespace GuiOverlay {
 
         ImGuiWindowFlags fixed_flags = ImGuiWindowFlags_NoMove | ImGuiWindowFlags_NoResize | ImGuiWindowFlags_NoCollapse | ImGuiWindowFlags_NoTitleBar | ImGuiWindowFlags_NoScrollbar | ImGuiWindowFlags_NoBringToFrontOnFocus;
 
-        // 1. Timeline/Play controls (above Preview)
+        // 1. Preview Panel (top left)
         ImGui::SetNextWindowPos(ImVec2(vp.x, vp.y));
+        ImGui::SetNextWindowSize(ImVec2(previewWidth, previewHeight));
+        ImGui::Begin("Preview", nullptr, fixed_flags);
+        {
+            ImVec2 size = ImGui::GetContentRegionAvail();
+            ImTextureID texID = (ImTextureID)appInstance->getRenderer()->getPreviewDescriptorSet();
+            if (texID)
+                ImGui::Image(texID, size);
+        }
+        ImGui::End();
+
+        // 2. Timeline/Play controls (below Preview)
+        ImGui::SetNextWindowPos(ImVec2(vp.x, vp.y + previewHeight + panelSpacing));
         ImGui::SetNextWindowSize(ImVec2(previewWidth, timelinePanelHeight));
         ImGui::Begin("TimelineControls", nullptr, fixed_flags);
         {
@@ -262,22 +274,11 @@ namespace GuiOverlay {
         }
         ImGui::End();
 
-        // 2. Preview Panel
-        ImGui::SetNextWindowPos(ImVec2(vp.x, vp.y + timelinePanelHeight + panelSpacing));
-        ImGui::SetNextWindowSize(ImVec2(previewWidth, previewHeight));
-        ImGui::Begin("Preview", nullptr, fixed_flags);
-        {
-            ImVec2 size = ImGui::GetContentRegionAvail();
-            ImTextureID texID = (ImTextureID)appInstance->getRenderer()->getPreviewDescriptorSet();
-            if (texID)
-                ImGui::Image(texID, size);
-        }
-        ImGui::End();
-
         // 3. Files Panel (fixed size, top right)
         ImGui::SetNextWindowPos(ImVec2(vp.x + previewWidth + panelSpacing, vp.y));
         ImGui::SetNextWindowSize(ImVec2(rightPanelWidth, filesPanelHeight));
         ImGui::Begin("Files", nullptr, fixed_flags);
+        ImGui::BeginDisabled(appInstance->m_batchActive.load() || appInstance->m_singleExportActive.load());
         {
             if (ImGui::Button("Add")) { appInstance->triggerOpenFileViaDialog(); }
             ImGui::SameLine();
@@ -306,12 +307,14 @@ namespace GuiOverlay {
             }
             ImGui::EndChild();
         }
+        ImGui::EndDisabled();
         ImGui::End();
 
         // 4. Controls & Export Panel (fixed width, fills right column below Files)
         ImGui::SetNextWindowPos(ImVec2(vp.x + previewWidth + panelSpacing, vp.y + filesPanelHeight + panelSpacing));
         ImGui::SetNextWindowSize(ImVec2(rightPanelWidth, controlsPanelHeight));
         ImGui::Begin("Controls & Export", nullptr, fixed_flags);
+        ImGui::BeginDisabled(appInstance->m_batchActive.load() || appInstance->m_singleExportActive.load());
         {
             if (appInstance->m_selectedBatchIndex != -1) {
                 int fmt = (int)appInstance->m_fileExportFormats[appInstance->m_selectedBatchIndex];
@@ -329,14 +332,30 @@ namespace GuiOverlay {
                 std::string folder = appInstance->openFolderDialog();
                 if (!folder.empty()) strncpy(appInstance->m_outputFolder, folder.c_str(), sizeof(appInstance->m_outputFolder)-1);
             }
-            if (ImGui::Button("Convert All", ImVec2(-1, 0)) && !appInstance->m_batchActive.load()) {
+            if (ImGui::Button("Convert All", ImVec2(-1, 0))) {
                 appInstance->startBatchConversion();
             }
+            if (ImGui::Button("Convert Selected", ImVec2(-1, 0))) {
+                appInstance->startSingleConversion(appInstance->m_selectedBatchIndex);
+            }
+        }
+        ImGui::EndDisabled();
+        if (appInstance->m_batchActive.load() || appInstance->m_singleExportActive.load()) {
+            if (ImGui::Button("Stop Conversion", ImVec2(-1, 0))) {
+                appInstance->stopAllExports();
+            }
+            double cur = appInstance->getCurrentFileProgress();
+            double batch = appInstance->getBatchProgress();
+            double eta = appInstance->calculateTimeRemaining();
+            ImGui::ProgressBar(static_cast<float>(cur), ImVec2(-1, 0), "Current");
+            ImGui::ProgressBar(static_cast<float>(batch), ImVec2(-1, 0), "Batch");
+            ImGui::Text("%s", appInstance->m_currentExportingFileName.c_str());
+            ImGui::Text("ETA: %.1fs", eta);
         }
         ImGui::End();
 
         // 5. Log Panel (bottom left, only as wide as Preview)
-        ImGui::SetNextWindowPos(ImVec2(vp.x, vp.y + timelinePanelHeight + panelSpacing + previewHeight + panelSpacing));
+        ImGui::SetNextWindowPos(ImVec2(vp.x, vp.y + previewHeight + panelSpacing + timelinePanelHeight + panelSpacing));
         ImGui::SetNextWindowSize(ImVec2(previewWidth, logPanelHeight));
         ImGui::Begin("Log", nullptr, fixed_flags);
         {


### PR DESCRIPTION
## Summary
- add flags and helpers for canceling exports and single-file conversion
- move timeline controls below the preview panel and expand export UI
- keep the UI visible by disabling the auto-hide fade
- implement new conversion control methods and progress calculations

## Testing
- `cmake -S . -B build`
- `cmake --build build` *(fails: libavutil/frame.h not found)*

------
https://chatgpt.com/codex/tasks/task_e_687f8b170890832793a3d574342308ef