### PR TITLE
Improve UI controls and conversion stats

### DIFF
--- a/include/App/App.h
+++ b/include/App/App.h
@@ -83,6 +83,7 @@ public:
     std::string m_cfaStringFromMetadata;
     bool m_showMetrics = false;
     bool m_showHelpPage = false;
+    bool m_showOutputFolderBrowser = false;
 
     double m_gpuWaitTimeMs = 0.0;
     double m_decodeTimeMs = 0.0;
@@ -149,6 +150,7 @@ public:
     double calculateTimeRemaining() const;
     double getCurrentFileProgress() const;
     double getBatchProgress() const;
+    double getCurrentFps() const;
     std::vector<std::string> m_batchLog;
     std::atomic<bool> m_batchActive{ false };
     std::thread m_batchThread;
@@ -267,6 +269,7 @@ private:
     float m_uiOpacity = 1.0f;
     double m_uiAutoHideDelaySec = 3.0;
     float m_uiFadeSpeed = 3.0f;
+    std::string m_folderBrowserPath;
 
 #ifdef ENABLE_PRORES_EXPORT
     struct ProResExportStatus {

--- a/src/App/AppIO.cpp
+++ b/src/App/AppIO.cpp
@@ -3110,4 +3110,20 @@ double App::calculateTimeRemaining() const {
     auto elapsed = std::chrono::duration_cast<std::chrono::seconds>(std::chrono::steady_clock::now() - m_exportStartTime).count();
     return (elapsed / progress) - elapsed;
 }
+
+double App::getCurrentFps() const {
+#ifdef ENABLE_PRORES_EXPORT
+    if (!m_batchActive.load() && !m_singleExportActive.load()) return 0.0;
+    auto elapsedMs = std::chrono::duration_cast<std::chrono::milliseconds>(
+        std::chrono::steady_clock::now() - m_exportStartTime).count();
+    if (elapsedMs <= 0) return 0.0;
+
+    int frame = 0;
+    if (m_proResStatus.active.load()) frame = m_proResStatus.currentFrame.load();
+    else if (m_dnxhrStatus.active.load()) frame = m_dnxhrStatus.currentFrame.load();
+    else if (m_hevcStatus.active.load()) frame = m_hevcStatus.currentFrame.load();
+    if (frame > 0) return frame * 1000.0 / elapsedMs;
+#endif
+    return 0.0;
+}
 #endif

--- a/src/App/AppInit.cpp
+++ b/src/App/AppInit.cpp
@@ -127,7 +127,7 @@ App::App(const std::string& filePath) :
     m_currentFrame(0), m_imguiDescriptorPool(VK_NULL_HANDLE),
     m_isFullscreen(false), m_cfaTypeFromMetadata(0), m_staticBlack(0.0), m_staticWhite(65535.0),
     m_dumpMetadata(false), m_currentFileIndex(-1),
-    m_showMetrics(false), m_showHelpPage(false),
+    m_showMetrics(false), m_showHelpPage(false), m_showOutputFolderBrowser(false),
     m_gpuWaitTimeMs(0.0), m_decodeTimeMs(0.0),
     m_renderPrepTimeMs(0.0), m_guiRenderTimeMs(0.0), m_vkSubmitPresentTimeMs(0.0),
     m_appLogicTimeMs(0.0), m_sleepTimeMs(0.0), m_totalLoopTimeMs(0.0),
@@ -145,7 +145,8 @@ App::App(const std::string& filePath) :
     m_uiAutoHidden(false),
     m_uiOpacity(1.0f),
     m_uiAutoHideDelaySec(3.0),
-    m_uiFadeSpeed(3.0f)
+    m_uiFadeSpeed(3.0f),
+    m_folderBrowserPath()
 #ifdef ENABLE_PRORES_EXPORT
     , m_showExportProgressPopup(false)
     , m_proResStatus()

--- a/src/Gui/GuiRender.cpp
+++ b/src/Gui/GuiRender.cpp
@@ -229,8 +229,7 @@ namespace GuiOverlay {
         const float panelSpacing = 3.0f;
 
         float previewWidth = vs.x - rightPanelWidth - panelSpacing;
-        // With timeline moved below preview there are only two gaps
-        float previewHeight = vs.y - timelinePanelHeight - logPanelHeight - panelSpacing * 2;
+        float previewHeight = vs.y - logPanelHeight - panelSpacing;
         float controlsPanelHeight = vs.y - filesPanelHeight - panelSpacing * 2;
         if (controlsPanelHeight < controlsPanelMinHeight) controlsPanelHeight = controlsPanelMinHeight;
 
@@ -248,9 +247,11 @@ namespace GuiOverlay {
         }
         ImGui::End();
 
-        // 2. Timeline/Play controls (below Preview)
-        ImGui::SetNextWindowPos(ImVec2(vp.x, vp.y + previewHeight + panelSpacing));
-        ImGui::SetNextWindowSize(ImVec2(previewWidth, timelinePanelHeight));
+        // 2. Timeline/Play controls (overlay bottom of Preview)
+        float timelineWidth = previewWidth * 0.6f;
+        ImGui::SetNextWindowPos(ImVec2(vp.x + previewWidth * 0.5f - timelineWidth * 0.5f,
+                                       vp.y + previewHeight - timelinePanelHeight - panelSpacing));
+        ImGui::SetNextWindowSize(ImVec2(timelineWidth, timelinePanelHeight));
         ImGui::Begin("TimelineControls", nullptr, fixed_flags);
         {
             bool paused = appInstance->m_playbackController_ptr ? appInstance->m_playbackController_ptr->isPaused() : true;
@@ -351,13 +352,11 @@ namespace GuiOverlay {
             }
             ImGui::InputText("Output Folder", appInstance->m_outputFolder, sizeof(appInstance->m_outputFolder));
             if (ImGui::IsItemActivated() && ImGui::IsMouseDoubleClicked(0)) {
-                std::string folder = appInstance->openFolderDialog();
-                if (!folder.empty()) strncpy(appInstance->m_outputFolder, folder.c_str(), sizeof(appInstance->m_outputFolder)-1);
+                appInstance->m_showOutputFolderBrowser = true;
             }
             ImGui::SameLine();
             if (ImGui::Button("Browse...")) {
-                std::string folder = appInstance->openFolderDialog();
-                if (!folder.empty()) strncpy(appInstance->m_outputFolder, folder.c_str(), sizeof(appInstance->m_outputFolder)-1);
+                appInstance->m_showOutputFolderBrowser = true;
             }
             ImVec4 btn = ImVec4(0.3f, 0.4f, 0.6f, 1.0f);
             ImVec4 hover = ImVec4(0.35f, 0.45f, 0.65f, 1.0f);
@@ -385,23 +384,69 @@ namespace GuiOverlay {
                 ImGui::ProgressBar(batch, ImVec2(-1,0));
                 ImGui::Text("%s", appInstance->m_currentExportingFileName.c_str());
                 double eta = appInstance->calculateTimeRemaining();
-                if (eta > 0.0) ImGui::Text("ETA %.1fs", eta);
+                double fps = appInstance->getCurrentFps();
+                if (eta > 0.0) {
+                    if (fps > 0.0)
+                        ImGui::Text("ETA %.1fs (%.1f fps)", eta, fps);
+                    else
+                        ImGui::Text("ETA %.1fs", eta);
+                } else if (fps > 0.0) {
+                    ImGui::Text("%.1f fps", fps);
+                }
             }
         }
         ImGui::End();
 
         // 5. Log Panel (bottom left, only as wide as Preview)
-        ImGui::SetNextWindowPos(ImVec2(vp.x, vp.y + previewHeight + panelSpacing + timelinePanelHeight + panelSpacing));
+        ImGui::SetNextWindowPos(ImVec2(vp.x, vp.y + previewHeight + panelSpacing));
         ImGui::SetNextWindowSize(ImVec2(previewWidth, logPanelHeight));
         ImGui::Begin("Log", nullptr, fixed_flags);
         {
-            if (ImGui::Button("Clear Logs")) appInstance->m_batchLog.clear();
-            ImGui::BeginChild("LogScrollingRegion", ImVec2(0,0), true);
+            ImGui::BeginChild("LogScrollingRegion", ImVec2(0, -ImGui::GetFrameHeightWithSpacing()), true);
             for (const auto& line : appInstance->m_batchLog) ImGui::TextUnformatted(line.c_str());
             if (ImGui::GetScrollY() >= ImGui::GetScrollMaxY()) ImGui::SetScrollHereY(1.0f);
             ImGui::EndChild();
+            float btnWidth = ImGui::CalcTextSize("Clear Logs").x + ImGui::GetStyle().FramePadding.x * 2.0f;
+            ImGui::SetCursorPosX(ImGui::GetCursorPosX() + ImGui::GetContentRegionAvail().x - btnWidth);
+            if (ImGui::Button("Clear Logs")) appInstance->m_batchLog.clear();
         }
         ImGui::End();
+
+        if (appInstance->m_showOutputFolderBrowser) {
+            ImGui::SetNextWindowSize(ImVec2(400, 300), ImGuiCond_FirstUseEver);
+            if (appInstance->m_folderBrowserPath.empty()) {
+                namespace fs = std::filesystem;
+                appInstance->m_folderBrowserPath = appInstance->m_outputFolder[0] ?
+                    std::string(appInstance->m_outputFolder) : fs::current_path().string();
+            }
+            namespace fs = std::filesystem;
+            fs::path currentPath = appInstance->m_folderBrowserPath;
+            ImGui::Begin("Select Output Folder", &appInstance->m_showOutputFolderBrowser);
+            ImGui::TextUnformatted(currentPath.string().c_str());
+            ImGui::Separator();
+            if (currentPath.has_parent_path()) {
+                if (ImGui::Selectable("..")) {
+                    appInstance->m_folderBrowserPath = currentPath.parent_path().string();
+                }
+            }
+            for (auto& entry : fs::directory_iterator(currentPath)) {
+                if (entry.is_directory()) {
+                    if (ImGui::Selectable(entry.path().filename().string().c_str())) {
+                        appInstance->m_folderBrowserPath = entry.path().string();
+                    }
+                }
+            }
+            if (ImGui::Button("Select")) {
+                strncpy(appInstance->m_outputFolder, appInstance->m_folderBrowserPath.c_str(),
+                        sizeof(appInstance->m_outputFolder) - 1);
+                appInstance->m_showOutputFolderBrowser = false;
+            }
+            ImGui::SameLine();
+            if (ImGui::Button("Cancel")) {
+                appInstance->m_showOutputFolderBrowser = false;
+            }
+            ImGui::End();
+        }
     }
 
     void endFrame(VkCommandBuffer commandBuffer) {


### PR DESCRIPTION
## Summary
- display FPS alongside ETA during conversions
- overlay timeline controls at bottom of preview
- reposition Clear Logs button to bottom-right
- add built-in folder browser for output path

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_687fc70c4df88327bb5b0788497ba4c9