### PR TITLE
UI and export tweaks

### DIFF
--- a/include/App/App.h
+++ b/include/App/App.h
@@ -143,18 +143,21 @@ public:
         HEVC_GPU,
         DNG
     };
-    void startBatchConversion();
+    void startBatchConversion(ExportFormat fmtForAll);
     void startSingleConversion(int fileIndex);
     void stopAllExports();
     double calculateTimeRemaining() const;
     double getCurrentFileProgress() const;
+    double getCurrentFps() const;
     double getBatchProgress() const;
+    void openFolderInExplorer(const std::string& path);
     std::vector<std::string> m_batchLog;
     std::atomic<bool> m_batchActive{ false };
     std::thread m_batchThread;
     int m_selectedBatchIndex = -1;
     char m_outputFolder[1024] = "";
     std::vector<ExportFormat> m_fileExportFormats;
+    ExportFormat m_globalExportFormat{ ExportFormat::PRORES_CPU };
     bool m_previewOpen = true;
 #endif
 

--- a/src/App/AppIO.cpp
+++ b/src/App/AppIO.cpp
@@ -17,6 +17,21 @@
 #endif
 #include <tinydng/tiny_dng_writer.h>
 
+#include <array>
+
+static const char* exportFormatName(App::ExportFormat fmt) {
+    switch (fmt) {
+    case App::ExportFormat::PRORES_CPU: return "ProRes CPU";
+    case App::ExportFormat::PRORES_GPU: return "ProRes GPU";
+    case App::ExportFormat::DNXHR_CPU:  return "DNxHR CPU";
+    case App::ExportFormat::DNXHR_GPU:  return "DNxHR GPU";
+    case App::ExportFormat::HEVC_CPU:   return "HEVC CPU";
+    case App::ExportFormat::HEVC_GPU:   return "HEVC GPU";
+    case App::ExportFormat::DNG:        return "DNG";
+    }
+    return "Unknown";
+}
+
 
 #include <filesystem>
 #include <thread>
@@ -2818,13 +2833,15 @@ void App::loadFileForExport(const std::string& path) {
 }
 
 #ifdef MOTIONCAM_CONVERTER
-void App::startBatchConversion() {
+void App::startBatchConversion(ExportFormat fmtForAll) {
     if (m_batchActive.load()) return;
     m_batchActive.store(true);
     m_cancelExportRequested.store(false);
     m_exportStartTime = std::chrono::steady_clock::now();
     m_batchCompletedFiles = 0;
     m_batchLog.clear();
+    m_globalExportFormat = fmtForAll;
+    for (auto& f : m_fileExportFormats) f = fmtForAll;
     namespace fs = std::filesystem;
     fs::path logDir = fs::path(getLogDirectory());
     std::error_code ec;
@@ -2840,6 +2857,7 @@ void App::startBatchConversion() {
             m_currentExportingFileName = fs::path(path).filename().string();
             m_currentFileExportStartTime = std::chrono::steady_clock::now();
             m_batchLog.push_back(std::string("Converting ") + fs::path(path).filename().string() + "...");
+            LogToFile(std::string("[Batch] Starting ") + fs::path(path).filename().string());
             if (logFile.is_open()) logFile << "[start] " << fs::path(path).filename().string() << std::endl;
             m_currentFileIndex = static_cast<int>(i);
             loadFileForExport(path);
@@ -2848,6 +2866,7 @@ void App::startBatchConversion() {
             std::string outPath;
             ExportFormat fmt = ExportFormat::PRORES_CPU;
             if (i < m_fileExportFormats.size()) fmt = m_fileExportFormats[i];
+            LogToFile(std::string("[Batch] Format: ") + exportFormatName(fmt));
             switch (fmt) {
             case ExportFormat::PRORES_CPU:
                 outPath = (fs::path(outFolder) / (stem + ".mov")).string();
@@ -3092,6 +3111,17 @@ double App::getCurrentFileProgress() const {
     if (m_proResStatus.active.load()) return m_proResStatus.totalFrames ? (double)m_proResStatus.currentFrame.load() / m_proResStatus.totalFrames : 0.0;
     if (m_dnxhrStatus.active.load()) return m_dnxhrStatus.totalFrames ? (double)m_dnxhrStatus.currentFrame.load() / m_dnxhrStatus.totalFrames : 0.0;
     if (m_hevcStatus.active.load()) return m_hevcStatus.totalFrames ? (double)m_hevcStatus.currentFrame.load() / m_hevcStatus.totalFrames : 0.0;
+#endif
+    return 0.0;
+}
+
+double App::getCurrentFps() const {
+#ifdef ENABLE_PRORES_EXPORT
+    auto elapsedMs = std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::steady_clock::now() - m_currentFileExportStartTime).count();
+    if (elapsedMs <= 0) return 0.0;
+    if (m_proResStatus.active.load()) return m_proResStatus.currentFrame.load() * 1000.0 / elapsedMs;
+    if (m_dnxhrStatus.active.load()) return m_dnxhrStatus.currentFrame.load() * 1000.0 / elapsedMs;
+    if (m_hevcStatus.active.load()) return m_hevcStatus.currentFrame.load() * 1000.0 / elapsedMs;
 #endif
     return 0.0;
 }

--- a/src/App/AppInput.cpp
+++ b/src/App/AppInput.cpp
@@ -14,6 +14,7 @@
 #include <GLFW/glfw3native.h>
 #include <ShlObj.h>
 #include <commdlg.h>
+#include <shellapi.h>
 namespace DebugLogHelper {
     extern std::string wstring_to_utf8(const std::wstring& wstr);
 }
@@ -651,6 +652,23 @@ std::string App::openFolderDialog() {
     return folder;
 #endif
     return {};
+}
+
+void App::openFolderInExplorer(const std::string& path) {
+#ifdef _WIN32
+    int len = MultiByteToWideChar(CP_UTF8, 0, path.c_str(), -1, NULL, 0);
+    if (len > 0) {
+        std::wstring w(len, L'\0');
+        MultiByteToWideChar(CP_UTF8, 0, path.c_str(), -1, w.data(), len);
+        ShellExecuteW(NULL, L"open", w.c_str(), NULL, NULL, SW_SHOWDEFAULT);
+    }
+#elif __APPLE__
+    std::string cmd = "open \"" + path + "\"";
+    system(cmd.c_str());
+#else
+    std::string cmd = "xdg-open \"" + path + "\"";
+    system(cmd.c_str());
+#endif
 }
 
 void App::triggerOpenFileViaDialog() {

--- a/src/Gui/GuiRender.cpp
+++ b/src/Gui/GuiRender.cpp
@@ -225,12 +225,11 @@ namespace GuiOverlay {
         const float filesPanelHeight = 260.0f; // Fixed height for Files panel
         const float controlsPanelMinHeight = 200.0f; // Minimum height for Controls panel
         const float timelinePanelHeight = 60.0f; // Height for play/timeline controls
-        const float logPanelHeight = 120.0f; // Fixed height for Log panel
+        const float logPanelHeight = 180.0f; // Fixed height for Log panel (taller)
         const float panelSpacing = 3.0f;
 
         float previewWidth = vs.x - rightPanelWidth - panelSpacing;
-        // With timeline moved below preview there are only two gaps
-        float previewHeight = vs.y - timelinePanelHeight - logPanelHeight - panelSpacing * 2;
+        float previewHeight = vs.y - logPanelHeight - panelSpacing;
         float controlsPanelHeight = vs.y - filesPanelHeight - panelSpacing * 2;
         if (controlsPanelHeight < controlsPanelMinHeight) controlsPanelHeight = controlsPanelMinHeight;
 
@@ -248,10 +247,11 @@ namespace GuiOverlay {
         }
         ImGui::End();
 
-        // 2. Timeline/Play controls (below Preview)
-        ImGui::SetNextWindowPos(ImVec2(vp.x, vp.y + previewHeight + panelSpacing));
-        ImGui::SetNextWindowSize(ImVec2(previewWidth, timelinePanelHeight));
-        ImGui::Begin("TimelineControls", nullptr, fixed_flags);
+        // 2. Timeline/Play controls (overlay on Preview)
+        ImGui::SetNextWindowBgAlpha(0.5f);
+        ImGui::SetNextWindowPos(ImVec2(vp.x + previewWidth * 0.1f, vp.y + previewHeight - timelinePanelHeight - 10.0f));
+        ImGui::SetNextWindowSize(ImVec2(previewWidth * 0.8f, timelinePanelHeight));
+        ImGui::Begin("TimelineControls", nullptr, fixed_flags | ImGuiWindowFlags_NoBringToFrontOnFocus);
         {
             bool paused = appInstance->m_playbackController_ptr ? appInstance->m_playbackController_ptr->isPaused() : true;
             if (ImGui::Button(paused ? "Play" : "Pause")) {
@@ -263,6 +263,7 @@ namespace GuiOverlay {
                         if (appInstance->m_audio) appInstance->m_audio->setPaused(nowPaused);
                         if (nowPaused) appInstance->recordPauseTime();
                         else appInstance->anchorPlaybackTimeForResume();
+                        appInstance->m_ioThreadFileCv.notify_all();
                     }
                 }
             }
@@ -359,6 +360,11 @@ namespace GuiOverlay {
                 std::string folder = appInstance->openFolderDialog();
                 if (!folder.empty()) strncpy(appInstance->m_outputFolder, folder.c_str(), sizeof(appInstance->m_outputFolder)-1);
             }
+            ImGui::SameLine();
+            if (ImGui::Button("Open")) {
+                std::string folder = appInstance->m_outputFolder;
+                if (!folder.empty()) appInstance->openFolderInExplorer(folder);
+            }
             ImVec4 btn = ImVec4(0.3f, 0.4f, 0.6f, 1.0f);
             ImVec4 hover = ImVec4(0.35f, 0.45f, 0.65f, 1.0f);
             ImVec4 active = ImVec4(0.2f, 0.3f, 0.5f, 1.0f);
@@ -366,7 +372,10 @@ namespace GuiOverlay {
             ImGui::PushStyleColor(ImGuiCol_ButtonHovered, hover);
             ImGui::PushStyleColor(ImGuiCol_ButtonActive, active);
             if (ImGui::Button("Convert All") && !exporting) {
-                appInstance->startBatchConversion();
+                App::ExportFormat fmt = App::ExportFormat::PRORES_CPU;
+                if (appInstance->m_selectedBatchIndex != -1 && appInstance->m_selectedBatchIndex < (int)appInstance->m_fileExportFormats.size())
+                    fmt = appInstance->m_fileExportFormats[appInstance->m_selectedBatchIndex];
+                appInstance->startBatchConversion(fmt);
             }
             ImGui::SameLine();
             if (ImGui::Button("Convert Selected") && appInstance->m_selectedBatchIndex != -1 && !exporting) {
@@ -385,20 +394,27 @@ namespace GuiOverlay {
                 ImGui::ProgressBar(batch, ImVec2(-1,0));
                 ImGui::Text("%s", appInstance->m_currentExportingFileName.c_str());
                 double eta = appInstance->calculateTimeRemaining();
-                if (eta > 0.0) ImGui::Text("ETA %.1fs", eta);
+                double fps = appInstance->getCurrentFps();
+                if (eta > 0.0)
+                    ImGui::Text("ETA %.1fs (%.1f fps)", eta, fps);
+                else if (fps > 0.0)
+                    ImGui::Text("%.1f fps", fps);
             }
         }
         ImGui::End();
 
         // 5. Log Panel (bottom left, only as wide as Preview)
-        ImGui::SetNextWindowPos(ImVec2(vp.x, vp.y + previewHeight + panelSpacing + timelinePanelHeight + panelSpacing));
+        ImGui::SetNextWindowPos(ImVec2(vp.x, vp.y + previewHeight + panelSpacing));
         ImGui::SetNextWindowSize(ImVec2(previewWidth, logPanelHeight));
         ImGui::Begin("Log", nullptr, fixed_flags);
         {
-            if (ImGui::Button("Clear Logs")) appInstance->m_batchLog.clear();
             ImGui::BeginChild("LogScrollingRegion", ImVec2(0,0), true);
             for (const auto& line : appInstance->m_batchLog) ImGui::TextUnformatted(line.c_str());
             if (ImGui::GetScrollY() >= ImGui::GetScrollMaxY()) ImGui::SetScrollHereY(1.0f);
+            ImVec2 btnSize = ImVec2(70, 0);
+            ImGui::SetCursorPos(ImVec2(ImGui::GetWindowWidth() - btnSize.x - 4,
+                                       ImGui::GetWindowHeight() - ImGui::GetFrameHeight() - 4));
+            if (ImGui::Button("Clear", btnSize)) appInstance->m_batchLog.clear();
             ImGui::EndChild();
         }
         ImGui::End();


### PR DESCRIPTION
## Summary
- overlay timeline controls over the preview and widen
- enlarge log panel and put clear button inside
- open output folder in explorer
- allow setting batch conversion format for all files
- display active FPS during conversion
- notify worker threads on play toggle
- fix layout by using supported ImGui APIs

## Testing
- `cmake -S . -B build`
- `cmake --build build -j 4` *(fails: libavutil/frame.h missing)*

------
https://chatgpt.com/codex/tasks/task_e_687f9ab9f80483279eac3e3680ded0a6