### PR TITLE
Use RCD demosaic everywhere

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -109,6 +109,8 @@ set(SHADER_FILES
     "${APP_SHADERS_SRC_DIR}/fullscreen_quad.vert"
     "${APP_SHADERS_SRC_DIR}/image_process.frag"
     "${APP_SHADERS_SRC_DIR}/raw_to_yuv422.comp"
+    "${APP_SHADERS_SRC_DIR}/rcd_conv.comp"
+    "${APP_SHADERS_SRC_DIR}/rcd_fill.comp"
 )
 set(COMPILED_SHADER_OUTPUTS "")
 foreach(SHADER_INPUT_FILE ${SHADER_FILES})

--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ runtime DLLs will be copied automatically.
   video packets were written.
 - You can override the detected CFA pattern at runtime by pressing the number
   keys `1`‑`4` which map to **BGGR**, **RGGB**, **GBRG**, and **GRBG** respectively.
-- Variable gradient demosaicing is always used for all export and preview paths.
+- RCD demosaicing is used for all export and preview paths.
 
 ### GPU ProRes Conversion
 

--- a/include/App/App.h
+++ b/include/App/App.h
@@ -81,7 +81,6 @@ public:
     std::vector<std::string> m_fileList;
     int m_currentFileIndex = -1;
     std::optional<int> m_cfaOverride;
-    int m_demosaicMode = 1;
     std::string m_cfaStringFromMetadata;
     bool m_showMetrics = false;
     bool m_showHelpPage = false;

--- a/include/Graphics/GpuColorParams.h
+++ b/include/Graphics/GpuColorParams.h
@@ -7,7 +7,6 @@ struct GpuColorParams {
     float wbB{1.0f};
     float colorMatrix[9]{1,0,0,0,1,0,0,0,1};
     int   cfaType{0};   // 0 BGGR,1 RGGB,2 GBRG,3 GRBG
-    int   demosaicMode{1}; // 0 bilinear, 1 variable gradient
     int   fullSwing{0}; // 0 studio, 1 full
     unsigned int black{64};
     unsigned int white{1023};

--- a/include/Graphics/Renderer_VK.h
+++ b/include/Graphics/Renderer_VK.h
@@ -51,8 +51,7 @@ public:
         double staticBlack, double staticWhite, int cfaTypeOverride,
         bool forceUpload,
         OrientationTag defaultOrientation,
-        bool containerFlipped,
-        int demosaicMode
+        bool containerFlipped
     );
 
     void recordDrawCommands(
@@ -130,7 +129,6 @@ private:
         alignas(16) glm::mat4 CCM;
         alignas(4) float saturationAdjustment;
         alignas(4) int orientationDegrees;
-        alignas(4) int demosaicMode;
     };
 
     // Internal state not directly manipulated by namespaced helpers

--- a/include/Utils/ColorPipelineCPU.h
+++ b/include/Utils/ColorPipelineCPU.h
@@ -7,7 +7,6 @@ struct CPUColorParams {
     int width{0};
     int height{0};
     int cfaType{0}; // 0 BGGR,1 RGGB,2 GBRG,3 GRBG
-    int demosaicMode{1}; // 0 bilinear, 1 variable gradient
     double blackLevel{0.0};
     double whiteLevel{65535.0};
     float gainR{1.0f};

--- a/shaders/fullscreen_quad.vert
+++ b/shaders/fullscreen_quad.vert
@@ -6,7 +6,7 @@ layout(binding = 1) uniform ShaderParams {
     int W; int H; int cfaType; float exposure;
     float blackLevel; float whiteLevel; float invBlackWhiteRange;
     float gainR; float gainG; float gainB;
-    mat4 CCM; float saturationAdjustment; int orientationDegrees; int demosaicMode;
+    mat4 CCM; float saturationAdjustment; int orientationDegrees;
 } params;
 
 // Fullscreen quad/triangle vertices. No actual vertex buffer needed.

--- a/shaders/image_process.frag
+++ b/shaders/image_process.frag
@@ -19,7 +19,6 @@ layout(binding = 1) uniform ShaderParams {
     mat4 CCM; // Pass as mat4, use top-left 3x3
     float saturationAdjustment; // e.g., 1.0 for no change, 1.25 for +25%
     int orientationDegrees;
-    int demosaicMode; // 0 bilinear, 1 variable gradient
 } params;
 
 // sRGB EOTF (gamma correction)
@@ -317,6 +316,106 @@ vec3 demosaicVG(int x,int y){
     return rgb;
 }
 
+float vh_calc(int x,int y){
+    float sx = 0.0;
+    float sy = 0.0;
+    for(int i=-1;i<=1;++i){
+        sx += lin(readU16_val(x+i,y-3)) - 3.0*lin(readU16_val(x+i,y-2)) - lin(readU16_val(x+i,y-1)) +
+              6.0*lin(readU16_val(x+i,y)) - lin(readU16_val(x+i,y+1)) - 3.0*lin(readU16_val(x+i,y+2)) +
+              lin(readU16_val(x+i,y+3));
+        sy += lin(readU16_val(x-3,y+i)) - 3.0*lin(readU16_val(x-2,y+i)) - lin(readU16_val(x-1,y+i)) +
+              6.0*lin(readU16_val(x,y+i)) - lin(readU16_val(x+1,y+i)) - 3.0*lin(readU16_val(x+2,y+i)) +
+              lin(readU16_val(x+3,y+i));
+    }
+    float sx2=sx*sx, sy2=sy*sy;
+    return sx2/(1e-5 + sx2 + sy2);
+}
+
+float pq_calc(int x,int y){
+    float a=1e-5, bv=1e-5;
+    for(int i=-1;i<=1;++i){
+        a += lin(readU16_val(x-3+i,y-3+i)) - lin(readU16_val(x+1+i,y-1+i)) - lin(readU16_val(x+1+i,y+1+i)) +
+             lin(readU16_val(x+3+i,y+3+i)) - 3.0*(lin(readU16_val(x-2+i,y-2+i)) + lin(readU16_val(x+2+i,y+2+i))) +
+             6.0*lin(readU16_val(x+i,y+i));
+        bv += lin(readU16_val(x+3+i,y-3-i)) - lin(readU16_val(x+1+i,y-1-i)) - lin(readU16_val(x-1+i,y+1-i)) +
+              lin(readU16_val(x-3+i,y+3-i)) - 3.0*(lin(readU16_val(x+2+i,y-2-i)) + lin(readU16_val(x-2+i,y+2-i))) +
+              6.0*lin(readU16_val(x+i,y-i));
+    }
+    a*=a; bv*=bv; return a/(a+bv);
+}
+
+float lp_calc(int x,int y){
+    float lp=0.0; int off=((x & 1)==1)?-1:1; float w[3] = float[3](0.5,1.0,0.5);
+    for(int j=-1;j<=1;++j) for(int i=-1;i<=1;++i)
+        lp += w[j+1]*w[i+1]*lin(readU16_val(x+i+off,y+j));
+    return max(1e-6, lp);
+}
+
+vec3 demosaicRCD(int x,int y){
+    bool is_green=((x+y)&1)==1;
+    bool is_red=!is_green && ((y&1)==0);
+    const float eps=1e-5;
+    vec3 rgb=vec3(0.0);
+    if(is_green){
+        rgb.g = lin(readU16_val(x,y));
+        float vh_val=vh_calc(x,y);
+        float vh_neighbor=0.25*(vh_calc(x-1,y-1)+vh_calc(x+1,y-1)+vh_calc(x-1,y+1)+vh_calc(x+1,y+1));
+        float vh_discr=abs(0.5 - vh_val) < abs(0.5 - vh_neighbor) ? vh_val : vh_neighbor;
+        float N_grad=eps+abs(lin(readU16_val(x,y-1))-lin(readU16_val(x,y+1)))+abs(lin(readU16_val(x,y))-lin(readU16_val(x,y-2)));
+        float S_grad=eps+abs(lin(readU16_val(x,y-1))-lin(readU16_val(x,y+1)))+abs(lin(readU16_val(x,y))-lin(readU16_val(x,y+2)));
+        float W_grad=eps+abs(lin(readU16_val(x-1,y))-lin(readU16_val(x+1,y)))+abs(lin(readU16_val(x,y))-lin(readU16_val(x-2,y)));
+        float E_grad=eps+abs(lin(readU16_val(x-1,y))-lin(readU16_val(x+1,y)))+abs(lin(readU16_val(x,y))-lin(readU16_val(x+2,y)));
+        float lp=lp_calc(x,y);
+        float r_N=lin(readU16_val(x,y-1))*2.0*lp/(eps+lp+lp_calc(x,y-2));
+        float r_S=lin(readU16_val(x,y+1))*2.0*lp/(eps+lp+lp_calc(x,y+2));
+        float r_W=lin(readU16_val(x-1,y))*2.0*lp/(eps+lp+lp_calc(x-2,y));
+        float r_E=lin(readU16_val(x+1,y))*2.0*lp/(eps+lp+lp_calc(x+2,y));
+        float r_v=(S_grad*r_N+N_grad*r_S)/(N_grad+S_grad);
+        float r_h=(E_grad*r_W+W_grad*r_E)/(E_grad+W_grad);
+        rgb.r=mix(r_v,r_h,vh_discr);
+        float b_N=lin(readU16_val(x,y-1))*2.0*lp/(eps+lp+lp_calc(x,y-2));
+        float b_S=lin(readU16_val(x,y+1))*2.0*lp/(eps+lp+lp_calc(x,y+2));
+        float b_W=lin(readU16_val(x-1,y))*2.0*lp/(eps+lp+lp_calc(x-2,y));
+        float b_E=lin(readU16_val(x+1,y))*2.0*lp/(eps+lp+lp_calc(x+2,y));
+        float b_v=(S_grad*b_N+N_grad*b_S)/(N_grad+S_grad);
+        float b_h=(E_grad*b_W+W_grad*b_E)/(E_grad+W_grad);
+        rgb.b=mix(b_v,b_h,vh_discr);
+    } else {
+        float c=lin(readU16_val(x,y));
+        float vh_val=vh_calc(x,y);
+        float vh_neighbor=0.25*(vh_calc(x-1,y-1)+vh_calc(x+1,y-1)+vh_calc(x-1,y+1)+vh_calc(x+1,y+1));
+        float vh_discr=abs(0.5 - vh_val) < abs(0.5 - vh_neighbor) ? vh_val : vh_neighbor;
+        float N=lin(readU16_val(x,y-1));
+        float S=lin(readU16_val(x,y+1));
+        float W=lin(readU16_val(x-1,y));
+        float E=lin(readU16_val(x+1,y));
+        float N_grad=eps+abs(N-lin(readU16_val(x,y+1)))+abs(lin(readU16_val(x,y-1))-lin(readU16_val(x,y-3)));
+        float S_grad=eps+abs(S-lin(readU16_val(x,y-1)))+abs(lin(readU16_val(x,y+1))-lin(readU16_val(x,y+3)));
+        float W_grad=eps+abs(W-lin(readU16_val(x+1,y)))+abs(lin(readU16_val(x-1,y))-lin(readU16_val(x-3,y)));
+        float E_grad=eps+abs(E-lin(readU16_val(x-1,y)))+abs(lin(readU16_val(x+1,y))-lin(readU16_val(x+3,y)));
+        float lp=lp_calc(x,y);
+        float g_N=N*2.0*lp/(eps+lp+lp_calc(x,y-2));
+        float g_S=S*2.0*lp/(eps+lp+lp_calc(x,y+2));
+        float g_W=W*2.0*lp/(eps+lp+lp_calc(x-2,y));
+        float g_E=E*2.0*lp/(eps+lp+lp_calc(x+2,y));
+        float g_v=(S_grad*g_N+N_grad*g_S)/(N_grad+S_grad);
+        float g_h=(E_grad*g_W+W_grad*g_E)/(E_grad+W_grad);
+        rgb.g=mix(g_v,g_h,vh_discr);
+        float pq_val=pq_calc(x,y);
+        float pq_neighbor=0.25*(pq_calc(x-1,y-1)+pq_calc(x+1,y-1)+pq_calc(x-1,y+1)+pq_calc(x+1,y+1));
+        float pq_discr=abs(0.5-pq_val)<abs(0.5-pq_neighbor)?pq_val:pq_neighbor;
+        float NW=lin(readU16_val(x-1,y-1))-(lin(readU16_val(x-1,y))+lin(readU16_val(x,y-1)))*0.5+rgb.g;
+        float NE=lin(readU16_val(x+1,y-1))-(lin(readU16_val(x+1,y))+lin(readU16_val(x,y-1)))*0.5+rgb.g;
+        float SW=lin(readU16_val(x-1,y+1))-(lin(readU16_val(x-1,y))+lin(readU16_val(x,y+1)))*0.5+rgb.g;
+        float SE=lin(readU16_val(x+1,y+1))-(lin(readU16_val(x+1,y))+lin(readU16_val(x,y+1)))*0.5+rgb.g;
+        float p=(NW+SE)*0.5;
+        float q=(NE+SW)*0.5;
+        float other=mix(p,q,pq_discr);
+        if(is_red){ rgb.r=c; rgb.b=other; } else { rgb.b=c; rgb.r=other; }
+    }
+    return rgb;
+}
+
 void main() {
     ivec2 p = ivec2(inTexCoord * vec2(params.W, params.H));
     
@@ -328,7 +427,7 @@ void main() {
     int x = p.x;
     int y = p.y;
 
-    vec3 rgb = (params.demosaicMode == 1) ? demosaicVG(x,y) : bilinearRGB(x,y);
+    vec3 rgb = demosaicRCD(x,y);
     float r_demosaiced = rgb.r;
     float g_demosaiced = rgb.g;
     float b_demosaiced = rgb.b;

--- a/shaders/raw_to_yuv422.comp
+++ b/shaders/raw_to_yuv422.comp
@@ -218,8 +218,95 @@ vec3 demosaicVG(int x,int y){
     return rgb;
 }
 
+float vh_calc(int x,int y){
+    float sx=0.0, sy=0.0;
+    for(int i=-1;i<=1;++i){
+        sx += RAW(x+i,y-3) - 3.0*RAW(x+i,y-2) - RAW(x+i,y-1) + 6.0*RAW(x+i,y) - RAW(x+i,y+1) - 3.0*RAW(x+i,y+2) + RAW(x+i,y+3);
+        sy += RAW(x-3,y+i) - 3.0*RAW(x-2,y+i) - RAW(x-1,y+i) + 6.0*RAW(x,y+i) - RAW(x+1,y+i) - 3.0*RAW(x+2,y+i) + RAW(x+3,y+i);
+    }
+    float sx2=sx*sx, sy2=sy*sy;
+    return sx2/(1e-5 + sx2 + sy2);
+}
+
+float pq_calc(int x,int y){
+    float a=1e-5, bv=1e-5;
+    for(int i=-1;i<=1;++i){
+        a += RAW(x-3+i,y-3+i) - RAW(x+1+i,y-1+i) - RAW(x+1+i,y+1+i) + RAW(x+3+i,y+3+i)
+           -3.0*(RAW(x-2+i,y-2+i)+RAW(x+2+i,y+2+i)) + 6.0*RAW(x+i,y+i);
+        bv += RAW(x+3+i,y-3-i) - RAW(x+1+i,y-1-i) - RAW(x-1+i,y+1-i) + RAW(x-3+i,y+3-i)
+           -3.0*(RAW(x+2+i,y-2-i)+RAW(x-2+i,y+2-i)) + 6.0*RAW(x+i,y-i);
+    }
+    a*=a; bv*=bv; return a/(a+bv);
+}
+
+float lp_calc(int x,int y){
+    float lp=0.0; int off=((x & 1)==1)?-1:1; const float w[3]={0.5,1.0,0.5};
+    for(int j=-1;j<=1;++j) for(int i=-1;i<=1;++i) lp+=w[j+1]*w[i+1]*RAW(x+i+off,y+j);
+    return max(1e-6, lp);
+}
+
+vec3 demosaicRCD(int x,int y){
+    bool is_green=((x+y)&1)==1;
+    bool is_red=!is_green && ((y&1)==0);
+    const float eps=1e-5;
+    vec3 rgb=vec3(0.0);
+    if(is_green){
+        rgb.g = RAW(x,y);
+        float vh_val=vh_calc(x,y);
+        float vh_neighbor=0.25*(vh_calc(x-1,y-1)+vh_calc(x+1,y-1)+vh_calc(x-1,y+1)+vh_calc(x+1,y+1));
+        float vh_discr=abs(0.5 - vh_val) < abs(0.5 - vh_neighbor) ? vh_val : vh_neighbor;
+        float N_grad=eps+abs(RAW(x,y-1)-RAW(x,y+1))+abs(RAW(x,y)-RAW(x,y-2));
+        float S_grad=eps+abs(RAW(x,y-1)-RAW(x,y+1))+abs(RAW(x,y)-RAW(x,y+2));
+        float W_grad=eps+abs(RAW(x-1,y)-RAW(x+1,y))+abs(RAW(x,y)-RAW(x-2,y));
+        float E_grad=eps+abs(RAW(x-1,y)-RAW(x+1,y))+abs(RAW(x,y)-RAW(x+2,y));
+        float lp=lp_calc(x,y);
+        float r_N=RAW(x,y-1)*2.0*lp/(eps+lp+lp_calc(x,y-2));
+        float r_S=RAW(x,y+1)*2.0*lp/(eps+lp+lp_calc(x,y+2));
+        float r_W=RAW(x-1,y)*2.0*lp/(eps+lp+lp_calc(x-2,y));
+        float r_E=RAW(x+1,y)*2.0*lp/(eps+lp+lp_calc(x+2,y));
+        float r_v=(S_grad*r_N+N_grad*r_S)/(N_grad+S_grad);
+        float r_h=(E_grad*r_W+W_grad*r_E)/(E_grad+W_grad);
+        rgb.r=mix(r_v,r_h,vh_discr);
+        float b_N=RAW(x,y-1)*2.0*lp/(eps+lp+lp_calc(x,y-2));
+        float b_S=RAW(x,y+1)*2.0*lp/(eps+lp+lp_calc(x,y+2));
+        float b_W=RAW(x-1,y)*2.0*lp/(eps+lp+lp_calc(x-2,y));
+        float b_E=RAW(x+1,y)*2.0*lp/(eps+lp+lp_calc(x+2,y));
+        float b_v=(S_grad*b_N+N_grad*b_S)/(N_grad+S_grad);
+        float b_h=(E_grad*b_W+W_grad*b_E)/(E_grad+W_grad);
+        rgb.b=mix(b_v,b_h,vh_discr);
+    } else {
+        float c=RAW(x,y);
+        float vh_val=vh_calc(x,y);
+        float vh_neighbor=0.25*(vh_calc(x-1,y-1)+vh_calc(x+1,y-1)+vh_calc(x-1,y+1)+vh_calc(x+1,y+1));
+        float vh_discr=abs(0.5 - vh_val) < abs(0.5 - vh_neighbor) ? vh_val : vh_neighbor;
+        float N=RAW(x,y-1); float S=RAW(x,y+1); float W=RAW(x-1,y); float E=RAW(x+1,y);
+        float N_grad=eps+abs(N-RAW(x,y+1))+abs(RAW(x,y-1)-RAW(x,y-3));
+        float S_grad=eps+abs(S-RAW(x,y-1))+abs(RAW(x,y+1)-RAW(x,y+3));
+        float W_grad=eps+abs(W-RAW(x+1,y))+abs(RAW(x-1,y)-RAW(x-3,y));
+        float E_grad=eps+abs(E-RAW(x-1,y))+abs(RAW(x+1,y)-RAW(x+3,y));
+        float lp=lp_calc(x,y);
+        float g_N=N*2.0*lp/(eps+lp+lp_calc(x,y-2));
+        float g_S=S*2.0*lp/(eps+lp+lp_calc(x,y+2));
+        float g_W=W*2.0*lp/(eps+lp+lp_calc(x-2,y));
+        float g_E=E*2.0*lp/(eps+lp+lp_calc(x+2,y));
+        float g_v=(S_grad*g_N+N_grad*g_S)/(N_grad+S_grad);
+        float g_h=(E_grad*g_W+W_grad*g_E)/(E_grad+W_grad);
+        rgb.g=mix(g_v,g_h,vh_discr);
+        float pq_val=pq_calc(x,y);
+        float pq_neighbor=0.25*(pq_calc(x-1,y-1)+pq_calc(x+1,y-1)+pq_calc(x-1,y+1)+pq_calc(x+1,y+1));
+        float pq_discr=abs(0.5-pq_val)<abs(0.5-pq_neighbor)?pq_val:pq_neighbor;
+        float NW=RAW(x-1,y-1)-(RAW(x-1,y)+RAW(x,y-1))*0.5+rgb.g;
+        float NE=RAW(x+1,y-1)-(RAW(x+1,y)+RAW(x,y-1))*0.5+rgb.g;
+        float SW=RAW(x-1,y+1)-(RAW(x-1,y)+RAW(x,y+1))*0.5+rgb.g;
+        float SE=RAW(x+1,y+1)-(RAW(x+1,y)+RAW(x,y+1))*0.5+rgb.g;
+        float p=(NW+SE)*0.5; float q=(NE+SW)*0.5; float other=mix(p,q,pq_discr);
+        if(is_red){ rgb.r=c; rgb.b=other; } else { rgb.b=c; rgb.r=other; }
+    }
+    return rgb;
+}
+
 vec3 bayerToRGB(uint x, uint y){
-    vec3 rgb = demosaicVG(int(x), int(y));
+    vec3 rgb = demosaicRCD(int(x), int(y));
     rgb *= vec3(pc.wbR, pc.wbG, pc.wbB);        // white balance
     rgb = pc.colMat * rgb;                      // sensor -> BT.709
     return clamp(rgb, 0.0, 1.0);

--- a/shaders/rcd_conv.comp
+++ b/shaders/rcd_conv.comp
@@ -1,0 +1,43 @@
+#version 460
+layout(binding = 0) uniform sampler2D img_cfa;
+layout(binding = 1, r8) uniform writeonly image2D img_vh;
+layout(binding = 2, r8) uniform writeonly image2D img_pq;
+layout(binding = 3, r32f) uniform writeonly image2D img_lp;
+
+layout(local_size_x = 16, local_size_y = 16) in;
+
+void main(){
+    ivec2 ipos = ivec2(gl_GlobalInvocationID.xy);
+    ivec2 size = textureSize(img_cfa,0);
+    if(any(greaterThanEqual(ipos,size))) return;
+#define IP(dx,dy) (ipos + ivec2(dx,dy))
+#define cfa(dx,dy) texelFetch(img_cfa, IP(dx,dy), 0).r
+    vec2 vhs = vec2(0.0);
+    for(int i=-1;i<=1;i++){
+        vhs += vec2(
+            cfa(i,-3) - 3.0*cfa(i,-2) - cfa(i,-1) + 6.0*cfa(i,0) - cfa(i,1) - 3.0*cfa(i,2) + cfa(i,3),
+            cfa(-3,i) - 3.0*cfa(-2,i) - cfa(-1,i) + 6.0*cfa(0,i) - cfa(1,i) - 3.0*cfa(2,i) + cfa(3,i)
+        );
+    }
+    vhs*=vhs;
+    float vh = vhs.x/(1e-5 + vhs.x + vhs.y);
+    imageStore(img_vh, ipos, vec4(vh));
+    if(((ipos.x+ipos.y)&1)==0){
+        vec2 pqs = vec2(1e-5);
+        for(int i=-1;i<=1;i++){
+            pqs += vec2(
+                cfa(-3+i,-3+i) - cfa(1+i,-1+i) - cfa(1+i,1+i) + cfa(3+i,3+i) - 3.0*(cfa(-2+i,-2+i)+cfa(2+i,2+i)) + 6.0*cfa(i,i),
+                cfa(3+i,-3-i) - cfa(1+i,-1-i) - cfa(-1+i,1-i) + cfa(-3+i,3-i) - 3.0*(cfa(2+i,-2-i)+cfa(-2+i,2-i)) + 6.0*cfa(i,-i)
+            );
+        }
+        pqs*=pqs;
+        float pq = pqs.x/(pqs.x+pqs.y);
+        imageStore(img_pq, ivec2(ipos.x/2, ipos.y), vec4(pq));
+    }else{
+        float lp=0.0; int off=((ipos.x&1)==1)?-1:1;
+        const float w[3]={0.5,1.0,0.5};
+        for(int j=-1;j<=1;j++) for(int i=-1;i<=1;i++) lp+=w[j+1]*w[i+1]*cfa(i+off,j);
+        imageStore(img_lp, ivec2(ipos.x/2, ipos.y), vec4(max(1e-6, lp)));
+    }
+#undef cfa
+}

--- a/shaders/rcd_fill.comp
+++ b/shaders/rcd_fill.comp
@@ -1,0 +1,78 @@
+#version 460
+layout(binding = 0) uniform sampler2D img_cfa;
+layout(binding = 1) uniform sampler2D img_vh;
+layout(binding = 2) uniform sampler2D img_pq;
+layout(binding = 3) uniform sampler2D img_lp;
+layout(binding = 4, rgba32f) uniform writeonly image2D img_out;
+layout(push_constant) uniform PushConstants { vec4 wb; } push;
+layout(local_size_x = 16, local_size_y = 16) in;
+
+void main(){
+    ivec2 ipos = ivec2(gl_GlobalInvocationID.xy);
+    ivec2 size = textureSize(img_cfa,0);
+    if(any(greaterThanEqual(ipos,size))) return;
+#define IP(dx,dy) (ipos + ivec2(dx,dy))
+#define cfa(dx,dy) texelFetch(img_cfa, IP(dx,dy), 0).r
+#define vh(dx,dy) texelFetch(img_vh, IP(dx,dy), 0).r
+#define pq(dx,dy) texelFetch(img_pq, ivec2((IP(dx,dy).x + (((IP(dx,dy).y) & 1)==1 ? 0 : 1)) / 2, IP(dx,dy).y), 0).r
+#define lp(dx,dy) texelFetch(img_lp, ivec2((IP(dx,dy).x + (((IP(dx,dy).y) & 1)==1 ? 0 : 1)) / 2, IP(dx,dy).y), 0).r
+    bool is_green=((ipos.x+ipos.y)&1)==1;
+    bool is_red=!is_green && ((ipos.y&1)==0);
+    float r,g,b; const float eps=1e-5;
+    if(is_green){
+        g=cfa(0,0);
+        float vh_val=vh(0,0);
+        float vh_neighbor=0.25*(vh(-1,-1)+vh(1,-1)+vh(-1,1)+vh(1,1));
+        float vh_discr=abs(0.5 - vh_val) < abs(0.5 - vh_neighbor) ? vh_val : vh_neighbor;
+        float N_grad=eps+abs(cfa(0,-1)-cfa(0,1))+abs(cfa(0,0)-cfa(0,-2));
+        float S_grad=eps+abs(cfa(0,-1)-cfa(0,1))+abs(cfa(0,0)-cfa(0,2));
+        float W_grad=eps+abs(cfa(-1,0)-cfa(1,0))+abs(cfa(0,0)-cfa(-2,0));
+        float E_grad=eps+abs(cfa(-1,0)-cfa(1,0))+abs(cfa(0,0)-cfa(2,0));
+        float r_N=cfa(0,-1)*2.0*lp(0,0)/(eps+lp(0,0)+lp(0,-2));
+        float r_S=cfa(0,1)*2.0*lp(0,0)/(eps+lp(0,0)+lp(0,2));
+        float r_W=cfa(-1,0)*2.0*lp(0,0)/(eps+lp(0,0)+lp(-2,0));
+        float r_E=cfa(1,0)*2.0*lp(0,0)/(eps+lp(0,0)+lp(2,0));
+        float r_v=(S_grad*r_N+N_grad*r_S)/(N_grad+S_grad);
+        float r_h=(E_grad*r_W+W_grad*r_E)/(E_grad+W_grad);
+        r=mix(r_v,r_h,vh_discr);
+        float b_N=cfa(0,-1)*2.0*lp(0,0)/(eps+lp(0,0)+lp(0,-2));
+        float b_S=cfa(0,1)*2.0*lp(0,0)/(eps+lp(0,0)+lp(0,2));
+        float b_W=cfa(-1,0)*2.0*lp(0,0)/(eps+lp(0,0)+lp(-2,0));
+        float b_E=cfa(1,0)*2.0*lp(0,0)/(eps+lp(0,0)+lp(2,0));
+        float b_v=(S_grad*b_N+N_grad*b_S)/(N_grad+S_grad);
+        float b_h=(E_grad*b_W+W_grad*b_E)/(E_grad+W_grad);
+        b=mix(b_v,b_h,vh_discr);
+    }else{
+        float c=cfa(0,0);
+        float vh_val=vh(0,0);
+        float vh_neighbor=0.25*(vh(-1,-1)+vh(1,-1)+vh(-1,1)+vh(1,1));
+        float vh_discr=abs(0.5 - vh_val) < abs(0.5 - vh_neighbor) ? vh_val : vh_neighbor;
+        float N=cfa(0,-1), S=cfa(0,1), W=cfa(-1,0), E=cfa(1,0);
+        float N_grad=eps+abs(N-cfa(0,1))+abs(cfa(0,-1)-cfa(0,-3));
+        float S_grad=eps+abs(S-cfa(0,-1))+abs(cfa(0,1)-cfa(0,3));
+        float W_grad=eps+abs(W-cfa(1,0))+abs(cfa(-1,0)-cfa(-3,0));
+        float E_grad=eps+abs(E-cfa(-1,0))+abs(cfa(1,0)-cfa(3,0));
+        float g_N=N*2.0*lp(0,0)/(eps+lp(0,0)+lp(0,-2));
+        float g_S=S*2.0*lp(0,0)/(eps+lp(0,0)+lp(0,2));
+        float g_W=W*2.0*lp(0,0)/(eps+lp(0,0)+lp(-2,0));
+        float g_E=E*2.0*lp(0,0)/(eps+lp(0,0)+lp(2,0));
+        float g_v=(S_grad*g_N+N_grad*g_S)/(N_grad+S_grad);
+        float g_h=(E_grad*g_W+W_grad*g_E)/(E_grad+W_grad);
+        g=mix(g_v,g_h,vh_discr);
+        float pq_val=pq(0,0);
+        float pq_neighbor=0.25*(pq(-1,-1)+pq(1,-1)+pq(-1,1)+pq(1,1));
+        float pq_discr=abs(0.5 - pq_val) < abs(0.5 - pq_neighbor) ? pq_val : pq_neighbor;
+        float NW=cfa(-1,-1)-(cfa(-1,0)+cfa(0,-1))*0.5+g;
+        float NE=cfa(1,-1)-(cfa(1,0)+cfa(0,-1))*0.5+g;
+        float SW=cfa(-1,1)-(cfa(-1,0)+cfa(0,1))*0.5+g;
+        float SE=cfa(1,1)-(cfa(1,0)+cfa(0,1))*0.5+g;
+        float p=(NW+SE)*0.5; float q=(NE+SW)*0.5; float other=mix(p,q,pq_discr);
+        if(is_red){ r=c; b=other; } else { b=c; r=other; }
+    }
+    vec4 color=vec4(r*push.wb.r, g*push.wb.g, b*push.wb.b, 1.0);
+    imageStore(img_out, ipos, color);
+#undef cfa
+#undef vh
+#undef pq
+#undef lp
+}

--- a/src/App/AppIO.cpp
+++ b/src/App/AppIO.cpp
@@ -1515,13 +1515,11 @@ void App::exportCurrentClipToProRes(const std::string& outputPathOverride) {
         cpParams.width = width;
         cpParams.height = height;
         cpParams.cfaType = m_cfaTypeFromMetadata;
-        cpParams.demosaicMode = m_demosaicMode;
         cpParams.blackLevel = m_staticBlack;
         cpParams.whiteLevel = m_staticWhite;
 
         GpuColorParams gpuParams{};
         gpuParams.cfaType = m_cfaTypeFromMetadata;
-        gpuParams.demosaicMode = m_demosaicMode;
         gpuParams.fullSwing = 0;
         gpuParams.black = static_cast<unsigned int>(m_staticBlack);
         gpuParams.white = static_cast<unsigned int>(m_staticWhite);
@@ -2060,13 +2058,11 @@ void App::exportCurrentClipToDNxHR(const std::string& outputPathOverride) {
         cpParams.width = width;
         cpParams.height = height;
         cpParams.cfaType = m_cfaTypeFromMetadata;
-        cpParams.demosaicMode = m_demosaicMode;
         cpParams.blackLevel = m_staticBlack;
         cpParams.whiteLevel = m_staticWhite;
 
         GpuColorParams gpuParams{};
         gpuParams.cfaType = m_cfaTypeFromMetadata;
-        gpuParams.demosaicMode = m_demosaicMode;
         gpuParams.fullSwing = 0;
         gpuParams.black = static_cast<unsigned int>(m_staticBlack);
         gpuParams.white = static_cast<unsigned int>(m_staticWhite);
@@ -2627,13 +2623,11 @@ void App::exportCurrentClipToHEVC_AMD(const std::string& outputPathOverride) {
         cpParams.width = width;
         cpParams.height = height;
         cpParams.cfaType = m_cfaTypeFromMetadata;
-        cpParams.demosaicMode = m_demosaicMode;
         cpParams.blackLevel = m_staticBlack;
         cpParams.whiteLevel = m_staticWhite;
 
         GpuColorParams gpuParams{};
         gpuParams.cfaType = m_cfaTypeFromMetadata;
-        gpuParams.demosaicMode = m_demosaicMode;
         gpuParams.fullSwing = 0;
         gpuParams.black = static_cast<unsigned int>(m_staticBlack);
         gpuParams.white = static_cast<unsigned int>(m_staticWhite);

--- a/src/App/AppLoop.cpp
+++ b/src/App/AppLoop.cpp
@@ -398,8 +398,7 @@ void App::drawFrame() {
                 m_staticBlack, m_staticWhite, m_cfaOverride.value_or(m_cfaTypeFromMetadata),
                 needsFreshUploadFromStaging,
                 m_containerOrientationTag,
-                m_containerFlipped,
-                m_demosaicMode
+                m_containerFlipped
             );
             // Always clear to black when there is video content
             clearColorValue.color = { {0.0f, 0.0f, 0.0f, 1.0f} };

--- a/src/Graphics/Renderer_VK.cpp
+++ b/src/Graphics/Renderer_VK.cpp
@@ -264,8 +264,7 @@ void Renderer_VK::prepareAndUploadFrameData(
     double staticBlack, double staticWhite, int cfaTypeOverride,
     bool forceUpload,
     OrientationTag defaultOrientation,
-    bool containerFlipped,
-    int demosaicMode
+    bool containerFlipped
 ) {
     if (frameWidth <= 0 || frameHeight <= 0) {
         LogToFile(std::string("[Renderer_VK::prepareAndUploadFrameData] Invalid dimensions ") + std::to_string(frameWidth) + "x" + std::to_string(frameHeight) + ". Skipping upload.");
@@ -414,7 +413,6 @@ void Renderer_VK::prepareAndUploadFrameData(
         defaultOrientation);
     ubo.orientationDegrees = orientationDegreesFromTag(tag);
     m_currentOrientationDegrees = ubo.orientationDegrees;
-    ubo.demosaicMode = demosaicMode;
 
     updateUniformBuffer(uboBindingIndex, ubo);
 }

--- a/src/Utils/ColorPipelineCPU.cpp
+++ b/src/Utils/ColorPipelineCPU.cpp
@@ -10,6 +10,10 @@ static inline float srgb_eotf(float v) {
     return (v <= 0.0031308f) ? v * 12.92f : 1.055f * std::pow(v, 1.0f/2.4f) - 0.055f;
 }
 
+static inline float lerp(float a, float b, float t) {
+    return a * (1.0f - t) + b * t;
+}
+
 static inline uint16_t readU16(const uint16_t* src, int x, int y, int w, int h) {
     x = std::clamp(x,0,w-1);
     y = std::clamp(y,0,h-1);
@@ -279,13 +283,95 @@ void convertRawToRGB24(const uint16_t* raw, const CPUColorParams& p,
         }
     };
 
+    auto vh_calc=[&](int x,int y){
+        float sx=0.0f, sy=0.0f;
+        for(int i=-1;i<=1;++i){
+            sx += lin(x+i,y-3) - 3.0f*lin(x+i,y-2) - lin(x+i,y-1) + 6.0f*lin(x+i,y) - lin(x+i,y+1) - 3.0f*lin(x+i,y+2) + lin(x+i,y+3);
+            sy += lin(x-3,y+i) - 3.0f*lin(x-2,y+i) - lin(x-1,y+i) + 6.0f*lin(x,y+i) - lin(x+1,y+i) - 3.0f*lin(x+2,y+i) + lin(x+3,y+i);
+        }
+        float sx2=sx*sx, sy2=sy*sy;
+        return (sx2)/(1e-5f + sx2 + sy2);
+    };
+
+    auto pq_calc=[&](int x,int y){
+        float a=1e-5f,bv=1e-5f;
+        for(int i=-1;i<=1;++i){
+            a += lin(x-3+i,y-3+i) - lin(x+1+i,y-1+i) - lin(x+1+i,y+1+i) + lin(x+3+i,y+3+i)
+                -3.0f*(lin(x-2+i,y-2+i)+lin(x+2+i,y+2+i)) + 6.0f*lin(x+i,y+i);
+            bv += lin(x+3+i,y-3-i) - lin(x+1+i,y-1-i) - lin(x-1+i,y+1-i) + lin(x-3+i,y+3-i)
+                -3.0f*(lin(x+2+i,y-2-i)+lin(x-2+i,y+2-i)) + 6.0f*lin(x+i,y-i);
+        }
+        a*=a; bv*=bv; return a/(a+bv);
+    };
+
+    auto lp_calc=[&](int x,int y){
+        float lp=0.0f; int off=((x & 1)==1)?-1:1; const float w[3]={0.5f,1.0f,0.5f};
+        for(int j=-1;j<=1;++j) for(int i=-1;i<=1;++i) lp+=w[j+1]*w[i+1]*lin(x+i+off,y+j);
+        return std::max(1e-6f, lp);
+    };
+
+    auto demosaicRCD=[&](int x,int y,float& r,float& g,float& b){
+        bool is_green=((x+y)&1)==1; bool is_red=!is_green && ((y&1)==0); const float eps=1e-5f;
+        if(is_green){
+            g=lin(x,y);
+            float vh_val=vh_calc(x,y);
+            float vh_neighbor=0.25f*(vh_calc(x-1,y-1)+vh_calc(x+1,y-1)+vh_calc(x-1,y+1)+vh_calc(x+1,y+1));
+            float vh_discr=std::abs(0.5f - vh_val) < std::abs(0.5f - vh_neighbor) ? vh_val : vh_neighbor;
+            float N_grad=eps+std::abs(lin(x,y-1)-lin(x,y+1))+std::abs(lin(x,y)-lin(x,y-2));
+            float S_grad=eps+std::abs(lin(x,y-1)-lin(x,y+1))+std::abs(lin(x,y)-lin(x,y+2));
+            float W_grad=eps+std::abs(lin(x-1,y)-lin(x+1,y))+std::abs(lin(x,y)-lin(x-2,y));
+            float E_grad=eps+std::abs(lin(x-1,y)-lin(x+1,y))+std::abs(lin(x,y)-lin(x+2,y));
+            float lp=lp_calc(x,y);
+            float r_N=lin(x,y-1)*2.0f*lp/(eps+lp+lp_calc(x,y-2));
+            float r_S=lin(x,y+1)*2.0f*lp/(eps+lp+lp_calc(x,y+2));
+            float r_W=lin(x-1,y)*2.0f*lp/(eps+lp+lp_calc(x-2,y));
+            float r_E=lin(x+1,y)*2.0f*lp/(eps+lp+lp_calc(x+2,y));
+            float r_v=(S_grad*r_N+N_grad*r_S)/(N_grad+S_grad);
+            float r_h=(E_grad*r_W+W_grad*r_E)/(E_grad+W_grad);
+            r=lerp(r_v,r_h,vh_discr);
+            float b_N=lin(x,y-1)*2.0f*lp/(eps+lp+lp_calc(x,y-2));
+            float b_S=lin(x,y+1)*2.0f*lp/(eps+lp+lp_calc(x,y+2));
+            float b_W=lin(x-1,y)*2.0f*lp/(eps+lp+lp_calc(x-2,y));
+            float b_E=lin(x+1,y)*2.0f*lp/(eps+lp+lp_calc(x+2,y));
+            float b_v=(S_grad*b_N+N_grad*b_S)/(N_grad+S_grad);
+            float b_h=(E_grad*b_W+W_grad*b_E)/(E_grad+W_grad);
+            b=lerp(b_v,b_h,vh_discr);
+        }else{
+            float c=lin(x,y);
+            float vh_val=vh_calc(x,y);
+            float vh_neighbor=0.25f*(vh_calc(x-1,y-1)+vh_calc(x+1,y-1)+vh_calc(x-1,y+1)+vh_calc(x+1,y+1));
+            float vh_discr=std::abs(0.5f - vh_val) < std::abs(0.5f - vh_neighbor) ? vh_val : vh_neighbor;
+            float N=lin(x,y-1), S=lin(x,y+1), W=lin(x-1,y), E=lin(x+1,y);
+            float N_grad=eps+std::abs(N-lin(x,y+1))+std::abs(lin(x,y-1)-lin(x,y-3));
+            float S_grad=eps+std::abs(S-lin(x,y-1))+std::abs(lin(x,y+1)-lin(x,y+3));
+            float W_grad=eps+std::abs(W-lin(x+1,y))+std::abs(lin(x-1,y)-lin(x-3,y));
+            float E_grad=eps+std::abs(E-lin(x-1,y))+std::abs(lin(x+1,y)-lin(x+3,y));
+            float lp=lp_calc(x,y);
+            float g_N=N*2.0f*lp/(eps+lp+lp_calc(x,y-2));
+            float g_S=S*2.0f*lp/(eps+lp+lp_calc(x,y+2));
+            float g_W=W*2.0f*lp/(eps+lp+lp_calc(x-2,y));
+            float g_E=E*2.0f*lp/(eps+lp+lp_calc(x+2,y));
+            float g_v=(S_grad*g_N+N_grad*g_S)/(N_grad+S_grad);
+            float g_h=(E_grad*g_W+W_grad*g_E)/(E_grad+W_grad);
+            g=lerp(g_v,g_h,vh_discr);
+            float pq_val=pq_calc(x,y);
+            float pq_neighbor=0.25f*(pq_calc(x-1,y-1)+pq_calc(x+1,y-1)+pq_calc(x-1,y+1)+pq_calc(x+1,y+1));
+            float pq_discr=std::abs(0.5f-pq_val)<std::abs(0.5f-pq_neighbor)?pq_val:pq_neighbor;
+            float NW=lin(x-1,y-1)-(lin(x-1,y)+lin(x,y-1))*0.5f+g;
+            float NE=lin(x+1,y-1)-(lin(x+1,y)+lin(x,y-1))*0.5f+g;
+            float SW=lin(x-1,y+1)-(lin(x-1,y)+lin(x,y+1))*0.5f+g;
+            float SE=lin(x+1,y+1)-(lin(x+1,y)+lin(x,y+1))*0.5f+g;
+            float p=(NW+SE)*0.5f; float q=(NE+SW)*0.5f; float other=lerp(p,q,pq_discr);
+            if(is_red){ r=c; b=other; } else { b=c; r=other; }
+        }
+    };
+
     const float* ccm = p.ccm.data();
 
     auto processRow = [&](int y){
         for(int x=0;x<p.width;++x){
             float r=0.0f,g=0.0f,b=0.0f;
-            if(p.demosaicMode==1) demosaicVG(x,y,r,g,b);
-            else bilinearRGB(x,y,r,g,b);
+            demosaicRCD(x,y,r,g,b);
             float r_wb = std::clamp(r * p.gainR, 0.0f, 1.0f);
             float g_wb = std::clamp(g * p.gainG, 0.0f, 1.0f);
             float b_wb = std::clamp(b * p.gainB, 0.0f, 1.0f);


### PR DESCRIPTION
## Summary
- make RCD the only demosaicing option
- remove `demosaicMode` parameters and fields
- implement RCD directly in preview and conversion shaders
- update CPU pipeline to always run RCD
- document the change
- add a helper `lerp` function for CPU RCD code

## Testing
- `glslangValidator -V shaders/rcd_conv.comp -o /tmp/out.spv`
- `glslangValidator -V shaders/rcd_fill.comp -o /tmp/out2.spv`
- `glslangValidator -V shaders/raw_to_yuv422.comp -o /tmp/out3.spv`
- `glslangValidator -V shaders/image_process.frag -o /tmp/out4.spv`
- `cmake -S . -B build` *(fails: Package 'glfw3' not found)*
- `cmake --build build -j 4` *(fails: No rule to make target 'Makefile')*

------
https://chatgpt.com/codex/tasks/task_e_688654d6b8548327bcdce19e46afcd9b