### PR TITLE
Improve UI controls and conversion stats

### DIFF
--- a/include/App/App.h
+++ b/include/App/App.h
@@ -83,6 +83,7 @@ public:
     std::string m_cfaStringFromMetadata;
     bool m_showMetrics = false;
     bool m_showHelpPage = false;
+    bool m_showOutputFolderBrowser = false;
 
     double m_gpuWaitTimeMs = 0.0;
     double m_decodeTimeMs = 0.0;
@@ -143,18 +144,21 @@ public:
         HEVC_GPU,
         DNG
     };
-    void startBatchConversion();
+    void startBatchConversion(ExportFormat fmtForAll);
     void startSingleConversion(int fileIndex);
     void stopAllExports();
     double calculateTimeRemaining() const;
     double getCurrentFileProgress() const;
     double getBatchProgress() const;
+    double getCurrentFps() const;
     std::vector<std::string> m_batchLog;
     std::atomic<bool> m_batchActive{ false };
     std::thread m_batchThread;
     int m_selectedBatchIndex = -1;
     char m_outputFolder[1024] = "";
     std::vector<ExportFormat> m_fileExportFormats;
+    ExportFormat m_globalExportFormat{ ExportFormat::PRORES_CPU };
+    std::atomic<int> m_pendingPreviewIndex{ -1 };
     bool m_previewOpen = true;
 #endif
 
@@ -267,6 +271,7 @@ private:
     float m_uiOpacity = 1.0f;
     double m_uiAutoHideDelaySec = 3.0;
     float m_uiFadeSpeed = 3.0f;
+    std::string m_folderBrowserPath;
 
 #ifdef ENABLE_PRORES_EXPORT
     struct ProResExportStatus {

--- a/src/App/AppIO.cpp
+++ b/src/App/AppIO.cpp
@@ -17,6 +17,21 @@
 #endif
 #include <tinydng/tiny_dng_writer.h>
 
+#include <array>
+
+static const char* exportFormatName(App::ExportFormat fmt) {
+    switch (fmt) {
+    case App::ExportFormat::PRORES_CPU: return "ProRes CPU";
+    case App::ExportFormat::PRORES_GPU: return "ProRes GPU";
+    case App::ExportFormat::DNXHR_CPU:  return "DNxHR CPU";
+    case App::ExportFormat::DNXHR_GPU:  return "DNxHR GPU";
+    case App::ExportFormat::HEVC_CPU:   return "HEVC CPU";
+    case App::ExportFormat::HEVC_GPU:   return "HEVC GPU";
+    case App::ExportFormat::DNG:        return "DNG";
+    }
+    return "Unknown";
+}
+
 
 #include <filesystem>
 #include <thread>
@@ -2818,13 +2833,15 @@ void App::loadFileForExport(const std::string& path) {
 }
 
 #ifdef MOTIONCAM_CONVERTER
-void App::startBatchConversion() {
+void App::startBatchConversion(ExportFormat fmtForAll) {
     if (m_batchActive.load()) return;
     m_batchActive.store(true);
     m_cancelExportRequested.store(false);
     m_exportStartTime = std::chrono::steady_clock::now();
     m_batchCompletedFiles = 0;
     m_batchLog.clear();
+    m_globalExportFormat = fmtForAll;
+    for (auto& f : m_fileExportFormats) f = fmtForAll;
     namespace fs = std::filesystem;
     fs::path logDir = fs::path(getLogDirectory());
     std::error_code ec;
@@ -2837,9 +2854,12 @@ void App::startBatchConversion() {
             if (m_cancelExportRequested.load()) break;
             if (m_window && glfwWindowShouldClose(m_window)) break;
             const std::string& path = m_fileList[i];
+            m_selectedBatchIndex = static_cast<int>(i);
+            m_pendingPreviewIndex.store(static_cast<int>(i), std::memory_order_release);
             m_currentExportingFileName = fs::path(path).filename().string();
             m_currentFileExportStartTime = std::chrono::steady_clock::now();
             m_batchLog.push_back(std::string("Converting ") + fs::path(path).filename().string() + "...");
+            LogToFile(std::string("[Batch] Starting ") + fs::path(path).filename().string());
             if (logFile.is_open()) logFile << "[start] " << fs::path(path).filename().string() << std::endl;
             m_currentFileIndex = static_cast<int>(i);
             loadFileForExport(path);
@@ -2848,6 +2868,7 @@ void App::startBatchConversion() {
             std::string outPath;
             ExportFormat fmt = ExportFormat::PRORES_CPU;
             if (i < m_fileExportFormats.size()) fmt = m_fileExportFormats[i];
+            LogToFile(std::string("[Batch] Format: ") + exportFormatName(fmt));
             switch (fmt) {
             case ExportFormat::PRORES_CPU:
                 outPath = (fs::path(outFolder) / (stem + ".mov")).string();
@@ -3109,5 +3130,18 @@ double App::calculateTimeRemaining() const {
     if (progress <= 0.0) return 0.0;
     auto elapsed = std::chrono::duration_cast<std::chrono::seconds>(std::chrono::steady_clock::now() - m_exportStartTime).count();
     return (elapsed / progress) - elapsed;
+}
+
+double App::getCurrentFps() const {
+#ifdef ENABLE_PRORES_EXPORT
+    auto elapsedMs = std::chrono::duration_cast<std::chrono::milliseconds>(
+        std::chrono::steady_clock::now() - m_currentFileExportStartTime).count();
+    if (elapsedMs <= 0) return 0.0;
+
+    if (m_proResStatus.active.load()) return m_proResStatus.currentFrame.load() * 1000.0 / elapsedMs;
+    if (m_dnxhrStatus.active.load()) return m_dnxhrStatus.currentFrame.load() * 1000.0 / elapsedMs;
+    if (m_hevcStatus.active.load()) return m_hevcStatus.currentFrame.load() * 1000.0 / elapsedMs;
+#endif
+    return 0.0;
 }
 #endif

--- a/src/App/AppInit.cpp
+++ b/src/App/AppInit.cpp
@@ -127,7 +127,7 @@ App::App(const std::string& filePath) :
     m_currentFrame(0), m_imguiDescriptorPool(VK_NULL_HANDLE),
     m_isFullscreen(false), m_cfaTypeFromMetadata(0), m_staticBlack(0.0), m_staticWhite(65535.0),
     m_dumpMetadata(false), m_currentFileIndex(-1),
-    m_showMetrics(false), m_showHelpPage(false),
+    m_showMetrics(false), m_showHelpPage(false), m_showOutputFolderBrowser(false),
     m_gpuWaitTimeMs(0.0), m_decodeTimeMs(0.0),
     m_renderPrepTimeMs(0.0), m_guiRenderTimeMs(0.0), m_vkSubmitPresentTimeMs(0.0),
     m_appLogicTimeMs(0.0), m_sleepTimeMs(0.0), m_totalLoopTimeMs(0.0),
@@ -145,7 +145,10 @@ App::App(const std::string& filePath) :
     m_uiAutoHidden(false),
     m_uiOpacity(1.0f),
     m_uiAutoHideDelaySec(3.0),
-    m_uiFadeSpeed(3.0f)
+    m_uiFadeSpeed(3.0f),
+    m_folderBrowserPath(),
+    m_globalExportFormat(ExportFormat::PRORES_CPU),
+    m_pendingPreviewIndex(-1)
 #ifdef ENABLE_PRORES_EXPORT
     , m_showExportProgressPopup(false)
     , m_proResStatus()

--- a/src/App/AppLoop.cpp
+++ b/src/App/AppLoop.cpp
@@ -56,6 +56,14 @@ bool App::run() {
         appLogicStartTime = steady_clock::now();
         glfwPollEvents();
 
+        int idx = m_pendingPreviewIndex.exchange(-1, std::memory_order_acquire);
+        if (idx != -1 && idx < static_cast<int>(m_fileList.size())) {
+            bool oldFirst = m_firstFileLoaded;
+            m_firstFileLoaded = true;
+            loadFileAtIndex(idx);
+            m_firstFileLoaded = oldFirst;
+        }
+
         bool paused = (m_playbackController ? m_playbackController->isPaused() : true);
         bool segment_looped_or_ended = false;
 

--- a/src/Gui/GuiRender.cpp
+++ b/src/Gui/GuiRender.cpp
@@ -229,8 +229,7 @@ namespace GuiOverlay {
         const float panelSpacing = 3.0f;
 
         float previewWidth = vs.x - rightPanelWidth - panelSpacing;
-        // With timeline moved below preview there are only two gaps
-        float previewHeight = vs.y - timelinePanelHeight - logPanelHeight - panelSpacing * 2;
+        float previewHeight = vs.y - logPanelHeight - panelSpacing;
         float controlsPanelHeight = vs.y - filesPanelHeight - panelSpacing * 2;
         if (controlsPanelHeight < controlsPanelMinHeight) controlsPanelHeight = controlsPanelMinHeight;
 
@@ -248,10 +247,11 @@ namespace GuiOverlay {
         }
         ImGui::End();
 
-        // 2. Timeline/Play controls (below Preview)
-        ImGui::SetNextWindowPos(ImVec2(vp.x, vp.y + previewHeight + panelSpacing));
-        ImGui::SetNextWindowSize(ImVec2(previewWidth, timelinePanelHeight));
-        ImGui::Begin("TimelineControls", nullptr, fixed_flags);
+        // 2. Timeline/Play controls (overlay on Preview)
+        ImGui::SetNextWindowBgAlpha(0.5f);
+        ImGui::SetNextWindowPos(ImVec2(vp.x + previewWidth * 0.1f, vp.y + previewHeight - timelinePanelHeight - 10.0f));
+        ImGui::SetNextWindowSize(ImVec2(previewWidth * 0.8f, timelinePanelHeight));
+        ImGui::Begin("TimelineControls", nullptr, fixed_flags | ImGuiWindowFlags_NoBringToFrontOnFocus);
         {
             bool paused = appInstance->m_playbackController_ptr ? appInstance->m_playbackController_ptr->isPaused() : true;
             if (ImGui::Button(paused ? "Play" : "Pause")) {
@@ -351,13 +351,11 @@ namespace GuiOverlay {
             }
             ImGui::InputText("Output Folder", appInstance->m_outputFolder, sizeof(appInstance->m_outputFolder));
             if (ImGui::IsItemActivated() && ImGui::IsMouseDoubleClicked(0)) {
-                std::string folder = appInstance->openFolderDialog();
-                if (!folder.empty()) strncpy(appInstance->m_outputFolder, folder.c_str(), sizeof(appInstance->m_outputFolder)-1);
+                appInstance->m_showOutputFolderBrowser = true;
             }
             ImGui::SameLine();
             if (ImGui::Button("Browse...")) {
-                std::string folder = appInstance->openFolderDialog();
-                if (!folder.empty()) strncpy(appInstance->m_outputFolder, folder.c_str(), sizeof(appInstance->m_outputFolder)-1);
+                appInstance->m_showOutputFolderBrowser = true;
             }
             ImVec4 btn = ImVec4(0.3f, 0.4f, 0.6f, 1.0f);
             ImVec4 hover = ImVec4(0.35f, 0.45f, 0.65f, 1.0f);
@@ -366,7 +364,10 @@ namespace GuiOverlay {
             ImGui::PushStyleColor(ImGuiCol_ButtonHovered, hover);
             ImGui::PushStyleColor(ImGuiCol_ButtonActive, active);
             if (ImGui::Button("Convert All") && !exporting) {
-                appInstance->startBatchConversion();
+                App::ExportFormat fmt = App::ExportFormat::PRORES_CPU;
+                if (appInstance->m_selectedBatchIndex != -1 && appInstance->m_selectedBatchIndex < (int)appInstance->m_fileExportFormats.size())
+                    fmt = appInstance->m_fileExportFormats[appInstance->m_selectedBatchIndex];
+                appInstance->startBatchConversion(fmt);
             }
             ImGui::SameLine();
             if (ImGui::Button("Convert Selected") && appInstance->m_selectedBatchIndex != -1 && !exporting) {
@@ -385,23 +386,70 @@ namespace GuiOverlay {
                 ImGui::ProgressBar(batch, ImVec2(-1,0));
                 ImGui::Text("%s", appInstance->m_currentExportingFileName.c_str());
                 double eta = appInstance->calculateTimeRemaining();
-                if (eta > 0.0) ImGui::Text("ETA %.1fs", eta);
+                double fps = appInstance->getCurrentFps();
+                if (eta > 0.0) {
+                    if (fps > 0.0)
+                        ImGui::Text("ETA %.1fs (%.1f fps)", eta, fps);
+                    else
+                        ImGui::Text("ETA %.1fs", eta);
+                } else if (fps > 0.0) {
+                    ImGui::Text("%.1f fps", fps);
+                }
             }
         }
         ImGui::End();
 
         // 5. Log Panel (bottom left, only as wide as Preview)
-        ImGui::SetNextWindowPos(ImVec2(vp.x, vp.y + previewHeight + panelSpacing + timelinePanelHeight + panelSpacing));
+        ImGui::SetNextWindowPos(ImVec2(vp.x, vp.y + previewHeight + panelSpacing));
         ImGui::SetNextWindowSize(ImVec2(previewWidth, logPanelHeight));
         ImGui::Begin("Log", nullptr, fixed_flags);
         {
-            if (ImGui::Button("Clear Logs")) appInstance->m_batchLog.clear();
             ImGui::BeginChild("LogScrollingRegion", ImVec2(0,0), true);
             for (const auto& line : appInstance->m_batchLog) ImGui::TextUnformatted(line.c_str());
             if (ImGui::GetScrollY() >= ImGui::GetScrollMaxY()) ImGui::SetScrollHereY(1.0f);
+            ImVec2 btnSize = ImVec2(70, 0);
+            ImGui::SetCursorPos(ImVec2(ImGui::GetWindowWidth() - btnSize.x - 4,
+                                       ImGui::GetWindowHeight() - ImGui::GetFrameHeight() - 4));
+            if (ImGui::Button("Clear", btnSize)) appInstance->m_batchLog.clear();
             ImGui::EndChild();
         }
         ImGui::End();
+
+        if (appInstance->m_showOutputFolderBrowser) {
+            ImGui::SetNextWindowSize(ImVec2(400, 300), ImGuiCond_FirstUseEver);
+            if (appInstance->m_folderBrowserPath.empty()) {
+                namespace fs = std::filesystem;
+                appInstance->m_folderBrowserPath = appInstance->m_outputFolder[0] ?
+                    std::string(appInstance->m_outputFolder) : fs::current_path().string();
+            }
+            namespace fs = std::filesystem;
+            fs::path currentPath = appInstance->m_folderBrowserPath;
+            ImGui::Begin("Select Output Folder", &appInstance->m_showOutputFolderBrowser);
+            ImGui::TextUnformatted(currentPath.string().c_str());
+            ImGui::Separator();
+            if (currentPath.has_parent_path()) {
+                if (ImGui::Selectable("..")) {
+                    appInstance->m_folderBrowserPath = currentPath.parent_path().string();
+                }
+            }
+            for (auto& entry : fs::directory_iterator(currentPath)) {
+                if (entry.is_directory()) {
+                    if (ImGui::Selectable(entry.path().filename().string().c_str())) {
+                        appInstance->m_folderBrowserPath = entry.path().string();
+                    }
+                }
+            }
+            if (ImGui::Button("Select")) {
+                strncpy(appInstance->m_outputFolder, appInstance->m_folderBrowserPath.c_str(),
+                        sizeof(appInstance->m_outputFolder) - 1);
+                appInstance->m_showOutputFolderBrowser = false;
+            }
+            ImGui::SameLine();
+            if (ImGui::Button("Cancel")) {
+                appInstance->m_showOutputFolderBrowser = false;
+            }
+            ImGui::End();
+        }
     }
 
     void endFrame(VkCommandBuffer commandBuffer) {


### PR DESCRIPTION
## Summary
- display FPS alongside ETA during conversions
- overlay timeline controls at bottom of preview
- reposition Clear Logs button to bottom-right
- add built-in folder browser for output path
- force selected export format for all files on batch convert
- update preview to show each file while converting

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_687fc70c4df88327bb5b0788497ba4c9