### PR TITLE
Implement UI refactor

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -165,6 +165,7 @@ set(APP_SOURCES
   src/Gui/GuiSetup.cpp
   src/Gui/GuiRender.cpp
   src/Gui/GuiUtils.cpp
+  src/Gui/GuiWidgets.cpp
   src/Gui/GuiStyles.cpp
 
   src/Playback/PlaybackController.cpp

--- a/include/Gui/GuiUtils.h
+++ b/include/Gui/GuiUtils.h
@@ -6,8 +6,9 @@
 
 namespace GuiUtils {
 
-	std::string formatHMS(int64_t ns);
-	std::string format_mm_ss(double total_seconds);
+        std::string formatHMS(int64_t ns);
+        std::string format_mm_ss(double total_seconds);
+        std::string truncateMiddle(const std::string& text, size_t maxLen);
 
 	// Any other small utility functions for GUI can go here.
 

--- a/include/Gui/GuiWidgets.h
+++ b/include/Gui/GuiWidgets.h
@@ -1,0 +1,10 @@
+#ifndef GUI_WIDGETS_H
+#define GUI_WIDGETS_H
+
+#include <imgui.h>
+
+namespace GuiWidgets {
+    bool Splitter(bool vertical, float thickness, float* size1, float* size2, float minSize1, float minSize2);
+}
+
+#endif // GUI_WIDGETS_H

--- a/include/Utils/IconsMaterial.h
+++ b/include/Utils/IconsMaterial.h
@@ -19,6 +19,8 @@
 #define ICON_MD_VOLUME_OFF u8"\ue04f"
 #define ICON_MD_KEYBOARD_ARROW_LEFT u8"\uE314"
 #define ICON_MD_KEYBOARD_ARROW_RIGHT u8"\uE315"
+#define ICON_MD_KEYBOARD_ARROW_UP u8"\uE313"
+#define ICON_MD_KEYBOARD_ARROW_DOWN u8"\uE316"
 
 // UI & Navigation
 #define ICON_MD_MENU u8"\ue5d2"         // Hamburger menu

--- a/src/Gui/GuiRender.cpp
+++ b/src/Gui/GuiRender.cpp
@@ -9,6 +9,7 @@
 #include "Gui/GuiOverlay.h"
 #include "Gui/GuiStyles.h"
 #include "Gui/GuiUtils.h"
+#include "Gui/GuiWidgets.h"
 #include "Utils/IconsMaterial.h"
 #include "Utils/DebugLog.h" // For LogToFile, if logging is desired
 
@@ -196,6 +197,7 @@ namespace GuiOverlay {
 
     void render(App* appInstance) {
         if (!appInstance) return;
+        UIData data = gatherData(appInstance);
 
         if (appInstance->m_previewFullscreen) {
             ImGuiViewport* viewport = ImGui::GetMainViewport();
@@ -220,17 +222,19 @@ namespace GuiOverlay {
         ImVec2 vp = viewport->WorkPos;
         ImVec2 vs = viewport->WorkSize;
 
-        // Layout constants
-        const float rightPanelWidth = 340.0f; // Fixed width for side panels
-        const float filesPanelHeight = 260.0f; // Fixed height for Files panel
-        const float controlsPanelMinHeight = 200.0f; // Minimum height for Controls panel
-        const float timelinePanelHeight = 60.0f; // Height for play/timeline controls
-        const float logPanelHeight = 120.0f; // Fixed height for Log panel
+        static float rightPanelWidth = 340.0f;
+        static float logPanelHeight = 120.0f;
+        static bool showRightPanel = true;
+        static bool showLogPanel = true;
+        const float filesPanelHeight = 260.0f;
+        const float controlsPanelMinHeight = 200.0f;
         const float panelSpacing = 3.0f;
+        const float timelinePanelHeight = 42.0f;
 
-        float previewWidth = vs.x - rightPanelWidth - panelSpacing;
-        // With timeline moved below preview there are only two gaps
-        float previewHeight = vs.y - timelinePanelHeight - logPanelHeight - panelSpacing * 2;
+        float rightSpace = showRightPanel ? rightPanelWidth + panelSpacing : 0.0f;
+        float bottomSpace = showLogPanel ? logPanelHeight + panelSpacing : 0.0f;
+        float previewWidth = vs.x - rightSpace;
+        float previewHeight = vs.y - bottomSpace;
         float controlsPanelHeight = vs.y - filesPanelHeight - panelSpacing * 2;
         if (controlsPanelHeight < controlsPanelMinHeight) controlsPanelHeight = controlsPanelMinHeight;
 
@@ -241,20 +245,66 @@ namespace GuiOverlay {
         ImGui::SetNextWindowSize(ImVec2(previewWidth, previewHeight));
         ImGui::Begin("Preview", nullptr, fixed_flags);
         {
-            ImVec2 size = ImGui::GetContentRegionAvail();
+            ImVec2 avail = ImGui::GetContentRegionAvail();
             ImTextureID texID = (ImTextureID)appInstance->getRenderer()->getPreviewDescriptorSet();
             if (texID)
-                ImGui::Image(texID, size);
+            {
+                float videoW = static_cast<float>(data.decodedWidth);
+                float videoH = static_cast<float>(data.decodedHeight);
+                if (videoW <= 0.0f || videoH <= 0.0f)
+                {
+                    ImGui::Image(texID, avail);
+                }
+                else
+                {
+                    float ratio = videoW / videoH;
+                    float availRatio = avail.x / avail.y;
+                    ImVec2 draw = avail;
+                    ImVec2 offset = ImVec2(0,0);
+                    if (availRatio > ratio)
+                    {
+                        draw.y = avail.y;
+                        draw.x = draw.y * ratio;
+                        offset.x = (avail.x - draw.x) * 0.5f;
+                    }
+                    else
+                    {
+                        draw.x = avail.x;
+                        draw.y = draw.x / ratio;
+                        offset.y = (avail.y - draw.y) * 0.5f;
+                    }
+                    ImGui::SetCursorPos(ImGui::GetCursorPos() + offset);
+                    ImGui::Image(texID, draw);
+                }
+            }
         }
         ImGui::End();
 
-        // 2. Timeline/Play controls (below Preview)
-        ImGui::SetNextWindowPos(ImVec2(vp.x, vp.y + previewHeight + panelSpacing));
+        if (showRightPanel)
+        {
+            ImGui::SetCursorPos(ImVec2(vp.x + previewWidth, vp.y));
+            float left = previewWidth;
+            float right = rightPanelWidth;
+            GuiWidgets::Splitter(false, panelSpacing, &left, &rightPanelWidth, 150.0f, 200.0f);
+            previewWidth = left;
+        }
+        ImGui::SetCursorPos(ImVec2(vp.x + previewWidth - 10.0f, vp.y + vs.y * 0.5f));
+        if (ImGui::SmallButton(showRightPanel ? ICON_MD_KEYBOARD_ARROW_RIGHT : ICON_MD_KEYBOARD_ARROW_LEFT))
+            showRightPanel = !showRightPanel;
+
+        ImGui::SetCursorPos(ImVec2(vp.x + previewWidth + 4.0f, vp.y + previewHeight - 10.0f));
+        if (ImGui::SmallButton(showLogPanel ? ICON_MD_KEYBOARD_ARROW_DOWN : ICON_MD_KEYBOARD_ARROW_UP))
+            showLogPanel = !showLogPanel;
+
+        // 2. Timeline overlay on preview
+        ImGui::SetNextWindowBgAlpha(0.5f);
+        ImGui::SetNextWindowPos(ImVec2(vp.x, vp.y + previewHeight - timelinePanelHeight - 5));
         ImGui::SetNextWindowSize(ImVec2(previewWidth, timelinePanelHeight));
-        ImGui::Begin("TimelineControls", nullptr, fixed_flags);
+        ImGuiWindowFlags timeline_flags = ImGuiWindowFlags_NoTitleBar | ImGuiWindowFlags_NoScrollbar | ImGuiWindowFlags_NoResize | ImGuiWindowFlags_NoCollapse | ImGuiWindowFlags_NoSavedSettings;
+        ImGui::Begin("TimelineControls", nullptr, timeline_flags);
         {
             bool paused = appInstance->m_playbackController_ptr ? appInstance->m_playbackController_ptr->isPaused() : true;
-            if (ImGui::Button(paused ? "Play" : "Pause")) {
+            if (ImGui::Button(paused ? ICON_MD_PLAY_ARROW : ICON_MD_PAUSE)) {
                 if (appInstance->m_playbackController_ptr) {
                     bool wasPaused = paused;
                     appInstance->m_playbackController_ptr->togglePause();
@@ -282,7 +332,17 @@ namespace GuiOverlay {
             }
             ImGui::PopItemWidth();
             ImGui::SameLine();
-            ImGui::Text("%zu / %zu", curIdx + 1, total);
+            std::string cur = GuiUtils::format_mm_ss(data.currentVideoTimeSec);
+            std::string tot = GuiUtils::format_mm_ss(data.totalDurationSec);
+            ImGui::Text("%s / %s", cur.c_str(), tot.c_str());
+
+            ImGui::SameLine();
+            bool zoomed = data.isZoomedToNative;
+            if (ImGui::SmallButton(zoomed ? "Zoom: 100%" : "Fit to Window")) {
+                if (appInstance->m_playbackController_ptr) {
+                    appInstance->m_playbackController_ptr->toggleZoomNativePixels();
+                }
+            }
         }
         ImGui::End();
 
@@ -297,30 +357,35 @@ namespace GuiOverlay {
 #endif
                 ;
             ImGui::BeginDisabled(exporting);
-            if (ImGui::Button("Add")) { appInstance->triggerOpenFileViaDialog(); }
+            if (ImGui::Button(ICON_MD_FOLDER_OPEN)) { appInstance->triggerOpenFileViaDialog(); }
+            if (ImGui::IsItemHovered()) ImGui::SetTooltip("Add Files");
             ImGui::SameLine();
-            if (ImGui::Button("Remove") && appInstance->m_selectedBatchIndex != -1) {
+            if (ImGui::Button(ICON_MD_DELETE) && appInstance->m_selectedBatchIndex != -1) {
                 appInstance->m_fileList.erase(appInstance->m_fileList.begin() + appInstance->m_selectedBatchIndex);
                 appInstance->m_fileExportFormats.erase(appInstance->m_fileExportFormats.begin() + appInstance->m_selectedBatchIndex);
                 appInstance->m_selectedBatchIndex = -1;
             }
+            if (ImGui::IsItemHovered()) ImGui::SetTooltip("Remove Selected");
             ImGui::SameLine();
-            if (ImGui::Button("Clear")) {
+            if (ImGui::Button(ICON_MD_CLOSE)) {
                 appInstance->m_fileList.clear();
                 appInstance->m_fileExportFormats.clear();
                 appInstance->m_selectedBatchIndex = -1;
             }
+            if (ImGui::IsItemHovered()) ImGui::SetTooltip("Clear List");
             ImGui::Separator();
             ImGui::BeginChild("FileListScrollingRegion");
             for (int i = 0; i < (int)appInstance->m_fileList.size(); ++i) {
                 bool is_selected = (i == appInstance->m_selectedBatchIndex);
-                std::string name = fs::path(appInstance->m_fileList[i]).filename().string();
+                std::string full = fs::path(appInstance->m_fileList[i]).filename().string();
+                std::string name = GuiUtils::truncateMiddle(full, 32);
                 if (ImGui::Selectable(name.c_str(), is_selected)) {
                     if (appInstance->m_selectedBatchIndex != i) {
                         appInstance->m_selectedBatchIndex = i;
                         appInstance->loadFileAtIndex(i);
                     }
                 }
+                if (ImGui::IsItemHovered()) ImGui::SetTooltip("%s", full.c_str());
             }
             ImGui::EndChild();
             ImGui::EndDisabled();
@@ -349,29 +414,36 @@ namespace GuiOverlay {
                     appInstance->m_fileExportFormats[appInstance->m_selectedBatchIndex] = (App::ExportFormat)fmt;
                 }
             }
-            ImGui::InputText("Output Folder", appInstance->m_outputFolder, sizeof(appInstance->m_outputFolder));
+            ImGui::Text("Choose Output Folder");
+            ImGui::PushItemWidth(-100);
+            ImGui::InputText("##OutputFolder", appInstance->m_outputFolder, sizeof(appInstance->m_outputFolder), ImGuiInputTextFlags_ReadOnly);
+            if (ImGui::IsItemHovered()) ImGui::SetTooltip("%s", appInstance->m_outputFolder);
+            ImGui::PopItemWidth();
             if (ImGui::IsItemActivated() && ImGui::IsMouseDoubleClicked(0)) {
                 std::string folder = appInstance->openFolderDialog();
                 if (!folder.empty()) strncpy(appInstance->m_outputFolder, folder.c_str(), sizeof(appInstance->m_outputFolder)-1);
             }
             ImGui::SameLine();
-            if (ImGui::Button("Browse...")) {
+            if (ImGui::Button(ICON_MD_FOLDER_OPEN)) {
                 std::string folder = appInstance->openFolderDialog();
                 if (!folder.empty()) strncpy(appInstance->m_outputFolder, folder.c_str(), sizeof(appInstance->m_outputFolder)-1);
             }
+            if (ImGui::IsItemHovered()) ImGui::SetTooltip("Browse");
             ImVec4 btn = ImVec4(0.3f, 0.4f, 0.6f, 1.0f);
             ImVec4 hover = ImVec4(0.35f, 0.45f, 0.65f, 1.0f);
             ImVec4 active = ImVec4(0.2f, 0.3f, 0.5f, 1.0f);
             ImGui::PushStyleColor(ImGuiCol_Button, btn);
             ImGui::PushStyleColor(ImGuiCol_ButtonHovered, hover);
             ImGui::PushStyleColor(ImGuiCol_ButtonActive, active);
-            if (ImGui::Button("Convert All") && !exporting) {
+            if (ImGui::Button(ICON_MD_SAVE " Convert All") && !exporting) {
                 appInstance->startBatchConversion();
             }
+            if (ImGui::IsItemHovered()) ImGui::SetTooltip("Convert all queued files");
             ImGui::SameLine();
-            if (ImGui::Button("Convert Selected") && appInstance->m_selectedBatchIndex != -1 && !exporting) {
+            if (ImGui::Button(ICON_MD_COLLECTIONS " Convert Selected") && appInstance->m_selectedBatchIndex != -1 && !exporting) {
                 appInstance->startSingleConversion(appInstance->m_selectedBatchIndex);
             }
+            if (ImGui::IsItemHovered()) ImGui::SetTooltip("Convert highlighted file");
             ImGui::PopStyleColor(3);
             ImGui::EndDisabled();
 
@@ -390,12 +462,22 @@ namespace GuiOverlay {
         }
         ImGui::End();
 
-        // 5. Log Panel (bottom left, only as wide as Preview)
-        ImGui::SetNextWindowPos(ImVec2(vp.x, vp.y + previewHeight + panelSpacing + timelinePanelHeight + panelSpacing));
+        // 5. Log Panel (bottom left, resizable)
+        if (showLogPanel)
+        {
+            ImGui::SetCursorPos(ImVec2(vp.x, vp.y + previewHeight));
+            float top = previewHeight;
+            float bottom = logPanelHeight;
+            GuiWidgets::Splitter(true, panelSpacing, &top, &logPanelHeight, 80.0f, 80.0f);
+            previewHeight = top;
+        }
+
+        ImGui::SetNextWindowPos(ImVec2(vp.x, vp.y + previewHeight + panelSpacing));
         ImGui::SetNextWindowSize(ImVec2(previewWidth, logPanelHeight));
         ImGui::Begin("Log", nullptr, fixed_flags);
         {
-            if (ImGui::Button("Clear Logs")) appInstance->m_batchLog.clear();
+            if (ImGui::Button(ICON_MD_DELETE)) appInstance->m_batchLog.clear();
+            if (ImGui::IsItemHovered()) ImGui::SetTooltip("Clear Logs");
             ImGui::BeginChild("LogScrollingRegion", ImVec2(0,0), true);
             for (const auto& line : appInstance->m_batchLog) ImGui::TextUnformatted(line.c_str());
             if (ImGui::GetScrollY() >= ImGui::GetScrollMaxY()) ImGui::SetScrollHereY(1.0f);

--- a/src/Gui/GuiUtils.cpp
+++ b/src/Gui/GuiUtils.cpp
@@ -1,37 +1,46 @@
 #include "Gui/GuiUtils.h"
 #include <sstream>
-#include <iomanip> // For std::setfill, std::setw, std::fixed, std::setprecision
+#include <iomanip>
 
 namespace GuiUtils {
 
-    std::string formatHMS(int64_t ns) {
-        if (ns < 0) ns = 0;
-        double s_total = static_cast<double>(ns) * 1e-9;
-        bool is_negative = s_total < 0;
-        if (is_negative) s_total = -s_total;
+std::string formatHMS(int64_t ns)
+{
+    if (ns < 0) ns = 0;
+    double s_total = static_cast<double>(ns) * 1e-9;
+    bool is_negative = s_total < 0;
+    if (is_negative) s_total = -s_total;
 
-        int h = static_cast<int>(s_total / 3600.0);
-        s_total -= static_cast<double>(h) * 3600.0;
-        int m = static_cast<int>(s_total / 60.0);
-        s_total -= static_cast<double>(m) * 60.0;
-        double sec_frac = s_total;
+    int h = static_cast<int>(s_total / 3600.0);
+    s_total -= static_cast<double>(h) * 3600.0;
+    int m = static_cast<int>(s_total / 60.0);
+    s_total -= static_cast<double>(m) * 60.0;
+    double sec_frac = s_total;
 
-        std::ostringstream oss;
-        if (is_negative) oss << "-";
-        oss << std::setfill('0') << std::setw(2) << h << ':'
-            << std::setw(2) << m << ':'
-            << std::fixed << std::setprecision(3) << std::setw(6) << sec_frac;
-        return oss.str();
-    }
+    std::ostringstream oss;
+    if (is_negative) oss << "-";
+    oss << std::setfill('0') << std::setw(2) << h << ':'
+        << std::setw(2) << m << ':'
+        << std::fixed << std::setprecision(3) << std::setw(6) << sec_frac;
+    return oss.str();
+}
 
-    std::string format_mm_ss(double total_seconds) {
-        if (total_seconds < 0) total_seconds = 0;
-        int minutes = static_cast<int>(total_seconds) / 60;
-        int seconds = static_cast<int>(total_seconds) % 60;
-        char buf[16];
-        // Using snprintf for safety, though with fixed format, sprintf would also work.
-        snprintf(buf, sizeof(buf), "%02d:%02d", minutes, seconds);
-        return std::string(buf);
-    }
+std::string format_mm_ss(double total_seconds)
+{
+    if (total_seconds < 0) total_seconds = 0;
+    int minutes = static_cast<int>(total_seconds) / 60;
+    int seconds = static_cast<int>(total_seconds) % 60;
+    char buf[16];
+    snprintf(buf, sizeof(buf), "%02d:%02d", minutes, seconds);
+    return std::string(buf);
+}
+
+std::string truncateMiddle(const std::string& text, size_t maxLen)
+{
+    if (text.size() <= maxLen) return text;
+    if (maxLen < 3) return text.substr(0, maxLen);
+    size_t keep = (maxLen - 3) / 2;
+    return text.substr(0, keep) + "..." + text.substr(text.size() - keep);
+}
 
 } // namespace GuiUtils

--- a/src/Gui/GuiWidgets.cpp
+++ b/src/Gui/GuiWidgets.cpp
@@ -1,0 +1,23 @@
+#include "Gui/GuiWidgets.h"
+
+namespace GuiWidgets {
+    bool Splitter(bool vertical, float thickness, float* size1, float* size2, float minSize1, float minSize2)
+    {
+        ImVec2 backup_pos = ImGui::GetCursorPos();
+        ImGui::InvisibleButton("##Splitter", vertical ? ImVec2(*size1 + *size2, thickness) : ImVec2(thickness, *size1 + *size2));
+        bool held = ImGui::IsItemActive();
+        bool hovered = ImGui::IsItemHovered();
+        if (hovered || held)
+            ImGui::SetMouseCursor(vertical ? ImGuiMouseCursor_ResizeNS : ImGuiMouseCursor_ResizeEW);
+        if (held)
+        {
+            float delta = vertical ? ImGui::GetIO().MouseDelta.y : ImGui::GetIO().MouseDelta.x;
+            *size1 += delta;
+            *size2 -= delta;
+            if (*size1 < minSize1) *size1 = minSize1;
+            if (*size2 < minSize2) *size2 = minSize2;
+        }
+        ImGui::SetCursorPos(backup_pos);
+        return held;
+    }
+}


### PR DESCRIPTION
## Summary
- add splitter widgets and aspect-ratio preview
- allow resizing right and log panels
- move timeline overlay with play icon, timecode and zoom toggle
- truncate filenames and style file buttons with icons
- update output folder label and icons

## Testing
- `cmake --build build --target MotionCam_Converter --config Release -j4` *(fails: libavutil/frame.h missing)*

------
https://chatgpt.com/codex/tasks/task_e_6880819c8f848327afd26c283c669a87