### PR TITLE
Fix UI play button alignment

### DIFF
--- a/src/Gui/GuiRender.cpp
+++ b/src/Gui/GuiRender.cpp
@@ -273,6 +273,7 @@ namespace GuiOverlay {
                 ImVec2 btnPos(videoRect.Min.x + margin, videoRect.Max.y - margin - btnSize);
                 ImGui::SetCursorScreenPos(btnPos);
                 ImGui::InvisibleButton("##PlayPause", ImVec2(btnSize, btnSize));
+                ImVec2 actualBtnPos = ImGui::GetItemRectMin();
                 if (ImGui::IsItemClicked() && appInstance->m_playbackController_ptr) {
                     bool wasPaused = paused;
                     appInstance->m_playbackController_ptr->togglePause();
@@ -284,8 +285,8 @@ namespace GuiOverlay {
                     }
                 }
                 float iconSize = btnSize * 0.95f;
-                ImVec2 iconPos(btnPos.x + (btnSize - iconSize) * 0.5f,
-                               btnPos.y + (btnSize - iconSize) * 0.5f);
+                ImVec2 iconPos(actualBtnPos.x + (btnSize - iconSize) * 0.5f,
+                               actualBtnPos.y + (btnSize - iconSize) * 0.5f);
                 ImU32 col = ImGui::GetColorU32(ImGuiCol_Text);
                 if (paused) {
                     ImVec2 p0(iconPos.x, iconPos.y);


### PR DESCRIPTION
## Summary
- align play button icon with its interactive area using ImGui item rect

## Testing
- `cmake -S . -B build`
- `cmake --build build -j $(nproc)` *(fails: libavutil/frame.h missing)*

------
https://chatgpt.com/codex/tasks/task_e_6880c5df1a3c8327975685129fb11937