### PR TITLE
Improve batch preview and folder dialog

### DIFF
--- a/src/App/AppInput.cpp
+++ b/src/App/AppInput.cpp
@@ -634,6 +634,7 @@ std::string App::openSaveMp4Dialog() {
 std::string App::openFolderDialog() {
 #ifdef _WIN32
     std::string folder;
+    HRESULT hrInit = CoInitializeEx(NULL, COINIT_APARTMENTTHREADED | COINIT_DISABLE_OLE1DDE);
     IFileDialog* dialog = nullptr;
     if (SUCCEEDED(CoCreateInstance(CLSID_FileOpenDialog, nullptr, CLSCTX_INPROC_SERVER, IID_PPV_ARGS(&dialog)))) {
         DWORD opts = 0;
@@ -654,6 +655,7 @@ std::string App::openFolderDialog() {
         }
         dialog->Release();
     }
+    if (SUCCEEDED(hrInit)) CoUninitialize();
     return folder;
 #else
     std::string folder;

--- a/src/App/AppLoop.cpp
+++ b/src/App/AppLoop.cpp
@@ -61,6 +61,7 @@ bool App::run() {
             bool oldFirst = m_firstFileLoaded;
             m_firstFileLoaded = true;
             loadFileAtIndex(idx);
+            m_selectedBatchIndex = idx;
             m_firstFileLoaded = oldFirst;
         }
 

--- a/src/Gui/GuiRender.cpp
+++ b/src/Gui/GuiRender.cpp
@@ -248,7 +248,7 @@ namespace GuiOverlay {
         ImGui::End();
 
         // 2. Timeline/Play controls (overlay on Preview)
-        ImGui::SetNextWindowBgAlpha(0.5f);
+        ImGui::SetNextWindowBgAlpha(0.75f);
         ImGui::SetNextWindowPos(ImVec2(vp.x + previewWidth * 0.1f, vp.y + previewHeight - timelinePanelHeight - 10.0f));
         ImGui::SetNextWindowSize(ImVec2(previewWidth * 0.8f, timelinePanelHeight));
         ImGui::Begin("TimelineControls", nullptr, fixed_flags | ImGuiWindowFlags_NoBringToFrontOnFocus);
@@ -300,17 +300,22 @@ namespace GuiOverlay {
             ImGui::BeginDisabled(exporting);
             if (ImGui::Button("Add")) { appInstance->triggerOpenFileViaDialog(); }
             ImGui::SameLine();
-            if (ImGui::Button("Remove") && appInstance->m_selectedBatchIndex != -1) {
+            bool removeClicked = ImGui::Button("Remove") && appInstance->m_selectedBatchIndex != -1;
+            ImGui::SameLine();
+            bool clearClicked = ImGui::Button("Clear");
+            ImGui::EndDisabled();
+
+            if (removeClicked) {
                 appInstance->m_fileList.erase(appInstance->m_fileList.begin() + appInstance->m_selectedBatchIndex);
                 appInstance->m_fileExportFormats.erase(appInstance->m_fileExportFormats.begin() + appInstance->m_selectedBatchIndex);
                 appInstance->m_selectedBatchIndex = -1;
             }
-            ImGui::SameLine();
-            if (ImGui::Button("Clear")) {
+            if (clearClicked) {
                 appInstance->m_fileList.clear();
                 appInstance->m_fileExportFormats.clear();
                 appInstance->m_selectedBatchIndex = -1;
             }
+
             ImGui::Separator();
             ImGui::BeginChild("FileListScrollingRegion");
             for (int i = 0; i < (int)appInstance->m_fileList.size(); ++i) {
@@ -324,7 +329,6 @@ namespace GuiOverlay {
                 }
             }
             ImGui::EndChild();
-            ImGui::EndDisabled();
         }
         ImGui::End();
 


### PR DESCRIPTION
## Summary
- update preview when moving to next batch item
- fix Windows folder picker initialization
- allow selecting files while exporting
- tweak timeline overlay appearance

## Testing
- `cmake -S . -B build`
- `cmake --build build` *(fails: libavutil/frame.h missing)*

------
https://chatgpt.com/codex/tasks/task_e_687fa5ecf8548327b565a875de4ae73c