### PR TITLE
Implement aspect-ratio preserving preview

### DIFF
--- a/src/Gui/GuiRender.cpp
+++ b/src/Gui/GuiRender.cpp
@@ -241,10 +241,35 @@ namespace GuiOverlay {
         ImGui::SetNextWindowSize(ImVec2(previewWidth, previewHeight));
         ImGui::Begin("Preview", nullptr, fixed_flags);
         {
-            ImVec2 size = ImGui::GetContentRegionAvail();
+            ImVec2 avail = ImGui::GetContentRegionAvail();
             ImTextureID texID = (ImTextureID)appInstance->getRenderer()->getPreviewDescriptorSet();
             if (texID)
-                ImGui::Image(texID, size);
+            {
+                float dispW = avail.x;
+                float dispH = avail.y;
+                int imgW = appInstance->getRenderer()->getImageWidth();
+                int imgH = appInstance->getRenderer()->getImageHeight();
+                if (imgW > 0 && imgH > 0)
+                {
+                    float imgAspect = static_cast<float>(imgW) / static_cast<float>(imgH);
+                    float availAspect = avail.x / avail.y;
+                    if (imgAspect > availAspect)
+                    {
+                        dispW = avail.x;
+                        dispH = dispW / imgAspect;
+                    }
+                    else
+                    {
+                        dispH = avail.y;
+                        dispW = dispH * imgAspect;
+                    }
+                }
+
+                ImVec2 cursor = ImGui::GetCursorScreenPos();
+                ImGui::SetCursorScreenPos(ImVec2(cursor.x + (avail.x - dispW) * 0.5f,
+                                                 cursor.y + (avail.y - dispH) * 0.5f));
+                ImGui::Image(texID, ImVec2(dispW, dispH));
+            }
         }
         ImGui::End();
 


### PR DESCRIPTION
## Summary
- ensure preview image keeps original video aspect ratio

## Testing
- `cmake --build build --target MotionCam_Converter` *(fails: cannot find -lavcodec.lib)*

------
https://chatgpt.com/codex/tasks/task_e_688085688fac832799f6593a3f217e11