### PR TITLE
Add experimental RCD demosaic mode

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -109,6 +109,8 @@ set(SHADER_FILES
     "${APP_SHADERS_SRC_DIR}/fullscreen_quad.vert"
     "${APP_SHADERS_SRC_DIR}/image_process.frag"
     "${APP_SHADERS_SRC_DIR}/raw_to_yuv422.comp"
+    "${APP_SHADERS_SRC_DIR}/rcd_conv.comp"
+    "${APP_SHADERS_SRC_DIR}/rcd_fill.comp"
 )
 set(COMPILED_SHADER_OUTPUTS "")
 foreach(SHADER_INPUT_FILE ${SHADER_FILES})

--- a/README.md
+++ b/README.md
@@ -68,6 +68,7 @@ runtime DLLs will be copied automatically.
 - You can override the detected CFA pattern at runtime by pressing the number
   keys `1`‑`4` which map to **BGGR**, **RGGB**, **GBRG**, and **GRBG** respectively.
 - Variable gradient demosaicing is always used for all export and preview paths.
+An experimental **RCD** demosaic option can be enabled by setting the demosaic mode to `2`.
 
 ### GPU ProRes Conversion
 

--- a/include/Graphics/GpuColorParams.h
+++ b/include/Graphics/GpuColorParams.h
@@ -7,7 +7,7 @@ struct GpuColorParams {
     float wbB{1.0f};
     float colorMatrix[9]{1,0,0,0,1,0,0,0,1};
     int   cfaType{0};   // 0 BGGR,1 RGGB,2 GBRG,3 GRBG
-    int   demosaicMode{1}; // 0 bilinear, 1 variable gradient
+    int   demosaicMode{1}; // 0 bilinear, 1 variable gradient, 2 RCD
     int   fullSwing{0}; // 0 studio, 1 full
     unsigned int black{64};
     unsigned int white{1023};

--- a/include/Utils/ColorPipelineCPU.h
+++ b/include/Utils/ColorPipelineCPU.h
@@ -7,7 +7,7 @@ struct CPUColorParams {
     int width{0};
     int height{0};
     int cfaType{0}; // 0 BGGR,1 RGGB,2 GBRG,3 GRBG
-    int demosaicMode{1}; // 0 bilinear, 1 variable gradient
+    int demosaicMode{1}; // 0 bilinear, 1 variable gradient, 2 RCD
     double blackLevel{0.0};
     double whiteLevel{65535.0};
     float gainR{1.0f};

--- a/shaders/image_process.frag
+++ b/shaders/image_process.frag
@@ -19,7 +19,7 @@ layout(binding = 1) uniform ShaderParams {
     mat4 CCM; // Pass as mat4, use top-left 3x3
     float saturationAdjustment; // e.g., 1.0 for no change, 1.25 for +25%
     int orientationDegrees;
-    int demosaicMode; // 0 bilinear, 1 variable gradient
+    int demosaicMode; // 0 bilinear, 1 variable gradient, 2 RCD
 } params;
 
 // sRGB EOTF (gamma correction)

--- a/shaders/rcd_conv.comp
+++ b/shaders/rcd_conv.comp
@@ -1,0 +1,42 @@
+#version 460
+layout(binding = 0) uniform sampler2D img_cfa;
+layout(binding = 1, r8) uniform writeonly image2D img_vh;
+layout(binding = 2, r8) uniform writeonly image2D img_pq;
+layout(binding = 3, r32f) uniform writeonly image2D img_lp;
+
+layout(local_size_x = 16, local_size_y = 16) in;
+
+void main(){
+    ivec2 ipos = ivec2(gl_GlobalInvocationID.xy);
+    ivec2 size = textureSize(img_cfa,0);
+    if(any(greaterThanEqual(ipos,size))) return;
+#define cfa(x,y) texelFetch(img_cfa, ivec2(ipos.x+(x), ipos.y+(y)),0).r
+    vec2 vhs = vec2(0.0);
+    for(int i=-1;i<=1;i++){
+        vhs += vec2(
+            cfa(i,-3) - 3.0*cfa(i,-2) - cfa(i,-1) + 6.0*cfa(i,0) - cfa(i,1) - 3.0*cfa(i,2) + cfa(i,3),
+            cfa(-3,i) - 3.0*cfa(-2,i) - cfa(-1,i) + 6.0*cfa(0,i) - cfa(1,i) - 3.0*cfa(2,i) + cfa(3,i)
+        );
+    }
+    vhs*=vhs;
+    float vh = vhs.x/(1e-5 + vhs.x + vhs.y);
+    imageStore(img_vh, ipos, vec4(vh));
+    if(((ipos.x+ipos.y)&1)==0){
+        vec2 pqs = vec2(1e-5);
+        for(int i=-1;i<=1;i++){
+            pqs += vec2(
+                cfa(-3+i,-3+i) - cfa(1+i,-1+i) - cfa(1+i,1+i) + cfa(3+i,3+i) - 3.0*(cfa(-2+i,-2+i)+cfa(2+i,2+i)) + 6.0*cfa(i,i),
+                cfa(3+i,-3-i) - cfa(1+i,-1-i) - cfa(-1+i,1-i) + cfa(-3+i,3-i) - 3.0*(cfa(2+i,-2-i)+cfa(-2+i,2-i)) + 6.0*cfa(i,-i)
+            );
+        }
+        pqs*=pqs;
+        float pq = pqs.x/(pqs.x+pqs.y);
+        imageStore(img_pq, ivec2(ipos.x/2, ipos.y), vec4(pq));
+    }else{
+        float lp=0.0; int off=((ipos.x&1)==1)?-1:1;
+        const float w[3]={0.5,1.0,0.5};
+        for(int j=-1;j<=1;j++) for(int i=-1;i<=1;i++) lp+=w[j+1]*w[i+1]*cfa(i+off,j);
+        imageStore(img_lp, ivec2(ipos.x/2, ipos.y), vec4(max(1e-6, lp)));
+    }
+#undef cfa
+}

--- a/shaders/rcd_fill.comp
+++ b/shaders/rcd_fill.comp
@@ -1,0 +1,77 @@
+#version 460
+layout(binding = 0) uniform sampler2D img_cfa;
+layout(binding = 1) uniform sampler2D img_vh;
+layout(binding = 2) uniform sampler2D img_pq;
+layout(binding = 3) uniform sampler2D img_lp;
+layout(binding = 4, rgba32f) uniform writeonly image2D img_out;
+layout(push_constant) uniform PushConstants { vec4 wb; } push;
+layout(local_size_x = 16, local_size_y = 16) in;
+
+void main(){
+    ivec2 ipos = ivec2(gl_GlobalInvocationID.xy);
+    ivec2 size = textureSize(img_cfa,0);
+    if(any(greaterThanEqual(ipos,size))) return;
+#define cfa(x,y) texelFetch(img_cfa, ivec2(ipos.x+(x), ipos.y+(y)),0).r
+#define vh(x,y) texelFetch(img_vh, ivec2(ipos.x+(x), ipos.y+(y)),0).r
+#define pq(x,y) texelFetch(img_pq, ivec2((ipos.x+(x)+(((ipos.y+(y))&1)==1?0:1))/2, ipos.y+(y)),0).r
+#define lp(x,y) texelFetch(img_lp, ivec2((ipos.x+(x)+(((ipos.y+(y))&1)==1?0:1))/2, ipos.y+(y)),0).r
+    bool is_green=((ipos.x+ipos.y)&1)==1;
+    bool is_red=!is_green && ((ipos.y&1)==0);
+    float r,g,b; const float eps=1e-5;
+    if(is_green){
+        g=cfa(0,0);
+        float vh_val=vh(0,0);
+        float vh_neighbor=0.25*(vh(-1,-1)+vh(1,-1)+vh(-1,1)+vh(1,1));
+        float vh_discr=abs(0.5 - vh_val) < abs(0.5 - vh_neighbor) ? vh_val : vh_neighbor;
+        float N_grad=eps+abs(cfa(0,-1)-cfa(0,1))+abs(cfa(0,0)-cfa(0,-2));
+        float S_grad=eps+abs(cfa(0,-1)-cfa(0,1))+abs(cfa(0,0)-cfa(0,2));
+        float W_grad=eps+abs(cfa(-1,0)-cfa(1,0))+abs(cfa(0,0)-cfa(-2,0));
+        float E_grad=eps+abs(cfa(-1,0)-cfa(1,0))+abs(cfa(0,0)-cfa(2,0));
+        float r_N=cfa(0,-1)*2.0*lp(0,0)/(eps+lp(0,0)+lp(0,-2));
+        float r_S=cfa(0,1)*2.0*lp(0,0)/(eps+lp(0,0)+lp(0,2));
+        float r_W=cfa(-1,0)*2.0*lp(0,0)/(eps+lp(0,0)+lp(-2,0));
+        float r_E=cfa(1,0)*2.0*lp(0,0)/(eps+lp(0,0)+lp(2,0));
+        float r_v=(S_grad*r_N+N_grad*r_S)/(N_grad+S_grad);
+        float r_h=(E_grad*r_W+W_grad*r_E)/(E_grad+W_grad);
+        r=mix(r_v,r_h,vh_discr);
+        float b_N=cfa(0,-1)*2.0*lp(0,0)/(eps+lp(0,0)+lp(0,-2));
+        float b_S=cfa(0,1)*2.0*lp(0,0)/(eps+lp(0,0)+lp(0,2));
+        float b_W=cfa(-1,0)*2.0*lp(0,0)/(eps+lp(0,0)+lp(-2,0));
+        float b_E=cfa(1,0)*2.0*lp(0,0)/(eps+lp(0,0)+lp(2,0));
+        float b_v=(S_grad*b_N+N_grad*b_S)/(N_grad+S_grad);
+        float b_h=(E_grad*b_W+W_grad*b_E)/(E_grad+W_grad);
+        b=mix(b_v,b_h,vh_discr);
+    }else{
+        float c=cfa(0,0);
+        float vh_val=vh(0,0);
+        float vh_neighbor=0.25*(vh(-1,-1)+vh(1,-1)+vh(-1,1)+vh(1,1));
+        float vh_discr=abs(0.5 - vh_val) < abs(0.5 - vh_neighbor) ? vh_val : vh_neighbor;
+        float N=cfa(0,-1), S=cfa(0,1), W=cfa(-1,0), E=cfa(1,0);
+        float N_grad=eps+abs(N-cfa(0,1))+abs(cfa(0,-1)-cfa(0,-3));
+        float S_grad=eps+abs(S-cfa(0,-1))+abs(cfa(0,1)-cfa(0,3));
+        float W_grad=eps+abs(W-cfa(1,0))+abs(cfa(-1,0)-cfa(-3,0));
+        float E_grad=eps+abs(E-cfa(-1,0))+abs(cfa(1,0)-cfa(3,0));
+        float g_N=N*2.0*lp(0,0)/(eps+lp(0,0)+lp(0,-2));
+        float g_S=S*2.0*lp(0,0)/(eps+lp(0,0)+lp(0,2));
+        float g_W=W*2.0*lp(0,0)/(eps+lp(0,0)+lp(-2,0));
+        float g_E=E*2.0*lp(0,0)/(eps+lp(0,0)+lp(2,0));
+        float g_v=(S_grad*g_N+N_grad*g_S)/(N_grad+S_grad);
+        float g_h=(E_grad*g_W+W_grad*g_E)/(E_grad+W_grad);
+        g=mix(g_v,g_h,vh_discr);
+        float pq_val=pq(0,0);
+        float pq_neighbor=0.25*(pq(-1,-1)+pq(1,-1)+pq(-1,1)+pq(1,1));
+        float pq_discr=abs(0.5 - pq_val) < abs(0.5 - pq_neighbor) ? pq_val : pq_neighbor;
+        float NW=cfa(-1,-1)-(cfa(-1,0)+cfa(0,-1))*0.5+g;
+        float NE=cfa(1,-1)-(cfa(1,0)+cfa(0,-1))*0.5+g;
+        float SW=cfa(-1,1)-(cfa(-1,0)+cfa(0,1))*0.5+g;
+        float SE=cfa(1,1)-(cfa(1,0)+cfa(0,1))*0.5+g;
+        float p=(NW+SE)*0.5; float q=(NE+SW)*0.5; float other=mix(p,q,pq_discr);
+        if(is_red){ r=c; b=other; } else { b=c; r=other; }
+    }
+    vec4 color=vec4(r*push.wb.r, g*push.wb.g, b*push.wb.b, 1.0);
+    imageStore(img_out, ipos, color);
+#undef cfa
+#undef vh
+#undef pq
+#undef lp
+}

--- a/src/Utils/ColorPipelineCPU.cpp
+++ b/src/Utils/ColorPipelineCPU.cpp
@@ -279,12 +279,96 @@ void convertRawToRGB24(const uint16_t* raw, const CPUColorParams& p,
         }
     };
 
+    auto vh_calc=[&](int x,int y){
+        float sx=0.0f, sy=0.0f;
+        for(int i=-1;i<=1;++i){
+            sx += lin(x+i,y-3) - 3.0f*lin(x+i,y-2) - lin(x+i,y-1) + 6.0f*lin(x+i,y) - lin(x+i,y+1) - 3.0f*lin(x+i,y+2) + lin(x+i,y+3);
+            sy += lin(x-3,y+i) - 3.0f*lin(x-2,y+i) - lin(x-1,y+i) + 6.0f*lin(x,y+i) - lin(x+1,y+i) - 3.0f*lin(x+2,y+i) + lin(x+3,y+i);
+        }
+        float sx2=sx*sx, sy2=sy*sy;
+        return (sx2)/(1e-5f + sx2 + sy2);
+    };
+
+    auto pq_calc=[&](int x,int y){
+        float a=1e-5f,bv=1e-5f;
+        for(int i=-1;i<=1;++i){
+            a += lin(x-3+i,y-3+i) - lin(x+1+i,y-1+i) - lin(x+1+i,y+1+i) + lin(x+3+i,y+3+i)
+                -3.0f*(lin(x-2+i,y-2+i)+lin(x+2+i,y+2+i)) + 6.0f*lin(x+i,y+i);
+            bv += lin(x+3+i,y-3-i) - lin(x+1+i,y-1-i) - lin(x-1+i,y+1-i) + lin(x-3+i,y+3-i)
+                -3.0f*(lin(x+2+i,y-2-i)+lin(x-2+i,y+2-i)) + 6.0f*lin(x+i,y-i);
+        }
+        a*=a; bv*=bv; return a/(a+bv);
+    };
+
+    auto lp_calc=[&](int x,int y){
+        float lp=0.0f; int off=((x & 1)==1)?-1:1; const float w[3]={0.5f,1.0f,0.5f};
+        for(int j=-1;j<=1;++j) for(int i=-1;i<=1;++i) lp+=w[j+1]*w[i+1]*lin(x+i+off,y+j);
+        return std::max(1e-6f, lp);
+    };
+
+    auto demosaicRCD=[&](int x,int y,float& r,float& g,float& b){
+        bool is_green=((x+y)&1)==1; bool is_red=!is_green && ((y&1)==0); const float eps=1e-5f;
+        if(is_green){
+            g=lin(x,y);
+            float vh_val=vh_calc(x,y);
+            float vh_neighbor=0.25f*(vh_calc(x-1,y-1)+vh_calc(x+1,y-1)+vh_calc(x-1,y+1)+vh_calc(x+1,y+1));
+            float vh_discr=std::abs(0.5f - vh_val) < std::abs(0.5f - vh_neighbor) ? vh_val : vh_neighbor;
+            float N_grad=eps+std::abs(lin(x,y-1)-lin(x,y+1))+std::abs(lin(x,y)-lin(x,y-2));
+            float S_grad=eps+std::abs(lin(x,y-1)-lin(x,y+1))+std::abs(lin(x,y)-lin(x,y+2));
+            float W_grad=eps+std::abs(lin(x-1,y)-lin(x+1,y))+std::abs(lin(x,y)-lin(x-2,y));
+            float E_grad=eps+std::abs(lin(x-1,y)-lin(x+1,y))+std::abs(lin(x,y)-lin(x+2,y));
+            float lp=lp_calc(x,y);
+            float r_N=lin(x,y-1)*2.0f*lp/(eps+lp+lp_calc(x,y-2));
+            float r_S=lin(x,y+1)*2.0f*lp/(eps+lp+lp_calc(x,y+2));
+            float r_W=lin(x-1,y)*2.0f*lp/(eps+lp+lp_calc(x-2,y));
+            float r_E=lin(x+1,y)*2.0f*lp/(eps+lp+lp_calc(x+2,y));
+            float r_v=(S_grad*r_N+N_grad*r_S)/(N_grad+S_grad);
+            float r_h=(E_grad*r_W+W_grad*r_E)/(E_grad+W_grad);
+            r=mix(r_v,r_h,vh_discr);
+            float b_N=lin(x,y-1)*2.0f*lp/(eps+lp+lp_calc(x,y-2));
+            float b_S=lin(x,y+1)*2.0f*lp/(eps+lp+lp_calc(x,y+2));
+            float b_W=lin(x-1,y)*2.0f*lp/(eps+lp+lp_calc(x-2,y));
+            float b_E=lin(x+1,y)*2.0f*lp/(eps+lp+lp_calc(x+2,y));
+            float b_v=(S_grad*b_N+N_grad*b_S)/(N_grad+S_grad);
+            float b_h=(E_grad*b_W+W_grad*b_E)/(E_grad+W_grad);
+            b=mix(b_v,b_h,vh_discr);
+        }else{
+            float c=lin(x,y);
+            float vh_val=vh_calc(x,y);
+            float vh_neighbor=0.25f*(vh_calc(x-1,y-1)+vh_calc(x+1,y-1)+vh_calc(x-1,y+1)+vh_calc(x+1,y+1));
+            float vh_discr=std::abs(0.5f - vh_val) < std::abs(0.5f - vh_neighbor) ? vh_val : vh_neighbor;
+            float N=lin(x,y-1), S=lin(x,y+1), W=lin(x-1,y), E=lin(x+1,y);
+            float N_grad=eps+std::abs(N-lin(x,y+1))+std::abs(lin(x,y-1)-lin(x,y-3));
+            float S_grad=eps+std::abs(S-lin(x,y-1))+std::abs(lin(x,y+1)-lin(x,y+3));
+            float W_grad=eps+std::abs(W-lin(x+1,y))+std::abs(lin(x-1,y)-lin(x-3,y));
+            float E_grad=eps+std::abs(E-lin(x-1,y))+std::abs(lin(x+1,y)-lin(x+3,y));
+            float lp=lp_calc(x,y);
+            float g_N=N*2.0f*lp/(eps+lp+lp_calc(x,y-2));
+            float g_S=S*2.0f*lp/(eps+lp+lp_calc(x,y+2));
+            float g_W=W*2.0f*lp/(eps+lp+lp_calc(x-2,y));
+            float g_E=E*2.0f*lp/(eps+lp+lp_calc(x+2,y));
+            float g_v=(S_grad*g_N+N_grad*g_S)/(N_grad+S_grad);
+            float g_h=(E_grad*g_W+W_grad*g_E)/(E_grad+W_grad);
+            g=mix(g_v,g_h,vh_discr);
+            float pq_val=pq_calc(x,y);
+            float pq_neighbor=0.25f*(pq_calc(x-1,y-1)+pq_calc(x+1,y-1)+pq_calc(x-1,y+1)+pq_calc(x+1,y+1));
+            float pq_discr=std::abs(0.5f-pq_val)<std::abs(0.5f-pq_neighbor)?pq_val:pq_neighbor;
+            float NW=lin(x-1,y-1)-(lin(x-1,y)+lin(x,y-1))*0.5f+g;
+            float NE=lin(x+1,y-1)-(lin(x+1,y)+lin(x,y-1))*0.5f+g;
+            float SW=lin(x-1,y+1)-(lin(x-1,y)+lin(x,y+1))*0.5f+g;
+            float SE=lin(x+1,y+1)-(lin(x+1,y)+lin(x,y+1))*0.5f+g;
+            float p=(NW+SE)*0.5f; float q=(NE+SW)*0.5f; float other=mix(p,q,pq_discr);
+            if(is_red){ r=c; b=other; } else { b=c; r=other; }
+        }
+    };
+
     const float* ccm = p.ccm.data();
 
     auto processRow = [&](int y){
         for(int x=0;x<p.width;++x){
             float r=0.0f,g=0.0f,b=0.0f;
             if(p.demosaicMode==1) demosaicVG(x,y,r,g,b);
+            else if(p.demosaicMode==2) demosaicRCD(x,y,r,g,b);
             else bilinearRGB(x,y,r,g,b);
             float r_wb = std::clamp(r * p.gainR, 0.0f, 1.0f);
             float g_wb = std::clamp(g * p.gainG, 0.0f, 1.0f);


### PR DESCRIPTION
## Summary
- add optional RCD demosaicing algorithm for CPU path
- provide experimental shaders for RCD (not yet wired in)
- extend shader build to compile new files
- document new mode in README

## Testing
- `cmake -S . -B build` *(fails: required package glfw3 not found)*

------
https://chatgpt.com/codex/tasks/task_e_688654d6b8548327bcdce19e46afcd9b