### PR TITLE
Integrate RCD demosaicing

### DIFF
--- a/shaders/image_process.frag
+++ b/shaders/image_process.frag
@@ -38,19 +38,37 @@ float lin(uint v_u16) {
     return clamp(t * params.exposure, 0.0, 1.0);
 }
 
-float interpG(int x, int y) {
-    return 0.25 * (lin(readU16_val(x + 1, y)) + lin(readU16_val(x - 1, y)) +
-                   lin(readU16_val(x, y + 1)) + lin(readU16_val(x, y - 1)));
+float vh(int x, int y){
+    float xs=0.0, ys=0.0;
+    for(int i=-1;i<=1;i++){
+        xs += lin(readU16_val(x+i,y-3)) - 3.0*lin(readU16_val(x+i,y-2)) - lin(readU16_val(x+i,y-1)) + 6.0*lin(readU16_val(x+i,y)) - lin(readU16_val(x+i,y+1)) - 3.0*lin(readU16_val(x+i,y+2)) + lin(readU16_val(x+i,y+3));
+        ys += lin(readU16_val(x-3,y+i)) - 3.0*lin(readU16_val(x-2,y+i)) - lin(readU16_val(x-1,y+i)) + 6.0*lin(readU16_val(x,y+i)) - lin(readU16_val(x+1,y+i)) - 3.0*lin(readU16_val(x+2,y+i)) + lin(readU16_val(x+3,y+i));
+    }
+    xs*=xs; ys*=ys;
+    return xs / (1e-5 + xs + ys);
 }
-float interpH(int x, int y) { 
-    return 0.5 * (lin(readU16_val(x + 1, y)) + lin(readU16_val(x - 1, y)));
+
+float greenAtRB(int x, int y){
+    float v = vh(x,y);
+    float n = 0.25*(vh(x-1,y-1)+vh(x+1,y-1)+vh(x-1,y+1)+vh(x+1,y+1));
+    float w = abs(0.5 - v) < abs(0.5 - n) ? n : v;
+    float eps = 1e-5;
+    float Ng = eps + abs(lin(readU16_val(x, y-1)) - lin(readU16_val(x, y+1))) + abs(lin(readU16_val(x, y)) - lin(readU16_val(x, y-2)));
+    float Sg = eps + abs(lin(readU16_val(x, y-1)) - lin(readU16_val(x, y+1))) + abs(lin(readU16_val(x, y)) - lin(readU16_val(x, y+2)));
+    float Eg = eps + abs(lin(readU16_val(x-1, y)) - lin(readU16_val(x+1, y))) + abs(lin(readU16_val(x, y)) - lin(readU16_val(x+2, y)));
+    float Wg = eps + abs(lin(readU16_val(x-1, y)) - lin(readU16_val(x+1, y))) + abs(lin(readU16_val(x, y)) - lin(readU16_val(x-2, y)));
+    float gv = (Sg*(lin(readU16_val(x, y-1))+lin(readU16_val(x, y+1)))*0.5 + Ng*(lin(readU16_val(x, y-1))+lin(readU16_val(x, y+1)))*0.5)/(Ng+Sg);
+    float gh = (Eg*(lin(readU16_val(x-1, y))+lin(readU16_val(x+1, y)))*0.5 + Wg*(lin(readU16_val(x-1, y))+lin(readU16_val(x+1, y)))*0.5)/(Eg+Wg);
+    return mix(gv,gh,w);
 }
-float interpV(int x, int y) { 
-    return 0.5 * (lin(readU16_val(x, y + 1)) + lin(readU16_val(x, y - 1)));
-}
-float interpD(int x, int y) { 
-    return 0.25 * (lin(readU16_val(x + 1, y + 1)) + lin(readU16_val(x - 1, y + 1)) +
-                   lin(readU16_val(x + 1, y - 1)) + lin(readU16_val(x - 1, y - 1)));
+
+float greenAt(int x, int y){
+    bool ye = (y % 2) == 0;
+    bool xe = (x % 2) == 0;
+    if(params.cfaType==0) return ye? (xe? greenAtRB(x,y): lin(readU16_val(x,y))) : (xe? lin(readU16_val(x,y)): greenAtRB(x,y));
+    if(params.cfaType==1) return ye? (xe? lin(readU16_val(x,y)): greenAtRB(x,y)) : (xe? greenAtRB(x,y): lin(readU16_val(x,y)));
+    if(params.cfaType==2) return ye? (xe? lin(readU16_val(x,y)): greenAtRB(x,y)) : (xe? greenAtRB(x,y): lin(readU16_val(x,y)));
+    return ye? (xe? greenAtRB(x,y): lin(readU16_val(x,y))) : (xe? lin(readU16_val(x,y)): greenAtRB(x,y));
 }
 
 void main() {
@@ -68,96 +86,108 @@ void main() {
 
     float r_demosaiced = 0.0, g_demosaiced = 0.0, b_demosaiced = 0.0;
 
-    // ... (your existing demosaicing logic remains the same) ...
-    if (params.cfaType == 0) { // BGGR
-        if (ye) { 
-            if (xe) { 
-                b_demosaiced = lin(readU16_val(x, y));
-                g_demosaiced = interpG(x, y);
-                r_demosaiced = interpD(x, y);
-            } else { 
-                g_demosaiced = lin(readU16_val(x, y));
-                r_demosaiced = interpV(x, y); 
-                b_demosaiced = interpH(x, y); 
+    float rcd_r = 0.0, rcd_g = 0.0, rcd_b = 0.0;
+    if(params.cfaType == 0){ // BGGR
+        if(ye){
+            if(xe){
+                rcd_g = greenAtRB(x,y); rcd_b = lin(readU16_val(x,y));
+                float dr = (lin(readU16_val(x-1,y-1))-greenAt(x-1,y-1)+lin(readU16_val(x+1,y-1))-greenAt(x+1,y-1)+lin(readU16_val(x-1,y+1))-greenAt(x-1,y+1)+lin(readU16_val(x+1,y+1))-greenAt(x+1,y+1))*0.25;
+                rcd_r = rcd_g + dr;
+            }else{
+                rcd_g = lin(readU16_val(x,y));
+                float dr=(lin(readU16_val(x,y-1))-greenAt(x,y-1)+lin(readU16_val(x,y+1))-greenAt(x,y+1))*0.5;
+                float db=(lin(readU16_val(x-1,y))-greenAt(x-1,y)+lin(readU16_val(x+1,y))-greenAt(x+1,y))*0.5;
+                rcd_r = rcd_g + dr; rcd_b = rcd_g + db;
             }
-        } else { 
-            if (xe) { 
-                g_demosaiced = lin(readU16_val(x, y));
-                r_demosaiced = interpH(x, y); 
-                b_demosaiced = interpV(x, y); 
-            } else { 
-                r_demosaiced = lin(readU16_val(x, y));
-                g_demosaiced = interpG(x, y);
-                b_demosaiced = interpD(x, y);
-            }
-        }
-    } else if (params.cfaType == 1) { // RGGB
-        if (ye) {
-            if (xe) { 
-                r_demosaiced = lin(readU16_val(x, y));
-                g_demosaiced = interpG(x, y);
-                b_demosaiced = interpD(x, y);
-            } else { 
-                g_demosaiced = lin(readU16_val(x, y));
-                r_demosaiced = interpH(x, y);
-                b_demosaiced = interpV(x, y);
-            }
-        } else {
-            if (xe) { 
-                g_demosaiced = lin(readU16_val(x, y));
-                r_demosaiced = interpV(x, y);
-                b_demosaiced = interpH(x, y);
-            } else { 
-                b_demosaiced = lin(readU16_val(x, y));
-                g_demosaiced = interpG(x, y);
-                r_demosaiced = interpD(x, y);
+        }else{
+            if(xe){
+                rcd_g = lin(readU16_val(x,y));
+                float dr=(lin(readU16_val(x-1,y))-greenAt(x-1,y)+lin(readU16_val(x+1,y))-greenAt(x+1,y))*0.5;
+                float db=(lin(readU16_val(x,y-1))-greenAt(x,y-1)+lin(readU16_val(x,y+1))-greenAt(x,y+1))*0.5;
+                rcd_r = rcd_g + dr; rcd_b = rcd_g + db;
+            }else{
+                rcd_g = greenAtRB(x,y); rcd_r = lin(readU16_val(x,y));
+                float db=(lin(readU16_val(x-1,y-1))-greenAt(x-1,y-1)+lin(readU16_val(x+1,y-1))-greenAt(x+1,y-1)+lin(readU16_val(x-1,y+1))-greenAt(x-1,y+1)+lin(readU16_val(x+1,y+1))-greenAt(x+1,y+1))*0.25;
+                rcd_b = rcd_g + db;
             }
         }
-    } else if (params.cfaType == 2) { // GBRG
-         if (ye) {
-            if (xe) { 
-                g_demosaiced = lin(readU16_val(x,y));
-                r_demosaiced = interpV(x,y);
-                b_demosaiced = interpH(x,y);
-            } else { 
-                b_demosaiced = lin(readU16_val(x,y));
-                g_demosaiced = interpG(x,y);
-                r_demosaiced = interpD(x,y);
+    }else if(params.cfaType == 1){ // RGGB
+        if(ye){
+            if(xe){
+                rcd_g = greenAtRB(x,y); rcd_r = lin(readU16_val(x,y));
+                float db=(lin(readU16_val(x-1,y-1))-greenAt(x-1,y-1)+lin(readU16_val(x+1,y-1))-greenAt(x+1,y-1)+lin(readU16_val(x-1,y+1))-greenAt(x-1,y+1)+lin(readU16_val(x+1,y+1))-greenAt(x+1,y+1))*0.25;
+                rcd_b = rcd_g + db;
+            }else{
+                rcd_g = lin(readU16_val(x,y));
+                float dr=(lin(readU16_val(x-1,y))-greenAt(x-1,y)+lin(readU16_val(x+1,y))-greenAt(x+1,y))*0.5;
+                float db=(lin(readU16_val(x,y-1))-greenAt(x,y-1)+lin(readU16_val(x,y+1))-greenAt(x,y+1))*0.5;
+                rcd_r = rcd_g + dr; rcd_b = rcd_g + db;
             }
-        } else {
-            if (xe) { 
-                r_demosaiced = lin(readU16_val(x,y));
-                g_demosaiced = interpG(x,y);
-                b_demosaiced = interpD(x,y);
-            } else { 
-                g_demosaiced = lin(readU16_val(x,y));
-                r_demosaiced = interpH(x,y);
-                b_demosaiced = interpV(x,y);
+        }else{
+            if(xe){
+                rcd_g = lin(readU16_val(x,y));
+                float dr=(lin(readU16_val(x,y-1))-greenAt(x,y-1)+lin(readU16_val(x,y+1))-greenAt(x,y+1))*0.5;
+                float db=(lin(readU16_val(x-1,y))-greenAt(x-1,y)+lin(readU16_val(x+1,y))-greenAt(x+1,y))*0.5;
+                rcd_r = rcd_g + dr; rcd_b = rcd_g + db;
+            }else{
+                rcd_g = greenAtRB(x,y); rcd_b = lin(readU16_val(x,y));
+                float dr=(lin(readU16_val(x-1,y-1))-greenAt(x-1,y-1)+lin(readU16_val(x+1,y-1))-greenAt(x+1,y-1)+lin(readU16_val(x-1,y+1))-greenAt(x-1,y+1)+lin(readU16_val(x+1,y+1))-greenAt(x+1,y+1))*0.25;
+                rcd_r = rcd_g + dr;
             }
         }
-    } else { // GRBG (cfaType == 3 or default)
-        if (ye) {
-            if (xe) { 
-                g_demosaiced = lin(readU16_val(x,y));
-                r_demosaiced = interpH(x,y);
-                b_demosaiced = interpV(x,y);
-            } else { 
-                r_demosaiced = lin(readU16_val(x,y));
-                g_demosaiced = interpG(x,y);
-                b_demosaiced = interpD(x,y);
+    }else if(params.cfaType == 2){ // GBRG
+        if(ye){
+            if(xe){
+                rcd_g = lin(readU16_val(x,y));
+                float db=(lin(readU16_val(x-1,y))-greenAt(x-1,y)+lin(readU16_val(x+1,y))-greenAt(x+1,y))*0.5;
+                float dr=(lin(readU16_val(x,y-1))-greenAt(x,y-1)+lin(readU16_val(x,y+1))-greenAt(x,y+1))*0.5;
+                rcd_b = rcd_g + db; rcd_r = rcd_g + dr;
+            }else{
+                rcd_g = greenAtRB(x,y); rcd_b = lin(readU16_val(x,y));
+                float dr=(lin(readU16_val(x-1,y-1))-greenAt(x-1,y-1)+lin(readU16_val(x+1,y-1))-greenAt(x+1,y-1)+lin(readU16_val(x-1,y+1))-greenAt(x-1,y+1)+lin(readU16_val(x+1,y+1))-greenAt(x+1,y+1))*0.25;
+                rcd_r = rcd_g + dr;
             }
-        } else {
-            if (xe) { 
-                b_demosaiced = lin(readU16_val(x,y));
-                g_demosaiced = interpG(x,y);
-                r_demosaiced = interpD(x,y);
-            } else { 
-                g_demosaiced = lin(readU16_val(x,y));
-                r_demosaiced = interpV(x,y);
-                b_demosaiced = interpH(x,y);
+        }else{
+            if(xe){
+                rcd_g = greenAtRB(x,y); rcd_r = lin(readU16_val(x,y));
+                float db=(lin(readU16_val(x-1,y-1))-greenAt(x-1,y-1)+lin(readU16_val(x+1,y-1))-greenAt(x+1,y-1)+lin(readU16_val(x-1,y+1))-greenAt(x-1,y+1)+lin(readU16_val(x+1,y+1))-greenAt(x+1,y+1))*0.25;
+                rcd_b = rcd_g + db;
+            }else{
+                rcd_g = lin(readU16_val(x,y));
+                float dr=(lin(readU16_val(x-1,y))-greenAt(x-1,y)+lin(readU16_val(x+1,y))-greenAt(x+1,y))*0.5;
+                float db=(lin(readU16_val(x,y-1))-greenAt(x,y-1)+lin(readU16_val(x,y+1))-greenAt(x,y+1))*0.5;
+                rcd_r = rcd_g + dr; rcd_b = rcd_g + db;
+            }
+        }
+    }else{ // GRBG
+        if(ye){
+            if(xe){
+                rcd_g = lin(readU16_val(x,y));
+                float dr=(lin(readU16_val(x-1,y))-greenAt(x-1,y)+lin(readU16_val(x+1,y))-greenAt(x+1,y))*0.5;
+                float db=(lin(readU16_val(x,y-1))-greenAt(x,y-1)+lin(readU16_val(x,y+1))-greenAt(x,y+1))*0.5;
+                rcd_r = rcd_g + dr; rcd_b = rcd_g + db;
+            }else{
+                rcd_g = greenAtRB(x,y); rcd_r = lin(readU16_val(x,y));
+                float db=(lin(readU16_val(x-1,y-1))-greenAt(x-1,y-1)+lin(readU16_val(x+1,y-1))-greenAt(x+1,y-1)+lin(readU16_val(x-1,y+1))-greenAt(x-1,y+1)+lin(readU16_val(x+1,y+1))-greenAt(x+1,y+1))*0.25;
+                rcd_b = rcd_g + db;
+            }
+        }else{
+            if(xe){
+                rcd_g = greenAtRB(x,y); rcd_b = lin(readU16_val(x,y));
+                float dr=(lin(readU16_val(x-1,y-1))-greenAt(x-1,y-1)+lin(readU16_val(x+1,y-1))-greenAt(x+1,y-1)+lin(readU16_val(x-1,y+1))-greenAt(x-1,y+1)+lin(readU16_val(x+1,y+1))-greenAt(x+1,y+1))*0.25;
+                rcd_r = rcd_g + dr;
+            }else{
+                rcd_g = lin(readU16_val(x,y));
+                float dr=(lin(readU16_val(x,y-1))-greenAt(x,y-1)+lin(readU16_val(x,y+1))-greenAt(x,y+1))*0.5;
+                float db=(lin(readU16_val(x-1,y))-greenAt(x-1,y)+lin(readU16_val(x+1,y))-greenAt(x+1,y))*0.5;
+                rcd_r = rcd_g + dr; rcd_b = rcd_g + db;
             }
         }
     }
+
+    r_demosaiced = rcd_r;
+    g_demosaiced = rcd_g;
+    b_demosaiced = rcd_b;
 
     float r_wb = clamp(r_demosaiced * params.gainR, 0.0, 1.0);
     float g_wb = clamp(g_demosaiced * params.gainG, 0.0, 1.0);

--- a/shaders/raw_to_yuv422.comp
+++ b/shaders/raw_to_yuv422.comp
@@ -20,7 +20,11 @@ layout(push_constant, std430) uniform PC {
 } pc;
 
 // -----------------------------------------------------------
-uint readRaw(uint x, uint y) { return imageLoad(rawImg, ivec2(x, y)).r; }
+uint readRaw(uint x, uint y) {
+    x = clamp(x, 0u, pc.width - 1u);
+    y = clamp(y, 0u, pc.height - 1u);
+    return imageLoad(rawImg, ivec2(x, y)).r;
+}
 
 float normRaw(uint r){
     return clamp(float(r) - float(pc.black), 0.0, float(pc.white - pc.black))
@@ -30,52 +34,146 @@ float normRaw(uint r){
 #define RAW(xx,yy) normRaw(readRaw(xx,yy))
 
 // -----------------------------------------------------------
+float vh(uint x, uint y){
+    float xs=0.0, ys=0.0;
+    for(int i=-1;i<=1;i++){
+        xs += RAW(x+i,y-3) - 3.0*RAW(x+i,y-2) - RAW(x+i,y-1) + 6.0*RAW(x+i,y) - RAW(x+i,y+1) - 3.0*RAW(x+i,y+2) + RAW(x+i,y+3);
+        ys += RAW(x-3,y+i) - 3.0*RAW(x-2,y+i) - RAW(x-1,y+i) + 6.0*RAW(x,y+i) - RAW(x+1,y+i) - 3.0*RAW(x+2,y+i) + RAW(x+3,y+i);
+    }
+    xs*=xs; ys*=ys;
+    return xs / (1e-5 + xs + ys);
+}
+
+float greenAtRB(uint x, uint y){
+    float v = vh(x,y);
+    float n = 0.25*(vh(x-1,y-1)+vh(x+1,y-1)+vh(x-1,y+1)+vh(x+1,y+1));
+    float w = abs(0.5 - v) < abs(0.5 - n) ? n : v;
+    float eps = 1e-5;
+    float Ng = eps + abs(RAW(x,y-1)-RAW(x,y+1)) + abs(RAW(x,y)-RAW(x,y-2));
+    float Sg = eps + abs(RAW(x,y-1)-RAW(x,y+1)) + abs(RAW(x,y)-RAW(x,y+2));
+    float Eg = eps + abs(RAW(x-1,y)-RAW(x+1,y)) + abs(RAW(x,y)-RAW(x+2,y));
+    float Wg = eps + abs(RAW(x-1,y)-RAW(x+1,y)) + abs(RAW(x,y)-RAW(x-2,y));
+    float gv = (Sg*(RAW(x,y-1)+RAW(x,y+1))*0.5 + Ng*(RAW(x,y-1)+RAW(x,y+1))*0.5)/(Ng+Sg);
+    float gh = (Eg*(RAW(x-1,y)+RAW(x+1,y))*0.5 + Wg*(RAW(x-1,y)+RAW(x+1,y))*0.5)/(Eg+Wg);
+    return mix(gv,gh,w);
+}
+
+float greenAt(uint x, uint y){
+    bool ye=(y&1u)==0u;
+    bool xe=(x&1u)==0u;
+    switch(pc.cfaType){
+        case 0u: return ye ? (xe ? greenAtRB(x,y) : RAW(x,y)) : (xe ? RAW(x,y) : greenAtRB(x,y));
+        case 1u: return ye ? (xe ? RAW(x,y) : greenAtRB(x,y)) : (xe ? greenAtRB(x,y) : RAW(x,y));
+        case 2u: return ye ? (xe ? RAW(x,y) : greenAtRB(x,y)) : (xe ? greenAtRB(x,y) : RAW(x,y));
+        default: return ye ? (xe ? greenAtRB(x,y) : RAW(x,y)) : (xe ? RAW(x,y) : greenAtRB(x,y));
+    }
+}
+
 vec3 bayerToRGB(uint x, uint y)
 {
-    bool xe = (x & 1u) == 0u;
-    bool ye = (y & 1u) == 0u;
-    float r = 0.0, g = 0.0, b = 0.0;
+    float r=0.0,g=0.0,b=0.0;
+    bool ye=(y&1u)==0u;
+    bool xe=(x&1u)==0u;
 
-    switch(pc.cfaType)
-    {
-    // BGGR --------------------------------------------------
-    case 0u:
+    switch(pc.cfaType){
+    case 0u: // BGGR
         if(ye){
-            if(xe){ b=RAW(x,y); g=(RAW(x-1,y)+RAW(x+1,y)+RAW(x,y-1)+RAW(x,y+1))*0.25; r=(RAW(x-1,y-1)+RAW(x+1,y-1)+RAW(x-1,y+1)+RAW(x+1,y+1))*0.25; }
-            else   { g=RAW(x,y); b=(RAW(x-1,y)+RAW(x+1,y))*0.5; r=(RAW(x,y-1)+RAW(x,y+1))*0.5; }
+            if(xe){
+                g=greenAtRB(x,y); b=RAW(x,y);
+                float dr=(RAW(x-1,y-1)-greenAt(x-1,y-1)+RAW(x+1,y-1)-greenAt(x+1,y-1)+RAW(x-1,y+1)-greenAt(x-1,y+1)+RAW(x+1,y+1)-greenAt(x+1,y+1))*0.25;
+                r=g+dr;
+            }else{
+                g=RAW(x,y);
+                float dr=(RAW(x,y-1)-greenAt(x,y-1)+RAW(x,y+1)-greenAt(x,y+1))*0.5;
+                float db=(RAW(x-1,y)-greenAt(x-1,y)+RAW(x+1,y)-greenAt(x+1,y))*0.5;
+                r=g+dr; b=g+db;
+            }
         }else{
-            if(xe){ g=RAW(x,y); b=(RAW(x,y-1)+RAW(x,y+1))*0.5; r=(RAW(x-1,y)+RAW(x+1,y))*0.5; }
-            else   { r=RAW(x,y); g=(RAW(x-1,y)+RAW(x+1,y)+RAW(x,y-1)+RAW(x,y+1))*0.25; b=(RAW(x-1,y-1)+RAW(x+1,y-1)+RAW(x-1,y+1)+RAW(x+1,y+1))*0.25; }
+            if(xe){
+                g=RAW(x,y);
+                float dr=(RAW(x-1,y)-greenAt(x-1,y)+RAW(x+1,y)-greenAt(x+1,y))*0.5;
+                float db=(RAW(x,y-1)-greenAt(x,y-1)+RAW(x,y+1)-greenAt(x,y+1))*0.5;
+                r=g+dr; b=g+db;
+            }else{
+                g=greenAtRB(x,y); r=RAW(x,y);
+                float db=(RAW(x-1,y-1)-greenAt(x-1,y-1)+RAW(x+1,y-1)-greenAt(x+1,y-1)+RAW(x-1,y+1)-greenAt(x-1,y+1)+RAW(x+1,y+1)-greenAt(x+1,y+1))*0.25;
+                b=g+db;
+            }
         }
         break;
-    // RGGB --------------------------------------------------
-    case 1u:
+    case 1u: // RGGB
         if(ye){
-            if(xe){ r=RAW(x,y); g=(RAW(x-1,y)+RAW(x+1,y)+RAW(x,y-1)+RAW(x,y+1))*0.25; b=(RAW(x-1,y-1)+RAW(x+1,y-1)+RAW(x-1,y+1)+RAW(x+1,y+1))*0.25; }
-            else   { g=RAW(x,y); r=(RAW(x-1,y)+RAW(x+1,y))*0.5; b=(RAW(x,y-1)+RAW(x,y+1))*0.5; }
+            if(xe){
+                g=greenAtRB(x,y); r=RAW(x,y);
+                float db=(RAW(x-1,y-1)-greenAt(x-1,y-1)+RAW(x+1,y-1)-greenAt(x+1,y-1)+RAW(x-1,y+1)-greenAt(x-1,y+1)+RAW(x+1,y+1)-greenAt(x+1,y+1))*0.25;
+                b=g+db;
+            }else{
+                g=RAW(x,y);
+                float dr=(RAW(x-1,y)-greenAt(x-1,y)+RAW(x+1,y)-greenAt(x+1,y))*0.5;
+                float db=(RAW(x,y-1)-greenAt(x,y-1)+RAW(x,y+1)-greenAt(x,y+1))*0.5;
+                r=g+dr; b=g+db;
+            }
         }else{
-            if(xe){ g=RAW(x,y); r=(RAW(x,y-1)+RAW(x,y+1))*0.5; b=(RAW(x-1,y)+RAW(x+1,y))*0.5; }
-            else   { b=RAW(x,y); g=(RAW(x-1,y)+RAW(x+1,y)+RAW(x,y-1)+RAW(x,y+1))*0.25; r=(RAW(x-1,y-1)+RAW(x+1,y-1)+RAW(x-1,y+1)+RAW(x+1,y+1))*0.25; }
+            if(xe){
+                g=RAW(x,y);
+                float dr=(RAW(x,y-1)-greenAt(x,y-1)+RAW(x,y+1)-greenAt(x,y+1))*0.5;
+                float db=(RAW(x-1,y)-greenAt(x-1,y)+RAW(x+1,y)-greenAt(x+1,y))*0.5;
+                r=g+dr; b=g+db;
+            }else{
+                g=greenAtRB(x,y); b=RAW(x,y);
+                float dr=(RAW(x-1,y-1)-greenAt(x-1,y-1)+RAW(x+1,y-1)-greenAt(x+1,y-1)+RAW(x-1,y+1)-greenAt(x-1,y+1)+RAW(x+1,y+1)-greenAt(x+1,y+1))*0.25;
+                r=g+dr;
+            }
         }
         break;
-    // GBRG --------------------------------------------------
-    case 2u:
+    case 2u: // GBRG
         if(ye){
-            if(xe){ g=RAW(x,y); b=(RAW(x-1,y)+RAW(x+1,y))*0.5; r=(RAW(x,y-1)+RAW(x,y+1))*0.5; }
-            else   { b=RAW(x,y); g=(RAW(x-1,y)+RAW(x+1,y)+RAW(x,y-1)+RAW(x,y+1))*0.25; r=(RAW(x-1,y-1)+RAW(x+1,y-1)+RAW(x-1,y+1)+RAW(x+1,y+1))*0.25; }
+            if(xe){
+                g=RAW(x,y);
+                float db=(RAW(x-1,y)-greenAt(x-1,y)+RAW(x+1,y)-greenAt(x+1,y))*0.5;
+                float dr=(RAW(x,y-1)-greenAt(x,y-1)+RAW(x,y+1)-greenAt(x,y+1))*0.5;
+                b=g+db; r=g+dr;
+            }else{
+                g=greenAtRB(x,y); b=RAW(x,y);
+                float dr=(RAW(x-1,y-1)-greenAt(x-1,y-1)+RAW(x+1,y-1)-greenAt(x+1,y-1)+RAW(x-1,y+1)-greenAt(x-1,y+1)+RAW(x+1,y+1)-greenAt(x+1,y+1))*0.25;
+                r=g+dr;
+            }
         }else{
-            if(xe){ r=RAW(x,y); g=(RAW(x-1,y)+RAW(x+1,y)+RAW(x,y-1)+RAW(x,y+1))*0.25; b=(RAW(x-1,y-1)+RAW(x+1,y-1)+RAW(x-1,y+1)+RAW(x+1,y+1))*0.25; }
-            else   { g=RAW(x,y); r=(RAW(x-1,y)+RAW(x+1,y))*0.5; b=(RAW(x,y-1)+RAW(x,y+1))*0.5; }
+            if(xe){
+                g=greenAtRB(x,y); r=RAW(x,y);
+                float db=(RAW(x-1,y-1)-greenAt(x-1,y-1)+RAW(x+1,y-1)-greenAt(x+1,y-1)+RAW(x-1,y+1)-greenAt(x-1,y+1)+RAW(x+1,y+1)-greenAt(x+1,y+1))*0.25;
+                b=g+db;
+            }else{
+                g=RAW(x,y);
+                float dr=(RAW(x-1,y)-greenAt(x-1,y)+RAW(x+1,y)-greenAt(x+1,y))*0.5;
+                float db=(RAW(x,y-1)-greenAt(x,y-1)+RAW(x,y+1)-greenAt(x,y+1))*0.5;
+                r=g+dr; b=g+db;
+            }
         }
         break;
-    // GRBG --------------------------------------------------
-    case 3u:
+    default: // GRBG
         if(ye){
-            if(xe){ g=RAW(x,y); r=(RAW(x-1,y)+RAW(x+1,y))*0.5; b=(RAW(x,y-1)+RAW(x,y+1))*0.5; }
-            else   { r=RAW(x,y); g=(RAW(x-1,y)+RAW(x+1,y)+RAW(x,y-1)+RAW(x,y+1))*0.25; b=(RAW(x-1,y-1)+RAW(x+1,y-1)+RAW(x-1,y+1)+RAW(x+1,y+1))*0.25; }
+            if(xe){
+                g=RAW(x,y);
+                float dr=(RAW(x-1,y)-greenAt(x-1,y)+RAW(x+1,y)-greenAt(x+1,y))*0.5;
+                float db=(RAW(x,y-1)-greenAt(x,y-1)+RAW(x,y+1)-greenAt(x,y+1))*0.5;
+                r=g+dr; b=g+db;
+            }else{
+                g=greenAtRB(x,y); r=RAW(x,y);
+                float db=(RAW(x-1,y-1)-greenAt(x-1,y-1)+RAW(x+1,y-1)-greenAt(x+1,y-1)+RAW(x-1,y+1)-greenAt(x-1,y+1)+RAW(x+1,y+1)-greenAt(x+1,y+1))*0.25;
+                b=g+db;
+            }
         }else{
-            if(xe){ b=RAW(x,y); g=(RAW(x-1,y)+RAW(x+1,y)+RAW(x,y-1)+RAW(x,y+1))*0.25; r=(RAW(x-1,y-1)+RAW(x+1,y-1)+RAW(x-1,y+1)+RAW(x+1,y+1))*0.25; }
-            else   { g=RAW(x,y); b=(RAW(x-1,y)+RAW(x+1,y))*0.5; r=(RAW(x,y-1)+RAW(x,y+1))*0.5; }
+            if(xe){
+                g=greenAtRB(x,y); b=RAW(x,y);
+                float dr=(RAW(x-1,y-1)-greenAt(x-1,y-1)+RAW(x+1,y-1)-greenAt(x+1,y-1)+RAW(x-1,y+1)-greenAt(x-1,y+1)+RAW(x+1,y+1)-greenAt(x+1,y+1))*0.25;
+                r=g+dr;
+            }else{
+                g=RAW(x,y);
+                float dr=(RAW(x,y-1)-greenAt(x,y-1)+RAW(x,y+1)-greenAt(x,y+1))*0.5;
+                float db=(RAW(x-1,y)-greenAt(x-1,y)+RAW(x+1,y)-greenAt(x+1,y))*0.5;
+                r=g+dr; b=g+db;
+            }
         }
         break;
     }

--- a/src/Utils/ColorPipelineCPU.cpp
+++ b/src/Utils/ColorPipelineCPU.cpp
@@ -31,56 +31,164 @@ void convertRawToRGB24(const uint16_t* raw, const CPUColorParams& p,
     auto lin = [&](int x, int y) -> float {
         return linFromRaw(readU16(raw,x,y,p.width,p.height), p.blackLevel, invRange);
     };
-    auto interpG = [&](int x, int y)->float{ return 0.25f*(lin(x+1,y)+lin(x-1,y)+lin(x,y+1)+lin(x,y-1));};
-    auto interpH = [&](int x, int y)->float{ return 0.5f*(lin(x+1,y)+lin(x-1,y));};
-    auto interpV = [&](int x, int y)->float{ return 0.5f*(lin(x,y+1)+lin(x,y-1));};
-    auto interpD = [&](int x, int y)->float{ return 0.25f*(lin(x+1,y+1)+lin(x-1,y+1)+lin(x+1,y-1)+lin(x-1,y-1));};
+    auto vh = [&](int x, int y)->float {
+        float xs = 0.0f, ys = 0.0f;
+        for(int i=-1;i<=1;++i){
+            xs += lin(x+i,y-3) - 3.0f*lin(x+i,y-2) - lin(x+i,y-1) + 6.0f*lin(x+i,y)
+                 - lin(x+i,y+1) - 3.0f*lin(x+i,y+2) + lin(x+i,y+3);
+            ys += lin(x-3,y+i) - 3.0f*lin(x-2,y+i) - lin(x-1,y+i) + 6.0f*lin(x,y+i)
+                 - lin(x+1,y+i) - 3.0f*lin(x+2,y+i) + lin(x+3,y+i);
+        }
+        xs *= xs; ys *= ys;
+        return xs / (1e-5f + xs + ys);
+    };
+
+    auto greenAtRB = [&](int x, int y)->float {
+        float vhVal = vh(x,y);
+        float vhNeigh = 0.25f*(vh(x-1,y-1)+vh(x+1,y-1)+vh(x-1,y+1)+vh(x+1,y+1));
+        float vhDiscr = std::abs(0.5f - vhVal) < std::abs(0.5f - vhNeigh) ? vhNeigh : vhVal;
+        float eps = 1e-5f;
+        float N_grad = eps + std::abs(lin(x, y-1) - lin(x, y+1)) + std::abs(lin(x, y) - lin(x, y-2));
+        float S_grad = eps + std::abs(lin(x, y-1) - lin(x, y+1)) + std::abs(lin(x, y) - lin(x, y+2));
+        float E_grad = eps + std::abs(lin(x-1, y) - lin(x+1, y)) + std::abs(lin(x, y) - lin(x+2, y));
+        float W_grad = eps + std::abs(lin(x-1, y) - lin(x+1, y)) + std::abs(lin(x, y) - lin(x-2, y));
+        float g_v = (S_grad * (lin(x, y-1)+lin(x, y+1))*0.5f + N_grad * (lin(x, y-1)+lin(x, y+1))*0.5f)/(N_grad + S_grad);
+        float g_h = (E_grad * (lin(x-1, y)+lin(x+1, y))*0.5f + W_grad * (lin(x-1, y)+lin(x+1, y))*0.5f)/(E_grad + W_grad);
+        return g_v*(1.0f - vhDiscr) + g_h*vhDiscr;
+    };
+
+    auto greenAt = [&](int x, int y)->float {
+        bool ye = (y%2)==0;
+        bool xe = (x%2)==0;
+        switch(p.cfaType){
+            case 0: // BGGR
+                return ye ? (xe ? greenAtRB(x,y) : lin(x,y))
+                          : (xe ? lin(x,y) : greenAtRB(x,y));
+            case 1: // RGGB
+                return ye ? (xe ? lin(x,y) : greenAtRB(x,y))
+                          : (xe ? greenAtRB(x,y) : lin(x,y));
+            case 2: // GBRG
+                return ye ? (xe ? lin(x,y) : greenAtRB(x,y))
+                          : (xe ? greenAtRB(x,y) : lin(x,y));
+            default: // GRBG
+                return ye ? (xe ? greenAtRB(x,y) : lin(x,y))
+                          : (xe ? lin(x,y) : greenAtRB(x,y));
+        }
+    };
+
+    auto rcdPixel = [&](int x, int y, float& r, float& g, float& b){
+        bool ye = (y%2)==0;
+        bool xe = (x%2)==0;
+        switch(p.cfaType){
+            case 0: // BGGR
+                if(ye){
+                    if(xe){
+                        g=greenAtRB(x,y); b=lin(x,y);
+                        float dr=(lin(x-1,y-1)-greenAt(x-1,y-1)+lin(x+1,y-1)-greenAt(x+1,y-1)+lin(x-1,y+1)-greenAt(x-1,y+1)+lin(x+1,y+1)-greenAt(x+1,y+1))*0.25f;
+                        r=g+dr;
+                    }else{
+                        g=lin(x,y);
+                        float dr=(lin(x,y-1)-greenAt(x,y-1)+lin(x,y+1)-greenAt(x,y+1))*0.5f;
+                        float db=(lin(x-1,y)-greenAt(x-1,y)+lin(x+1,y)-greenAt(x+1,y))*0.5f;
+                        r=g+dr; b=g+db;
+                    }
+                }else{
+                    if(xe){
+                        g=lin(x,y);
+                        float dr=(lin(x-1,y)-greenAt(x-1,y)+lin(x+1,y)-greenAt(x+1,y))*0.5f;
+                        float db=(lin(x,y-1)-greenAt(x,y-1)+lin(x,y+1)-greenAt(x,y+1))*0.5f;
+                        r=g+dr; b=g+db;
+                    }else{
+                        g=greenAtRB(x,y); r=lin(x,y);
+                        float db=(lin(x-1,y-1)-greenAt(x-1,y-1)+lin(x+1,y-1)-greenAt(x+1,y-1)+lin(x-1,y+1)-greenAt(x-1,y+1)+lin(x+1,y+1)-greenAt(x+1,y+1))*0.25f;
+                        b=g+db;
+                    }
+                }
+                break;
+            case 1: // RGGB
+                if(ye){
+                    if(xe){
+                        g=greenAtRB(x,y); r=lin(x,y);
+                        float db=(lin(x-1,y-1)-greenAt(x-1,y-1)+lin(x+1,y-1)-greenAt(x+1,y-1)+lin(x-1,y+1)-greenAt(x-1,y+1)+lin(x+1,y+1)-greenAt(x+1,y+1))*0.25f;
+                        b=g+db;
+                    }else{
+                        g=lin(x,y);
+                        float dr=(lin(x-1,y)-greenAt(x-1,y)+lin(x+1,y)-greenAt(x+1,y))*0.5f;
+                        float db=(lin(x,y-1)-greenAt(x,y-1)+lin(x,y+1)-greenAt(x,y+1))*0.5f;
+                        r=g+dr; b=g+db;
+                    }
+                }else{
+                    if(xe){
+                        g=lin(x,y);
+                        float dr=(lin(x,y-1)-greenAt(x,y-1)+lin(x,y+1)-greenAt(x,y+1))*0.5f;
+                        float db=(lin(x-1,y)-greenAt(x-1,y)+lin(x+1,y)-greenAt(x+1,y))*0.5f;
+                        r=g+dr; b=g+db;
+                    }else{
+                        g=greenAtRB(x,y); b=lin(x,y);
+                        float dr=(lin(x-1,y-1)-greenAt(x-1,y-1)+lin(x+1,y-1)-greenAt(x+1,y-1)+lin(x-1,y+1)-greenAt(x-1,y+1)+lin(x+1,y+1)-greenAt(x+1,y+1))*0.25f;
+                        r=g+dr;
+                    }
+                }
+                break;
+            case 2: // GBRG
+                if(ye){
+                    if(xe){
+                        g=lin(x,y);
+                        float db=(lin(x-1,y)-greenAt(x-1,y)+lin(x+1,y)-greenAt(x+1,y))*0.5f;
+                        float dr=(lin(x,y-1)-greenAt(x,y-1)+lin(x,y+1)-greenAt(x,y+1))*0.5f;
+                        b=g+db; r=g+dr;
+                    }else{
+                        g=greenAtRB(x,y); b=lin(x,y);
+                        float dr=(lin(x-1,y-1)-greenAt(x-1,y-1)+lin(x+1,y-1)-greenAt(x+1,y-1)+lin(x-1,y+1)-greenAt(x-1,y+1)+lin(x+1,y+1)-greenAt(x+1,y+1))*0.25f;
+                        r=g+dr;
+                    }
+                }else{
+                    if(xe){
+                        g=greenAtRB(x,y); r=lin(x,y);
+                        float db=(lin(x-1,y-1)-greenAt(x-1,y-1)+lin(x+1,y-1)-greenAt(x+1,y-1)+lin(x-1,y+1)-greenAt(x-1,y+1)+lin(x+1,y+1)-greenAt(x+1,y+1))*0.25f;
+                        b=g+db;
+                    }else{
+                        g=lin(x,y);
+                        float dr=(lin(x-1,y)-greenAt(x-1,y)+lin(x+1,y)-greenAt(x+1,y))*0.5f;
+                        float db=(lin(x,y-1)-greenAt(x,y-1)+lin(x,y+1)-greenAt(x,y+1))*0.5f;
+                        r=g+dr; b=g+db;
+                    }
+                }
+                break;
+            default: // GRBG
+                if(ye){
+                    if(xe){
+                        g=lin(x,y);
+                        float dr=(lin(x-1,y)-greenAt(x-1,y)+lin(x+1,y)-greenAt(x+1,y))*0.5f;
+                        float db=(lin(x,y-1)-greenAt(x,y-1)+lin(x,y+1)-greenAt(x,y+1))*0.5f;
+                        r=g+dr; b=g+db;
+                    }else{
+                        g=greenAtRB(x,y); r=lin(x,y);
+                        float db=(lin(x-1,y-1)-greenAt(x-1,y-1)+lin(x+1,y-1)-greenAt(x+1,y-1)+lin(x-1,y+1)-greenAt(x-1,y+1)+lin(x+1,y+1)-greenAt(x+1,y+1))*0.25f;
+                        b=g+db;
+                    }
+                }else{
+                    if(xe){
+                        g=greenAtRB(x,y); b=lin(x,y);
+                        float dr=(lin(x-1,y-1)-greenAt(x-1,y-1)+lin(x+1,y-1)-greenAt(x+1,y-1)+lin(x-1,y+1)-greenAt(x-1,y+1)+lin(x+1,y+1)-greenAt(x+1,y+1))*0.25f;
+                        r=g+dr;
+                    }else{
+                        g=lin(x,y);
+                        float dr=(lin(x,y-1)-greenAt(x,y-1)+lin(x,y+1)-greenAt(x,y+1))*0.5f;
+                        float db=(lin(x-1,y)-greenAt(x-1,y)+lin(x+1,y)-greenAt(x+1,y))*0.5f;
+                        r=g+dr; b=g+db;
+                    }
+                }
+                break;
+        }
+    };
 
     const float* ccm = p.ccm.data();
 
     auto processRow = [&](int y){
         for(int x=0;x<p.width;++x){
-            bool ye = (y%2)==0;
-            bool xe = (x%2)==0;
             float r=0,g=0,b=0;
-            switch(p.cfaType){
-                case 0: // BGGR
-                    if(ye){
-                        if(xe){ b=lin(x,y); g=interpG(x,y); r=interpD(x,y); }
-                        else { g=lin(x,y); r=interpV(x,y); b=interpH(x,y); }
-                    }else{
-                        if(xe){ g=lin(x,y); r=interpH(x,y); b=interpV(x,y); }
-                        else { r=lin(x,y); g=interpG(x,y); b=interpD(x,y); }
-                    }
-                    break;
-                case 1: // RGGB
-                    if(ye){
-                        if(xe){ r=lin(x,y); g=interpG(x,y); b=interpD(x,y); }
-                        else { g=lin(x,y); r=interpH(x,y); b=interpV(x,y); }
-                    }else{
-                        if(xe){ g=lin(x,y); r=interpV(x,y); b=interpH(x,y); }
-                        else { b=lin(x,y); g=interpG(x,y); r=interpD(x,y); }
-                    }
-                    break;
-                case 2: // GBRG
-                    if(ye){
-                        if(xe){ g=lin(x,y); r=interpV(x,y); b=interpH(x,y); }
-                        else { b=lin(x,y); g=interpG(x,y); r=interpD(x,y); }
-                    }else{
-                        if(xe){ r=lin(x,y); g=interpG(x,y); b=interpD(x,y); }
-                        else { g=lin(x,y); r=interpH(x,y); b=interpV(x,y); }
-                    }
-                    break;
-                default: // GRBG
-                    if(ye){
-                        if(xe){ g=lin(x,y); r=interpH(x,y); b=interpV(x,y); }
-                        else { r=lin(x,y); g=interpG(x,y); b=interpD(x,y); }
-                    }else{
-                        if(xe){ b=lin(x,y); g=interpG(x,y); r=interpD(x,y); }
-                        else { g=lin(x,y); r=interpV(x,y); b=interpH(x,y); }
-                    }
-                    break;
-            }
+            rcdPixel(x,y,r,g,b);
             float r_wb = std::clamp(r * p.gainR, 0.0f, 1.0f);
             float g_wb = std::clamp(g * p.gainG, 0.0f, 1.0f);
             float b_wb = std::clamp(b * p.gainB, 0.0f, 1.0f);


### PR DESCRIPTION
## Summary
- implement Residual Color Difference demosaicing in the CPU color pipeline
- add RCD logic to the Vulkan YUV converter compute shader
- replace bilinear approach in the display fragment shader

## Testing
- `cmake -S . -B build`
- `cmake --build build -j4` *(fails: libavutil/frame.h missing)*

------
https://chatgpt.com/codex/tasks/task_e_688676866810832782bb002e5efee1d0