### PR TITLE
Switch to RCD demosaicing

### DIFF
--- a/shaders/image_process.frag
+++ b/shaders/image_process.frag
@@ -38,20 +38,36 @@ float lin(uint v_u16) {
     return clamp(t * params.exposure, 0.0, 1.0);
 }
 
-float interpG(int x, int y) {
-    return 0.25 * (lin(readU16_val(x + 1, y)) + lin(readU16_val(x - 1, y)) +
-                   lin(readU16_val(x, y + 1)) + lin(readU16_val(x, y - 1)));
+float vhEdge(int x, int y) {
+    float v = 0.0, h = 0.0;
+    for (int i = -1; i <= 1; i++) {
+        v += lin(readU16_val(x + i, y - 3)) - 3.0 * lin(readU16_val(x + i, y - 2)) - lin(readU16_val(x + i, y - 1)) +
+             6.0 * lin(readU16_val(x + i, y)) - lin(readU16_val(x + i, y + 1)) - 3.0 * lin(readU16_val(x + i, y + 2)) + lin(readU16_val(x + i, y + 3));
+        h += lin(readU16_val(x - 3, y + i)) - 3.0 * lin(readU16_val(x - 2, y + i)) - lin(readU16_val(x - 1, y + i)) +
+             6.0 * lin(readU16_val(x, y + i)) - lin(readU16_val(x + 1, y + i)) - 3.0 * lin(readU16_val(x + 2, y + i)) + lin(readU16_val(x + 3, y + i));
+    }
+    v *= v; h *= h;
+    return v / (1e-5 + v + h);
 }
-float interpH(int x, int y) { 
-    return 0.5 * (lin(readU16_val(x + 1, y)) + lin(readU16_val(x - 1, y)));
+
+float interpGreen(int x, int y) {
+    float vhVal = vhEdge(x, y);
+    float vhNbr = 0.25 * (vhEdge(x - 1, y - 1) + vhEdge(x + 1, y - 1) + vhEdge(x - 1, y + 1) + vhEdge(x + 1, y + 1));
+    float vhDiscr = abs(0.5 - vhVal) < abs(0.5 - vhNbr) ? vhNbr : vhVal;
+    float eps = 1e-5;
+    float nGrad = eps + abs(lin(readU16_val(x, y - 1)) - lin(readU16_val(x, y + 1))) + abs(lin(readU16_val(x, y)) - lin(readU16_val(x, y - 2)));
+    float sGrad = eps + abs(lin(readU16_val(x, y + 1)) - lin(readU16_val(x, y - 1))) + abs(lin(readU16_val(x, y)) - lin(readU16_val(x, y + 2)));
+    float eGrad = eps + abs(lin(readU16_val(x - 1, y)) - lin(readU16_val(x + 1, y))) + abs(lin(readU16_val(x, y)) - lin(readU16_val(x - 2, y)));
+    float wGrad = eps + abs(lin(readU16_val(x + 1, y)) - lin(readU16_val(x - 1, y))) + abs(lin(readU16_val(x, y)) - lin(readU16_val(x + 2, y)));
+    float gV = (sGrad * lin(readU16_val(x, y - 1)) + nGrad * lin(readU16_val(x, y + 1))) / (nGrad + sGrad);
+    float gH = (eGrad * lin(readU16_val(x - 1, y)) + wGrad * lin(readU16_val(x + 1, y))) / (eGrad + wGrad);
+    return mix(gV, gH, vhDiscr);
 }
-float interpV(int x, int y) { 
-    return 0.5 * (lin(readU16_val(x, y + 1)) + lin(readU16_val(x, y - 1)));
-}
-float interpD(int x, int y) { 
-    return 0.25 * (lin(readU16_val(x + 1, y + 1)) + lin(readU16_val(x - 1, y + 1)) +
-                   lin(readU16_val(x + 1, y - 1)) + lin(readU16_val(x - 1, y - 1)));
-}
+
+float interpHoriz(int x, int y) { return 0.5 * (lin(readU16_val(x + 1, y)) + lin(readU16_val(x - 1, y))); }
+float interpVert(int x, int y)  { return 0.5 * (lin(readU16_val(x, y + 1)) + lin(readU16_val(x, y - 1))); }
+float interpDiag(int x, int y)  { return 0.25 * (lin(readU16_val(x + 1, y + 1)) + lin(readU16_val(x - 1, y + 1)) +
+                                                  lin(readU16_val(x + 1, y - 1)) + lin(readU16_val(x - 1, y - 1))); }
 
 void main() {
     ivec2 p = ivec2(inTexCoord * vec2(params.W, params.H));
@@ -71,90 +87,90 @@ void main() {
     // ... (your existing demosaicing logic remains the same) ...
     if (params.cfaType == 0) { // BGGR
         if (ye) { 
-            if (xe) { 
+            if (xe) {
                 b_demosaiced = lin(readU16_val(x, y));
-                g_demosaiced = interpG(x, y);
-                r_demosaiced = interpD(x, y);
-            } else { 
+                g_demosaiced = interpGreen(x, y);
+                r_demosaiced = interpDiag(x, y);
+            } else {
                 g_demosaiced = lin(readU16_val(x, y));
-                r_demosaiced = interpV(x, y); 
-                b_demosaiced = interpH(x, y); 
+                r_demosaiced = interpVert(x, y);
+                b_demosaiced = interpHoriz(x, y);
             }
-        } else { 
-            if (xe) { 
+        } else {
+            if (xe) {
                 g_demosaiced = lin(readU16_val(x, y));
-                r_demosaiced = interpH(x, y); 
-                b_demosaiced = interpV(x, y); 
-            } else { 
+                r_demosaiced = interpHoriz(x, y);
+                b_demosaiced = interpVert(x, y);
+            } else {
                 r_demosaiced = lin(readU16_val(x, y));
-                g_demosaiced = interpG(x, y);
-                b_demosaiced = interpD(x, y);
+                g_demosaiced = interpGreen(x, y);
+                b_demosaiced = interpDiag(x, y);
             }
         }
     } else if (params.cfaType == 1) { // RGGB
         if (ye) {
-            if (xe) { 
+            if (xe) {
                 r_demosaiced = lin(readU16_val(x, y));
-                g_demosaiced = interpG(x, y);
-                b_demosaiced = interpD(x, y);
-            } else { 
+                g_demosaiced = interpGreen(x, y);
+                b_demosaiced = interpDiag(x, y);
+            } else {
                 g_demosaiced = lin(readU16_val(x, y));
-                r_demosaiced = interpH(x, y);
-                b_demosaiced = interpV(x, y);
+                r_demosaiced = interpHoriz(x, y);
+                b_demosaiced = interpVert(x, y);
             }
         } else {
-            if (xe) { 
+            if (xe) {
                 g_demosaiced = lin(readU16_val(x, y));
-                r_demosaiced = interpV(x, y);
-                b_demosaiced = interpH(x, y);
-            } else { 
+                r_demosaiced = interpVert(x, y);
+                b_demosaiced = interpHoriz(x, y);
+            } else {
                 b_demosaiced = lin(readU16_val(x, y));
-                g_demosaiced = interpG(x, y);
-                r_demosaiced = interpD(x, y);
+                g_demosaiced = interpGreen(x, y);
+                r_demosaiced = interpDiag(x, y);
             }
         }
     } else if (params.cfaType == 2) { // GBRG
          if (ye) {
-            if (xe) { 
+            if (xe) {
                 g_demosaiced = lin(readU16_val(x,y));
-                r_demosaiced = interpV(x,y);
-                b_demosaiced = interpH(x,y);
-            } else { 
+                r_demosaiced = interpVert(x,y);
+                b_demosaiced = interpHoriz(x,y);
+            } else {
                 b_demosaiced = lin(readU16_val(x,y));
-                g_demosaiced = interpG(x,y);
-                r_demosaiced = interpD(x,y);
+                g_demosaiced = interpGreen(x,y);
+                r_demosaiced = interpDiag(x,y);
             }
         } else {
-            if (xe) { 
+            if (xe) {
                 r_demosaiced = lin(readU16_val(x,y));
-                g_demosaiced = interpG(x,y);
-                b_demosaiced = interpD(x,y);
-            } else { 
+                g_demosaiced = interpGreen(x,y);
+                b_demosaiced = interpDiag(x,y);
+            } else {
                 g_demosaiced = lin(readU16_val(x,y));
-                r_demosaiced = interpH(x,y);
-                b_demosaiced = interpV(x,y);
+                r_demosaiced = interpHoriz(x,y);
+                b_demosaiced = interpVert(x,y);
             }
         }
     } else { // GRBG (cfaType == 3 or default)
         if (ye) {
-            if (xe) { 
+            if (xe) {
                 g_demosaiced = lin(readU16_val(x,y));
-                r_demosaiced = interpH(x,y);
-                b_demosaiced = interpV(x,y);
-            } else { 
+                r_demosaiced = interpHoriz(x,y);
+                b_demosaiced = interpVert(x,y);
+            } else {
                 r_demosaiced = lin(readU16_val(x,y));
-                g_demosaiced = interpG(x,y);
-                b_demosaiced = interpD(x,y);
+                g_demosaiced = interpGreen(x,y);
+                b_demosaiced = interpDiag(x,y);
             }
         } else {
-            if (xe) { 
+            if (xe) {
                 b_demosaiced = lin(readU16_val(x,y));
-                g_demosaiced = interpG(x,y);
-                r_demosaiced = interpD(x,y);
-            } else { 
+                g_demosaiced = interpGreen(x,y);
+                r_demosaiced = interpDiag(x,y);
+            } else {
                 g_demosaiced = lin(readU16_val(x,y));
-                r_demosaiced = interpV(x,y);
-                b_demosaiced = interpH(x,y);
+                r_demosaiced = interpVert(x,y);
+                b_demosaiced = interpHoriz(x,y);
             }
         }
     }

--- a/shaders/raw_to_yuv422.comp
+++ b/shaders/raw_to_yuv422.comp
@@ -29,6 +29,35 @@ float normRaw(uint r){
 
 #define RAW(xx,yy) normRaw(readRaw(xx,yy))
 
+// helper functions for RCD demosaicing
+float vhEdge(int ix, int iy){
+    float v = 0.0, h = 0.0;
+    for(int i=-1;i<=1;i++){
+        v += RAW(ix+i,iy-3) - 3.0*RAW(ix+i,iy-2) - RAW(ix+i,iy-1) + 6.0*RAW(ix+i,iy) - RAW(ix+i,iy+1) - 3.0*RAW(ix+i,iy+2) + RAW(ix+i,iy+3);
+        h += RAW(ix-3,iy+i) - 3.0*RAW(ix-2,iy+i) - RAW(ix-1,iy+i) + 6.0*RAW(ix,iy+i) - RAW(ix+1,iy+i) - 3.0*RAW(ix+2,iy+i) + RAW(ix+3,iy+i);
+    }
+    v*=v; h*=h;
+    return v / (1e-5 + v + h);
+}
+
+float interpGreen(int ix,int iy){
+    float vhVal = vhEdge(ix,iy);
+    float vhNbr = 0.25*(vhEdge(ix-1,iy-1)+vhEdge(ix+1,iy-1)+vhEdge(ix-1,iy+1)+vhEdge(ix+1,iy+1));
+    float vhDiscr = abs(0.5 - vhVal) < abs(0.5 - vhNbr) ? vhNbr : vhVal;
+    float eps=1e-5;
+    float nGrad = eps + abs(RAW(ix,iy-1)-RAW(ix,iy+1)) + abs(RAW(ix,iy)-RAW(ix,iy-2));
+    float sGrad = eps + abs(RAW(ix,iy+1)-RAW(ix,iy-1)) + abs(RAW(ix,iy)-RAW(ix,iy+2));
+    float eGrad = eps + abs(RAW(ix-1,iy)-RAW(ix+1,iy)) + abs(RAW(ix,iy)-RAW(ix-2,iy));
+    float wGrad = eps + abs(RAW(ix+1,iy)-RAW(ix-1,iy)) + abs(RAW(ix,iy)-RAW(ix+2,iy));
+    float gV = (sGrad*RAW(ix,iy-1) + nGrad*RAW(ix,iy+1))/(nGrad+sGrad);
+    float gH = (eGrad*RAW(ix-1,iy) + wGrad*RAW(ix+1,iy))/(eGrad+wGrad);
+    return mix(gV,gH,vhDiscr);
+}
+
+float interpHoriz(int ix,int iy){ return 0.5*(RAW(ix+1,iy)+RAW(ix-1,iy)); }
+float interpVert (int ix,int iy){ return 0.5*(RAW(ix,iy+1)+RAW(ix,iy-1)); }
+float interpDiag (int ix,int iy){ return 0.25*(RAW(ix+1,iy+1)+RAW(ix-1,iy+1)+RAW(ix+1,iy-1)+RAW(ix-1,iy-1)); }
+
 // -----------------------------------------------------------
 vec3 bayerToRGB(uint x, uint y)
 {
@@ -41,41 +70,41 @@ vec3 bayerToRGB(uint x, uint y)
     // BGGR --------------------------------------------------
     case 0u:
         if(ye){
-            if(xe){ b=RAW(x,y); g=(RAW(x-1,y)+RAW(x+1,y)+RAW(x,y-1)+RAW(x,y+1))*0.25; r=(RAW(x-1,y-1)+RAW(x+1,y-1)+RAW(x-1,y+1)+RAW(x+1,y+1))*0.25; }
-            else   { g=RAW(x,y); b=(RAW(x-1,y)+RAW(x+1,y))*0.5; r=(RAW(x,y-1)+RAW(x,y+1))*0.5; }
+            if(xe){ b=RAW(x,y); g=interpGreen(int(x),int(y)); r=interpDiag(int(x),int(y)); }
+            else   { g=RAW(x,y); r=interpVert(int(x),int(y)); b=interpHoriz(int(x),int(y)); }
         }else{
-            if(xe){ g=RAW(x,y); b=(RAW(x,y-1)+RAW(x,y+1))*0.5; r=(RAW(x-1,y)+RAW(x+1,y))*0.5; }
-            else   { r=RAW(x,y); g=(RAW(x-1,y)+RAW(x+1,y)+RAW(x,y-1)+RAW(x,y+1))*0.25; b=(RAW(x-1,y-1)+RAW(x+1,y-1)+RAW(x-1,y+1)+RAW(x+1,y+1))*0.25; }
+            if(xe){ g=RAW(x,y); r=interpHoriz(int(x),int(y)); b=interpVert(int(x),int(y)); }
+            else   { r=RAW(x,y); g=interpGreen(int(x),int(y)); b=interpDiag(int(x),int(y)); }
         }
         break;
     // RGGB --------------------------------------------------
     case 1u:
         if(ye){
-            if(xe){ r=RAW(x,y); g=(RAW(x-1,y)+RAW(x+1,y)+RAW(x,y-1)+RAW(x,y+1))*0.25; b=(RAW(x-1,y-1)+RAW(x+1,y-1)+RAW(x-1,y+1)+RAW(x+1,y+1))*0.25; }
-            else   { g=RAW(x,y); r=(RAW(x-1,y)+RAW(x+1,y))*0.5; b=(RAW(x,y-1)+RAW(x,y+1))*0.5; }
+            if(xe){ r=RAW(x,y); g=interpGreen(int(x),int(y)); b=interpDiag(int(x),int(y)); }
+            else   { g=RAW(x,y); r=interpHoriz(int(x),int(y)); b=interpVert(int(x),int(y)); }
         }else{
-            if(xe){ g=RAW(x,y); r=(RAW(x,y-1)+RAW(x,y+1))*0.5; b=(RAW(x-1,y)+RAW(x+1,y))*0.5; }
-            else   { b=RAW(x,y); g=(RAW(x-1,y)+RAW(x+1,y)+RAW(x,y-1)+RAW(x,y+1))*0.25; r=(RAW(x-1,y-1)+RAW(x+1,y-1)+RAW(x-1,y+1)+RAW(x+1,y+1))*0.25; }
+            if(xe){ g=RAW(x,y); r=interpVert(int(x),int(y)); b=interpHoriz(int(x),int(y)); }
+            else   { b=RAW(x,y); g=interpGreen(int(x),int(y)); r=interpDiag(int(x),int(y)); }
         }
         break;
     // GBRG --------------------------------------------------
     case 2u:
         if(ye){
-            if(xe){ g=RAW(x,y); b=(RAW(x-1,y)+RAW(x+1,y))*0.5; r=(RAW(x,y-1)+RAW(x,y+1))*0.5; }
-            else   { b=RAW(x,y); g=(RAW(x-1,y)+RAW(x+1,y)+RAW(x,y-1)+RAW(x,y+1))*0.25; r=(RAW(x-1,y-1)+RAW(x+1,y-1)+RAW(x-1,y+1)+RAW(x+1,y+1))*0.25; }
+            if(xe){ g=RAW(x,y); r=interpVert(int(x),int(y)); b=interpHoriz(int(x),int(y)); }
+            else   { b=RAW(x,y); g=interpGreen(int(x),int(y)); r=interpDiag(int(x),int(y)); }
         }else{
-            if(xe){ r=RAW(x,y); g=(RAW(x-1,y)+RAW(x+1,y)+RAW(x,y-1)+RAW(x,y+1))*0.25; b=(RAW(x-1,y-1)+RAW(x+1,y-1)+RAW(x-1,y+1)+RAW(x+1,y+1))*0.25; }
-            else   { g=RAW(x,y); r=(RAW(x-1,y)+RAW(x+1,y))*0.5; b=(RAW(x,y-1)+RAW(x,y+1))*0.5; }
+            if(xe){ r=RAW(x,y); g=interpGreen(int(x),int(y)); b=interpDiag(int(x),int(y)); }
+            else   { g=RAW(x,y); r=interpHoriz(int(x),int(y)); b=interpVert(int(x),int(y)); }
         }
         break;
     // GRBG --------------------------------------------------
     case 3u:
         if(ye){
-            if(xe){ g=RAW(x,y); r=(RAW(x-1,y)+RAW(x+1,y))*0.5; b=(RAW(x,y-1)+RAW(x,y+1))*0.5; }
-            else   { r=RAW(x,y); g=(RAW(x-1,y)+RAW(x+1,y)+RAW(x,y-1)+RAW(x,y+1))*0.25; b=(RAW(x-1,y-1)+RAW(x+1,y-1)+RAW(x-1,y+1)+RAW(x+1,y+1))*0.25; }
+            if(xe){ g=RAW(x,y); r=interpHoriz(int(x),int(y)); b=interpVert(int(x),int(y)); }
+            else   { r=RAW(x,y); g=interpGreen(int(x),int(y)); b=interpDiag(int(x),int(y)); }
         }else{
-            if(xe){ b=RAW(x,y); g=(RAW(x-1,y)+RAW(x+1,y)+RAW(x,y-1)+RAW(x,y+1))*0.25; r=(RAW(x-1,y-1)+RAW(x+1,y-1)+RAW(x-1,y+1)+RAW(x+1,y+1))*0.25; }
-            else   { g=RAW(x,y); b=(RAW(x-1,y)+RAW(x+1,y))*0.5; r=(RAW(x,y-1)+RAW(x,y+1))*0.5; }
+            if(xe){ b=RAW(x,y); g=interpGreen(int(x),int(y)); r=interpDiag(int(x),int(y)); }
+            else   { g=RAW(x,y); b=interpHoriz(int(x),int(y)); r=interpVert(int(x),int(y)); }
         }
         break;
     }

--- a/src/Utils/ColorPipelineCPU.cpp
+++ b/src/Utils/ColorPipelineCPU.cpp
@@ -31,10 +31,31 @@ void convertRawToRGB24(const uint16_t* raw, const CPUColorParams& p,
     auto lin = [&](int x, int y) -> float {
         return linFromRaw(readU16(raw,x,y,p.width,p.height), p.blackLevel, invRange);
     };
-    auto interpG = [&](int x, int y)->float{ return 0.25f*(lin(x+1,y)+lin(x-1,y)+lin(x,y+1)+lin(x,y-1));};
-    auto interpH = [&](int x, int y)->float{ return 0.5f*(lin(x+1,y)+lin(x-1,y));};
-    auto interpV = [&](int x, int y)->float{ return 0.5f*(lin(x,y+1)+lin(x,y-1));};
-    auto interpD = [&](int x, int y)->float{ return 0.25f*(lin(x+1,y+1)+lin(x-1,y+1)+lin(x+1,y-1)+lin(x-1,y-1));};
+    auto vhEdge = [&](int x, int y){
+        float v=0.0f,h=0.0f;
+        for(int i=-1;i<=1;++i){
+            v += lin(x+i,y-3) - 3.0f*lin(x+i,y-2) - lin(x+i,y-1) + 6.0f*lin(x+i,y) - lin(x+i,y+1) - 3.0f*lin(x+i,y+2) + lin(x+i,y+3);
+            h += lin(x-3,y+i) - 3.0f*lin(x-2,y+i) - lin(x-1,y+i) + 6.0f*lin(x,y+i) - lin(x+1,y+i) - 3.0f*lin(x+2,y+i) + lin(x+3,y+i);
+        }
+        v*=v; h*=h;
+        return v / (1e-5f + v + h);
+    };
+    auto interpGreen = [&](int x,int y){
+        float vhVal = vhEdge(x,y);
+        float vhNbr = 0.25f*(vhEdge(x-1,y-1)+vhEdge(x+1,y-1)+vhEdge(x-1,y+1)+vhEdge(x+1,y+1));
+        float vhDiscr = (std::abs(0.5f-vhVal) < std::abs(0.5f-vhNbr)) ? vhNbr : vhVal;
+        float eps=1e-5f;
+        float nGrad = eps + std::abs(lin(x,y-1)-lin(x,y+1)) + std::abs(lin(x,y)-lin(x,y-2));
+        float sGrad = eps + std::abs(lin(x,y+1)-lin(x,y-1)) + std::abs(lin(x,y)-lin(x,y+2));
+        float eGrad = eps + std::abs(lin(x-1,y)-lin(x+1,y)) + std::abs(lin(x,y)-lin(x-2,y));
+        float wGrad = eps + std::abs(lin(x+1,y)-lin(x-1,y)) + std::abs(lin(x,y)-lin(x+2,y));
+        float gV = (sGrad*lin(x,y-1) + nGrad*lin(x,y+1))/(nGrad+sGrad);
+        float gH = (eGrad*lin(x-1,y) + wGrad*lin(x+1,y))/(eGrad+wGrad);
+        return gV*(1.0f-vhDiscr) + gH*vhDiscr;
+    };
+    auto interpHoriz = [&](int x,int y){ return 0.5f*(lin(x+1,y)+lin(x-1,y)); };
+    auto interpVert  = [&](int x,int y){ return 0.5f*(lin(x,y+1)+lin(x,y-1)); };
+    auto interpDiag  = [&](int x,int y){ return 0.25f*(lin(x+1,y+1)+lin(x-1,y+1)+lin(x+1,y-1)+lin(x-1,y-1)); };
 
     const float* ccm = p.ccm.data();
 
@@ -46,38 +67,38 @@ void convertRawToRGB24(const uint16_t* raw, const CPUColorParams& p,
             switch(p.cfaType){
                 case 0: // BGGR
                     if(ye){
-                        if(xe){ b=lin(x,y); g=interpG(x,y); r=interpD(x,y); }
-                        else { g=lin(x,y); r=interpV(x,y); b=interpH(x,y); }
+                        if(xe){ b=lin(x,y); g=interpGreen(x,y); r=interpDiag(x,y); }
+                        else { g=lin(x,y); r=interpVert(x,y); b=interpHoriz(x,y); }
                     }else{
-                        if(xe){ g=lin(x,y); r=interpH(x,y); b=interpV(x,y); }
-                        else { r=lin(x,y); g=interpG(x,y); b=interpD(x,y); }
+                        if(xe){ g=lin(x,y); r=interpHoriz(x,y); b=interpVert(x,y); }
+                        else { r=lin(x,y); g=interpGreen(x,y); b=interpDiag(x,y); }
                     }
                     break;
                 case 1: // RGGB
                     if(ye){
-                        if(xe){ r=lin(x,y); g=interpG(x,y); b=interpD(x,y); }
-                        else { g=lin(x,y); r=interpH(x,y); b=interpV(x,y); }
+                        if(xe){ r=lin(x,y); g=interpGreen(x,y); b=interpDiag(x,y); }
+                        else { g=lin(x,y); r=interpHoriz(x,y); b=interpVert(x,y); }
                     }else{
-                        if(xe){ g=lin(x,y); r=interpV(x,y); b=interpH(x,y); }
-                        else { b=lin(x,y); g=interpG(x,y); r=interpD(x,y); }
+                        if(xe){ g=lin(x,y); r=interpVert(x,y); b=interpHoriz(x,y); }
+                        else { b=lin(x,y); g=interpGreen(x,y); r=interpDiag(x,y); }
                     }
                     break;
                 case 2: // GBRG
                     if(ye){
-                        if(xe){ g=lin(x,y); r=interpV(x,y); b=interpH(x,y); }
-                        else { b=lin(x,y); g=interpG(x,y); r=interpD(x,y); }
+                        if(xe){ g=lin(x,y); r=interpVert(x,y); b=interpHoriz(x,y); }
+                        else { b=lin(x,y); g=interpGreen(x,y); r=interpDiag(x,y); }
                     }else{
-                        if(xe){ r=lin(x,y); g=interpG(x,y); b=interpD(x,y); }
-                        else { g=lin(x,y); r=interpH(x,y); b=interpV(x,y); }
+                        if(xe){ r=lin(x,y); g=interpGreen(x,y); b=interpDiag(x,y); }
+                        else { g=lin(x,y); r=interpHoriz(x,y); b=interpVert(x,y); }
                     }
                     break;
                 default: // GRBG
                     if(ye){
-                        if(xe){ g=lin(x,y); r=interpH(x,y); b=interpV(x,y); }
-                        else { r=lin(x,y); g=interpG(x,y); b=interpD(x,y); }
+                        if(xe){ g=lin(x,y); r=interpHoriz(x,y); b=interpVert(x,y); }
+                        else { r=lin(x,y); g=interpGreen(x,y); b=interpDiag(x,y); }
                     }else{
-                        if(xe){ b=lin(x,y); g=interpG(x,y); r=interpD(x,y); }
-                        else { g=lin(x,y); r=interpV(x,y); b=interpH(x,y); }
+                        if(xe){ b=lin(x,y); g=interpGreen(x,y); r=interpDiag(x,y); }
+                        else { g=lin(x,y); r=interpVert(x,y); b=interpHoriz(x,y); }
                     }
                     break;
             }


### PR DESCRIPTION
## Summary
- implement edge‐aware RCD helpers in `ColorPipelineCPU.cpp`
- replace fragment shader bilinear demosaic with RCD implementation
- update compute shader used for YUV conversion with new RCD logic

## Testing
- `cmake -S . -B build`
- `cmake --build build -j$(nproc)` *(fails: libavutil/frame.h missing)*

------
https://chatgpt.com/codex/tasks/task_e_688676866810832782bb002e5efee1d0