### PR TITLE
Replace bilinear fallback with RCD demosaicing

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -109,6 +109,8 @@ set(SHADER_FILES
     "${APP_SHADERS_SRC_DIR}/fullscreen_quad.vert"
     "${APP_SHADERS_SRC_DIR}/image_process.frag"
     "${APP_SHADERS_SRC_DIR}/raw_to_yuv422.comp"
+    "${APP_SHADERS_SRC_DIR}/rcd_conv.comp"
+    "${APP_SHADERS_SRC_DIR}/rcd_fill.comp"
 )
 set(COMPILED_SHADER_OUTPUTS "")
 foreach(SHADER_INPUT_FILE ${SHADER_FILES})

--- a/shaders/config.h
+++ b/shaders/config.h
@@ -1,0 +1,7 @@
+#define DT_RCD_LOCAL_SIZE_X 32
+#define DT_RCD_LOCAL_SIZE_Y 32
+#define DT_RCD_TILE_SIZE_X 64
+#define DT_RCD_TILE_SIZE_Y 32
+#define DT_RCD_BORDER 3
+#define DT_LOCAL_SIZE_X 32
+#define DT_LOCAL_SIZE_Y 32

--- a/shaders/image_process.frag
+++ b/shaders/image_process.frag
@@ -113,14 +113,119 @@ void main() {
                 b_demosaiced = mix(bd1, bd2, vh);
             }
         }
-    } else {
-        // Fallback to bilinear for other patterns
+    } else if (params.cfaType == 1) { // RGGB
         if (ye) {
-            if (xe) { g_demosaiced = lin(readU16_val(x,y)); r_demosaiced = interpH(x,y); b_demosaiced = interpV(x,y); }
-            else { r_demosaiced = lin(readU16_val(x,y)); g_demosaiced = interpG(x,y); b_demosaiced = interpD(x,y); }
+            if (xe) { // red
+                r_demosaiced = lin(readU16_val(x,y));
+                float g_h = 0.5 * (lin(readU16_val(x+1,y)) + lin(readU16_val(x-1,y)));
+                float g_v = 0.5 * (lin(readU16_val(x,y+1)) + lin(readU16_val(x,y-1)));
+                g_demosaiced = mix(g_v, g_h, vh);
+                float bd1 = 0.5 * (lin(readU16_val(x-1,y-1)) + lin(readU16_val(x+1,y+1)));
+                float bd2 = 0.5 * (lin(readU16_val(x-1,y+1)) + lin(readU16_val(x+1,y-1)));
+                b_demosaiced = mix(bd1, bd2, vh);
+            } else { // green
+                g_demosaiced = lin(readU16_val(x,y));
+                float b_h = 0.5 * (lin(readU16_val(x-1,y)) + lin(readU16_val(x+1,y)));
+                float b_v = 0.5 * (lin(readU16_val(x,y-1)) + lin(readU16_val(x,y+1)));
+                b_demosaiced = mix(b_v, b_h, vh);
+                float r_h = 0.5 * (lin(readU16_val(x,y-1)) + lin(readU16_val(x,y+1)));
+                float r_v = 0.5 * (lin(readU16_val(x-1,y)) + lin(readU16_val(x+1,y)));
+                r_demosaiced = mix(r_h, r_v, vh);
+            }
         } else {
-            if (xe) { b_demosaiced = lin(readU16_val(x,y)); g_demosaiced = interpG(x,y); r_demosaiced = interpD(x,y); }
-            else { g_demosaiced = lin(readU16_val(x,y)); r_demosaiced = interpV(x,y); b_demosaiced = interpH(x,y); }
+            if (xe) { // green
+                g_demosaiced = lin(readU16_val(x,y));
+                float r_h = 0.5 * (lin(readU16_val(x-1,y)) + lin(readU16_val(x+1,y)));
+                float r_v = 0.5 * (lin(readU16_val(x,y-1)) + lin(readU16_val(x,y+1)));
+                r_demosaiced = mix(r_v, r_h, vh);
+                float b_h = 0.5 * (lin(readU16_val(x,y-1)) + lin(readU16_val(x,y+1)));
+                float b_v = 0.5 * (lin(readU16_val(x-1,y)) + lin(readU16_val(x+1,y)));
+                b_demosaiced = mix(b_h, b_v, vh);
+            } else { // blue
+                b_demosaiced = lin(readU16_val(x,y));
+                float g_h = 0.5 * (lin(readU16_val(x-1,y)) + lin(readU16_val(x+1,y)));
+                float g_v = 0.5 * (lin(readU16_val(x,y-1)) + lin(readU16_val(x,y+1)));
+                g_demosaiced = mix(g_v, g_h, vh);
+                float rd1 = 0.5 * (lin(readU16_val(x-1,y-1)) + lin(readU16_val(x+1,y+1)));
+                float rd2 = 0.5 * (lin(readU16_val(x-1,y+1)) + lin(readU16_val(x+1,y-1)));
+                r_demosaiced = mix(rd1, rd2, vh);
+            }
+        }
+    } else if (params.cfaType == 2) { // GBRG
+        if (ye) {
+            if (xe) { // green
+                g_demosaiced = lin(readU16_val(x,y));
+                float b_h = 0.5 * (lin(readU16_val(x-1,y)) + lin(readU16_val(x+1,y)));
+                float b_v = 0.5 * (lin(readU16_val(x,y-1)) + lin(readU16_val(x,y+1)));
+                b_demosaiced = mix(b_h, b_v, vh);
+                float r_h = 0.5 * (lin(readU16_val(x,y-1)) + lin(readU16_val(x,y+1)));
+                float r_v = 0.5 * (lin(readU16_val(x-1,y)) + lin(readU16_val(x+1,y)));
+                r_demosaiced = mix(r_h, r_v, vh);
+            } else { // blue
+                b_demosaiced = lin(readU16_val(x,y));
+                float g_h = 0.5 * (lin(readU16_val(x-1,y)) + lin(readU16_val(x+1,y)));
+                float g_v = 0.5 * (lin(readU16_val(x,y-1)) + lin(readU16_val(x,y+1)));
+                g_demosaiced = mix(g_h, g_v, vh);
+                float rd1 = 0.5 * (lin(readU16_val(x-1,y-1)) + lin(readU16_val(x+1,y+1)));
+                float rd2 = 0.5 * (lin(readU16_val(x-1,y+1)) + lin(readU16_val(x+1,y-1)));
+                r_demosaiced = mix(rd1, rd2, vh);
+            }
+        } else {
+            if (xe) { // red
+                r_demosaiced = lin(readU16_val(x,y));
+                float g_h = 0.5 * (lin(readU16_val(x-1,y)) + lin(readU16_val(x+1,y)));
+                float g_v = 0.5 * (lin(readU16_val(x,y-1)) + lin(readU16_val(x,y+1)));
+                g_demosaiced = mix(g_h, g_v, vh);
+                float bd1 = 0.5 * (lin(readU16_val(x-1,y-1)) + lin(readU16_val(x+1,y+1)));
+                float bd2 = 0.5 * (lin(readU16_val(x-1,y+1)) + lin(readU16_val(x+1,y-1)));
+                b_demosaiced = mix(bd1, bd2, vh);
+            } else { // green
+                g_demosaiced = lin(readU16_val(x,y));
+                float r_h = 0.5 * (lin(readU16_val(x-1,y)) + lin(readU16_val(x+1,y)));
+                float r_v = 0.5 * (lin(readU16_val(x,y-1)) + lin(readU16_val(x,y+1)));
+                r_demosaiced = mix(r_h, r_v, vh);
+                float b_h = 0.5 * (lin(readU16_val(x,y-1)) + lin(readU16_val(x,y+1)));
+                float b_v = 0.5 * (lin(readU16_val(x-1,y)) + lin(readU16_val(x+1,y)));
+                b_demosaiced = mix(b_v, b_h, vh);
+            }
+        }
+    } else { // GRBG
+        if (ye) {
+            if (xe) { // green
+                g_demosaiced = lin(readU16_val(x,y));
+                float r_h = 0.5 * (lin(readU16_val(x-1,y)) + lin(readU16_val(x+1,y)));
+                float r_v = 0.5 * (lin(readU16_val(x,y-1)) + lin(readU16_val(x,y+1)));
+                r_demosaiced = mix(r_h, r_v, vh);
+                float b_h = 0.5 * (lin(readU16_val(x,y-1)) + lin(readU16_val(x,y+1)));
+                float b_v = 0.5 * (lin(readU16_val(x-1,y)) + lin(readU16_val(x+1,y)));
+                b_demosaiced = mix(b_v, b_h, vh);
+            } else { // red
+                r_demosaiced = lin(readU16_val(x,y));
+                float g_h = 0.5 * (lin(readU16_val(x-1,y)) + lin(readU16_val(x+1,y)));
+                float g_v = 0.5 * (lin(readU16_val(x,y-1)) + lin(readU16_val(x,y+1)));
+                g_demosaiced = mix(g_h, g_v, vh);
+                float bd1 = 0.5 * (lin(readU16_val(x-1,y-1)) + lin(readU16_val(x+1,y+1)));
+                float bd2 = 0.5 * (lin(readU16_val(x-1,y+1)) + lin(readU16_val(x+1,y-1)));
+                b_demosaiced = mix(bd1, bd2, vh);
+            }
+        } else {
+            if (xe) { // blue
+                b_demosaiced = lin(readU16_val(x,y));
+                float g_h = 0.5 * (lin(readU16_val(x-1,y)) + lin(readU16_val(x+1,y)));
+                float g_v = 0.5 * (lin(readU16_val(x,y-1)) + lin(readU16_val(x,y+1)));
+                g_demosaiced = mix(g_h, g_v, vh);
+                float rd1 = 0.5 * (lin(readU16_val(x-1,y-1)) + lin(readU16_val(x+1,y+1)));
+                float rd2 = 0.5 * (lin(readU16_val(x-1,y+1)) + lin(readU16_val(x+1,y-1)));
+                r_demosaiced = mix(rd1, rd2, vh);
+            } else { // green
+                g_demosaiced = lin(readU16_val(x,y));
+                float b_h = 0.5 * (lin(readU16_val(x-1,y)) + lin(readU16_val(x+1,y)));
+                float b_v = 0.5 * (lin(readU16_val(x,y-1)) + lin(readU16_val(x,y+1)));
+                b_demosaiced = mix(b_h, b_v, vh);
+                float r_h = 0.5 * (lin(readU16_val(x,y-1)) + lin(readU16_val(x,y+1)));
+                float r_v = 0.5 * (lin(readU16_val(x-1,y)) + lin(readU16_val(x+1,y)));
+                r_demosaiced = mix(r_v, r_h, vh);
+            }
         }
     }
 

--- a/shaders/raw_to_yuv422.comp
+++ b/shaders/raw_to_yuv422.comp
@@ -81,15 +81,127 @@ vec3 bayerToRGB(uint x, uint y)
             }
         }
         break;
-    default:
-        // For other patterns fall back to simple bilinear
+    // RGGB --------------------------------------------------
+    case 1u:
         if(ye){
-            if(xe){ g=RAW(x,y); r=(RAW(x-1,y)+RAW(x+1,y))*0.5; b=(RAW(x,y-1)+RAW(x,y+1))*0.5; }
-            else   { r=RAW(x,y); g=(RAW(x-1,y)+RAW(x+1,y)+RAW(x,y-1)+RAW(x,y+1))*0.25; b=(RAW(x-1,y-1)+RAW(x+1,y-1)+RAW(x-1,y+1)+RAW(x+1,y+1))*0.25; }
+            if(xe){
+                r = RAW(x,y);
+                float g_h = 0.5*(RAW(x-1,y)+RAW(x+1,y));
+                float g_v = 0.5*(RAW(x,y-1)+RAW(x,y+1));
+                g = mix(g_v, g_h, vh);
+                float bd1 = 0.5*(RAW(x-1,y-1)+RAW(x+1,y+1));
+                float bd2 = 0.5*(RAW(x-1,y+1)+RAW(x+1,y-1));
+                b = mix(bd1, bd2, vh);
+            } else {
+                g = RAW(x,y);
+                float b_h = 0.5*(RAW(x-1,y)+RAW(x+1,y));
+                float b_v = 0.5*(RAW(x,y-1)+RAW(x,y+1));
+                b = mix(b_v, b_h, vh);
+                float r_h = 0.5*(RAW(x,y-1)+RAW(x,y+1));
+                float r_v = 0.5*(RAW(x-1,y)+RAW(x+1,y));
+                r = mix(r_h, r_v, vh);
+            }
         }else{
-            if(xe){ b=RAW(x,y); g=(RAW(x-1,y)+RAW(x+1,y)+RAW(x,y-1)+RAW(x,y+1))*0.25; r=(RAW(x-1,y-1)+RAW(x+1,y-1)+RAW(x-1,y+1)+RAW(x+1,y+1))*0.25; }
-            else   { g=RAW(x,y); b=(RAW(x-1,y)+RAW(x+1,y))*0.5; r=(RAW(x,y-1)+RAW(x,y+1))*0.5; }
+            if(xe){
+                g = RAW(x,y);
+                float r_h = 0.5*(RAW(x-1,y)+RAW(x+1,y));
+                float r_v = 0.5*(RAW(x,y-1)+RAW(x,y+1));
+                r = mix(r_v, r_h, vh);
+                float b_h = 0.5*(RAW(x,y-1)+RAW(x,y+1));
+                float b_v = 0.5*(RAW(x-1,y)+RAW(x+1,y));
+                b = mix(b_h, b_v, vh);
+            } else {
+                b = RAW(x,y);
+                float g_h = 0.5*(RAW(x-1,y)+RAW(x+1,y));
+                float g_v = 0.5*(RAW(x,y-1)+RAW(x,y+1));
+                g = mix(g_v, g_h, vh);
+                float rd1 = 0.5*(RAW(x-1,y-1)+RAW(x+1,y+1));
+                float rd2 = 0.5*(RAW(x-1,y+1)+RAW(x+1,y-1));
+                r = mix(rd1, rd2, vh);
+            }
         }
+        break;
+    // GBRG --------------------------------------------------
+    case 2u:
+        if(ye){
+            if(xe){
+                g = RAW(x,y);
+                float b_h = 0.5*(RAW(x-1,y)+RAW(x+1,y));
+                float b_v = 0.5*(RAW(x,y-1)+RAW(x,y+1));
+                b = mix(b_h, b_v, vh);
+                float r_h = 0.5*(RAW(x,y-1)+RAW(x,y+1));
+                float r_v = 0.5*(RAW(x-1,y)+RAW(x+1,y));
+                r = mix(r_h, r_v, vh);
+            } else {
+                b = RAW(x,y);
+                float g_h = 0.5*(RAW(x-1,y)+RAW(x+1,y));
+                float g_v = 0.5*(RAW(x,y-1)+RAW(x,y+1));
+                g = mix(g_h, g_v, vh);
+                float rd1 = 0.5*(RAW(x-1,y-1)+RAW(x+1,y+1));
+                float rd2 = 0.5*(RAW(x-1,y+1)+RAW(x+1,y-1));
+                r = mix(rd1, rd2, vh);
+            }
+        }else{
+            if(xe){
+                r = RAW(x,y);
+                float g_h = 0.5*(RAW(x-1,y)+RAW(x+1,y));
+                float g_v = 0.5*(RAW(x,y-1)+RAW(x,y+1));
+                g = mix(g_h, g_v, vh);
+                float bd1 = 0.5*(RAW(x-1,y-1)+RAW(x+1,y+1));
+                float bd2 = 0.5*(RAW(x-1,y+1)+RAW(x+1,y-1));
+                b = mix(bd1, bd2, vh);
+            } else {
+                g = RAW(x,y);
+                float r_h = 0.5*(RAW(x-1,y)+RAW(x+1,y));
+                float r_v = 0.5*(RAW(x,y-1)+RAW(x,y+1));
+                r = mix(r_h, r_v, vh);
+                float b_h = 0.5*(RAW(x,y-1)+RAW(x,y+1));
+                float b_v = 0.5*(RAW(x-1,y)+RAW(x+1,y));
+                b = mix(b_v, b_h, vh);
+            }
+        }
+        break;
+    // GRBG --------------------------------------------------
+    case 3u:
+        if(ye){
+            if(xe){
+                g = RAW(x,y);
+                float r_h = 0.5*(RAW(x-1,y)+RAW(x+1,y));
+                float r_v = 0.5*(RAW(x,y-1)+RAW(x,y+1));
+                r = mix(r_h, r_v, vh);
+                float b_h = 0.5*(RAW(x,y-1)+RAW(x,y+1));
+                float b_v = 0.5*(RAW(x-1,y)+RAW(x+1,y));
+                b = mix(b_v, b_h, vh);
+            } else {
+                r = RAW(x,y);
+                float g_h = 0.5*(RAW(x-1,y)+RAW(x+1,y));
+                float g_v = 0.5*(RAW(x,y-1)+RAW(x,y+1));
+                g = mix(g_h, g_v, vh);
+                float bd1 = 0.5*(RAW(x-1,y-1)+RAW(x+1,y+1));
+                float bd2 = 0.5*(RAW(x-1,y+1)+RAW(x+1,y-1));
+                b = mix(bd1, bd2, vh);
+            }
+        }else{
+            if(xe){
+                b = RAW(x,y);
+                float g_h = 0.5*(RAW(x-1,y)+RAW(x+1,y));
+                float g_v = 0.5*(RAW(x,y-1)+RAW(x,y+1));
+                g = mix(g_h, g_v, vh);
+                float rd1 = 0.5*(RAW(x-1,y-1)+RAW(x+1,y+1));
+                float rd2 = 0.5*(RAW(x-1,y+1)+RAW(x+1,y-1));
+                r = mix(rd1, rd2, vh);
+            } else {
+                g = RAW(x,y);
+                float b_h = 0.5*(RAW(x-1,y)+RAW(x+1,y));
+                float b_v = 0.5*(RAW(x,y-1)+RAW(x,y+1));
+                b = mix(b_h, b_v, vh);
+                float r_h = 0.5*(RAW(x,y-1)+RAW(x,y+1));
+                float r_v = 0.5*(RAW(x-1,y)+RAW(x+1,y));
+                r = mix(r_v, r_h, vh);
+            }
+        }
+        break;
+    default:
         break;
     }
 

--- a/shaders/rcd_conv.comp
+++ b/shaders/rcd_conv.comp
@@ -1,0 +1,47 @@
+#version 460
+#extension GL_GOOGLE_include_directive    : enable
+#extension GL_EXT_control_flow_attributes : enable
+#include "shared.glsl"
+#include "config.h"
+layout(local_size_x = DT_LOCAL_SIZE_X, local_size_y = DT_LOCAL_SIZE_Y, local_size_z = 1) in;
+layout(set = 1, binding = 0) uniform sampler2D img_cfa;
+layout(set = 1, binding = 1) uniform writeonly image2D img_vh; // 8bit [0,1] vertical/horizontal discr
+layout(set = 1, binding = 2) uniform writeonly image2D img_pq; // 8bit [0,1] diagonal discr
+layout(set = 1, binding = 3) uniform writeonly image2D img_lp; // low pass filtered green
+
+void main()
+{
+  ivec2 ipos = ivec2(gl_GlobalInvocationID);
+  if(any(greaterThanEqual(ipos, textureSize(img_cfa, 0)))) return;
+#define cfa(x,y) texture(img_cfa, (ipos+vec2(x,y)+0.5)/vec2(textureSize(img_cfa,0))).r
+  vec2 vhs = vec2(0.0);
+  [[unroll]] for(int i=-1;i<=1;i++)
+    vhs += vec2(
+      cfa(i,-3) - 3.0 * cfa(i,-2) - cfa(i,-1) + 6.0*cfa(i,0) - cfa(i,1) - 3.0*cfa(i,2) + cfa(i,3),
+      cfa(-3,i) - 3.0 * cfa(-2,i) - cfa(-1,i) + 6.0*cfa(0,i) - cfa(1,i) - 3.0*cfa(2,i) + cfa(3,i));
+  vhs *= vhs;
+  float vh = vhs.x/(1e-5 + vhs.x + vhs.y);
+  imageStore(img_vh, ipos, vec4(vh));
+
+  if(((ipos.x + ipos.y) & 1) == 0)
+  {
+    vec2 pqs = vec2(1e-5);
+    [[unroll]] for(int i=-1;i<=1;i++)
+      pqs += vec2(
+        cfa(-3+i,-3+i) - cfa(1+i,-1+i) - cfa( 1+i,1+i) + cfa( 3+i,3+i) - 3.0*(cfa(-2+i,-2+i) + cfa( 2+i,2+i)) + 6.0 * cfa(i, i),
+        cfa( 3+i,-3-i) - cfa(1+i,-1-i) - cfa(-1+i,1-i) + cfa(-3+i,3-i) - 3.0*(cfa( 2+i,-2-i) + cfa(-2+i,2-i)) + 6.0 * cfa(i,-i));
+    pqs *= pqs;
+    float pq = pqs.x/(pqs.x + pqs.y);
+    imageStore(img_pq, ivec2(ipos.x/2,ipos.y), vec4(pq));
+  }
+  else
+  {
+    float lp = 0.0;
+    const int off = ((ipos.x & 1) == 1) ? -1: 1;
+    const float w[3] = {0.5, 1.0, 0.5};
+    [[unroll]] for(int j=-1;j<=1;j++) for(int i=-1;i<=1;i++)
+      lp += w[j+1]*w[i+1]*cfa(i+off,j);
+    imageStore(img_lp, ivec2(ipos.x/2,ipos.y), vec4(max(1e-6, lp)));
+  }
+#undef cfa
+}

--- a/shaders/rcd_fill.comp
+++ b/shaders/rcd_fill.comp
@@ -1,0 +1,162 @@
+#version 460
+#extension GL_GOOGLE_include_directive : enable
+#extension GL_EXT_shader_explicit_arithmetic_types_float16 : enable
+#extension GL_EXT_control_flow_attributes : enable
+#include "shared.glsl"
+#include "config.h"
+layout(local_size_x = DT_RCD_LOCAL_SIZE_X, local_size_y = DT_RCD_LOCAL_SIZE_Y, local_size_z = 1) in;
+layout(set = 1, binding = 0) uniform sampler2D img_cfa;
+layout(set = 1, binding = 1) uniform sampler2D img_vh; // vertical/horizontal discr
+layout(set = 1, binding = 2) uniform sampler2D img_pq; // diagonal discr
+layout(set = 1, binding = 3) uniform sampler2D img_lp; // low pass filtered green
+layout(set = 1, binding = 4) uniform writeonly image2D img_out; // interpolated output
+layout(push_constant, std140) uniform push_t
+{
+  vec4 wb;
+  uint filters;
+} push;
+
+#define STRIDE (DT_RCD_TILE_SIZE_X)
+shared float16_t shm_r[STRIDE*DT_RCD_TILE_SIZE_Y];
+shared float16_t shm_g[STRIDE*DT_RCD_TILE_SIZE_Y];
+shared float16_t shm_b[STRIDE*DT_RCD_TILE_SIZE_Y];
+
+int col(ivec2 p) { return (((p.x+p.y)&1)==1) ? 1 : ((p.y&1)==0 ? 0 : 2); }
+
+void main()
+{
+#define cfa(x,y) texelFetch(img_cfa, ivec2(tc. x,tc. y), 0).r
+#define vh(x,y)  texture(img_vh,  (vec2(tc. x,tc. y)+0.5)/vec2(textureSize(img_vh,0))).r
+#define pq(x,y)  texture(img_pq,  (vec2((tc. x +((((tc.y)&1)==1)?0:1) )/2,tc. y)+0.5)/vec2(textureSize(img_pq,0))).r
+#define lp(x,y)  texture(img_lp,  (vec2((tc. x +((((tc.y)&1)==1)?0:1) )/2,tc. y)+0.5)/vec2(textureSize(img_lp,0))).r
+#define ind(x,y) (STRIDE*(lid. y) + lid. x + tc.r - ipos.r)
+  ivec2 ipos = ivec2(gl_WorkGroupID.xy * ivec2(
+        DT_RCD_TILE_SIZE_X-2*DT_RCD_BORDER,
+        DT_RCD_TILE_SIZE_Y-2*DT_RCD_BORDER));
+  if(any(greaterThanEqual(ipos, imageSize(img_out)))) return;
+  const ivec2 lid = ivec2(2,1)*ivec2(gl_LocalInvocationID.xy);
+  ipos += lid - DT_RCD_BORDER;
+  const float eps = 1e-5;
+  {
+    const int c0 = col(ipos), c1 = col(ipos+ivec2(1,0));
+    const ivec2 tc = ipos;
+    const float v0 = clamp(cfa(x, y), 0.0, 65535.0), v1 = clamp(cfa(x+1, y), 0.0, 65535.0);
+    if(c0 == 0) shm_r[ind(x,  y)] = float16_t(push.wb.r * v0);
+    else        shm_r[ind(x,  y)] = float16_t(0.0);
+    if(c1 == 0) shm_r[ind(x+1,y)] = float16_t(push.wb.r * v1);
+    else        shm_r[ind(x+1,y)] = float16_t(0.0);
+    if(c0 == 1) shm_g[ind(x,  y)] = float16_t(push.wb.g * v0);
+    else        shm_g[ind(x,  y)] = float16_t(0.0);
+    if(c1 == 1) shm_g[ind(x+1,y)] = float16_t(push.wb.g * v1);
+    else        shm_g[ind(x+1,y)] = float16_t(0.0);
+    if(c0 == 2) shm_b[ind(x,  y)] = float16_t(push.wb.b * v0);
+    else        shm_b[ind(x,  y)] = float16_t(0.0);
+    if(c1 == 2) shm_b[ind(x+1,y)] = float16_t(push.wb.b * v1);
+    else        shm_b[ind(x+1,y)] = float16_t(0.0);
+  }
+  barrier();
+  {
+    const ivec2 tc = (col(ipos) == 1) ? ipos+ivec2(1,0) : ipos;
+    const float vhc = vh(x, y);
+    const float vhn = 0.25 * (vh(x-1,y-1) + vh(x+1,y-1) + vh(x-1,y+1) + vh(x+1,y+1));
+    const float vh_discr = mix(vhc, vhn, abs(0.5-vhc) < abs(0.5-vhn));
+
+    const float N_grad = eps
+      + abs(cfa(x,y-1) - cfa(x,y+1)) + abs(cfa(x,y)   - cfa(x,y-2))
+      + abs(cfa(x,y-1) - cfa(x,y-3)) + abs(cfa(x,y-2) - cfa(x,y-4));
+    const float S_grad = eps
+      + abs(cfa(x,y-1) - cfa(x,y+1)) + abs(cfa(x,y)   - cfa(x,y+2))
+      + abs(cfa(x,y+1) - cfa(x,y+3)) + abs(cfa(x,y+2) - cfa(x,y+4));
+    const float W_grad = eps
+      + abs(cfa(x-1,y) - cfa(x+1,y)) + abs(cfa(x,y)   - cfa(x-2,y))
+      + abs(cfa(x-1,y) - cfa(x-3,y)) + abs(cfa(x-2,y) - cfa(x-4,y));
+    const float E_grad = eps
+      + abs(cfa(x-1,y) - cfa(x+1,y)) + abs(cfa(x,y)   - cfa(x+2,y))
+      + abs(cfa(x+1,y) - cfa(x+3,y)) + abs(cfa(x+2,y) - cfa(x+4,y));
+
+    const float N_est = cfa(x,y-1) * 2.0*lp(x,y)/(eps + lp(x,y) + lp(x,y-2));
+    const float S_est = cfa(x,y+1) * 2.0*lp(x,y)/(eps + lp(x,y) + lp(x,y+2));
+    const float W_est = cfa(x-1,y) * 2.0*lp(x,y)/(eps + lp(x,y) + lp(x-2,y));
+    const float E_est = cfa(x+1,y) * 2.0*lp(x,y)/(eps + lp(x,y) + lp(x+2,y));
+
+    const float v_est = clamp((S_grad * N_est + N_grad * S_est) / (N_grad + S_grad), 0.0, 65534.0);
+    const float h_est = clamp((W_grad * E_est + E_grad * W_est) / (E_grad + W_grad), 0.0, 65534.0);
+    shm_g[ind(x,y)] = float16_t(mix(v_est, h_est, vh_discr));
+  }
+  barrier();
+  {
+    const ivec2 tc = (col(ipos) == 1) ? ipos+ivec2(1,0) : ipos;
+    const bool red = (col(tc) == 0);
+    const float pqc = pq(x,y);
+    const float pqn = 0.25*(pq(x-1,y-1) + pq(x+1,y-1) + pq(x-1,y+1) + pq(x+1,y+1));
+    const float pq_discr = mix(pqc, pqn, abs(0.5-pqc) < abs(0.5-pqn));
+#define sg(x,y) shm_g[ind(x,y)]
+#define sc(x,y) (red ? shm_b[ind(x,y)] : shm_r[ind(x,y)])
+    float NW_grad = eps + abs(sc(x-1,y-1) - sc(x+1,y+1)) + abs(sc(x-1,y-1) - sc(x-3,y-3)) + abs(sg(x,y) - sg(x-2,y-2));
+    float NE_grad = eps + abs(sc(x+1,y-1) - sc(x-1,y+1)) + abs(sc(x+1,y-1) - sc(x+3,y-3)) + abs(sg(x,y) - sg(x+2,y-2));
+    float SW_grad = eps + abs(sc(x+1,y-1) - sc(x-1,y+1)) + abs(sc(x-1,y+1) - sc(x-3,y+3)) + abs(sg(x,y) - sg(x-2,y+2));
+    float SE_grad = eps + abs(sc(x-1,y-1) - sc(x+1,y+1)) + abs(sc(x+1,y+1) - sc(x+3,y+3)) + abs(sg(x,y) - sg(x+2,y+2));
+    const float NW_est = sc(x-1,y-1) - sg(x-1,y-1);
+    const float NE_est = sc(x+1,y-1) - sg(x+1,y-1);
+    const float SW_est = sc(x-1,y+1) - sg(x-1,y+1);
+    const float SE_est = sc(x+1,y+1) - sg(x+1,y+1);
+
+    const float p_est = (NW_grad * SE_est + SE_grad * NW_est) / (NW_grad + SE_grad);
+    const float q_est = (NE_grad * SW_est + SW_grad * NE_est) / (NE_grad + SW_grad);
+    if(red) shm_b[ind(x,y)] = float16_t(clamp(sg(x,y) + mix(p_est, q_est, pq_discr), 0.0, 65535.0));
+    else    shm_r[ind(x,y)] = float16_t(clamp(sg(x,y) + mix(p_est, q_est, pq_discr), 0.0, 65535.0));
+#undef sc
+  }
+  barrier();
+  {
+    const ivec2 tc = (col(ipos) == 1) ? ipos : ipos+ivec2(1,0);
+    const float vhc = vh(x,y);
+    const float vhn = 0.25 * (vh(x-1,y-1) + vh(x+1,y-1) + vh(x-1,y+1) + vh(x+1,y+1));
+    const float vh_discr = mix(vhc, vhn, abs(0.5-vhc) < abs(0.5-vhn));
+
+    const float N1 = eps + abs(sg(x,y) - sg(x,y-2));
+    const float S1 = eps + abs(sg(x,y) - sg(x,y+2));
+    const float W1 = eps + abs(sg(x,y) - sg(x-2,y));
+    const float E1 = eps + abs(sg(x,y) - sg(x+2,y));
+#define sc(x,y) ((c==0) ? shm_r[ind(x,y)] : shm_b[ind(x,y)])
+    [[unroll]] for(int c=0;c<2;c++)
+    {
+      const float SNabs = abs(sc(x,y-1) - sc(x,y+1));
+      const float EWabs = abs(sc(x-1,y) - sc(x+1,y));
+      const float N_grad = N1 + SNabs + abs(sc(x,y-1) - sc(x,y-3));
+      const float S_grad = S1 + SNabs + abs(sc(x,y+1) - sc(x,y+3));
+      const float W_grad = W1 + EWabs + abs(sc(x-1,y) - sc(x-3,y));
+      const float E_grad = E1 + EWabs + abs(sc(x+1,y) - sc(x+3,y));
+      const float N_est = sc(x,y-1) - sg(x,y-1);
+      const float S_est = sc(x,y+1) - sg(x,y+1);
+      const float W_est = sc(x-1,y) - sg(x-1,y);
+      const float E_est = sc(x+1,y) - sg(x+1,y);
+      const float v_est = (N_grad * S_est + S_grad * N_est) / (N_grad + S_grad);
+      const float h_est = (E_grad * W_est + W_grad * E_est) / (E_grad + W_grad);
+      if(c == 0) shm_r[ind(x,y)] = float16_t(clamp(sg(x,y) + mix(v_est, h_est, vh_discr), 0.0, 65535.0));
+      else       shm_b[ind(x,y)] = float16_t(clamp(sg(x,y) + mix(v_est, h_est, vh_discr), 0.0, 65535.0));
+    }
+#undef sc
+#undef sg
+  }
+  barrier();
+  {
+    uint lidx = STRIDE * lid.y + lid.x;
+    ivec2 gp = ipos, lp = lid;
+    [[unroll]] for(int i=0;i<2;i++)
+    {
+      if(all(greaterThanEqual(lp, ivec2(DT_RCD_BORDER))) &&
+         all(lessThan(gp, imageSize(img_out))) &&
+         all(lessThan(lp, ivec2(DT_RCD_TILE_SIZE_X, DT_RCD_TILE_SIZE_Y)-DT_RCD_BORDER)))
+        imageStore(img_out, gp, vec4(vec3(shm_r[lidx], shm_g[lidx], shm_b[lidx])/push.wb.rgb, 1.0));
+      lidx++;
+      lp.x += 1;
+      gp.x += 1;
+    }
+  }
+#undef cfa
+#undef vh
+#undef pq
+#undef lp
+#undef ind
+}

--- a/shaders/shared.glsl
+++ b/shaders/shared.glsl
@@ -1,0 +1,1 @@
+// Placeholder shared definitions for RCD shaders

--- a/src/Utils/ColorPipelineCPU.cpp
+++ b/src/Utils/ColorPipelineCPU.cpp
@@ -143,49 +143,148 @@ void convertRawToRGB24_RCD(const uint16_t* raw, const CPUColorParams& p,
             bool xe = (x%2)==0;
             float r=0,g=0,b=0;
             float vh = edgeRatio(x,y);
-            if(p.cfaType==0){ // BGGR
-                if(ye){
-                    if(xe){ // B pixel
-                        b = lin(x,y);
-                        float g_h = 0.5f*(lin(x-1,y)+lin(x+1,y));
-                        float g_v = 0.5f*(lin(x,y-1)+lin(x,y+1));
-                        g = (1.0f-vh)*g_v + vh*g_h;
-                        float rb_diag1 = 0.5f*(lin(x-1,y-1)+lin(x+1,y+1));
-                        float rb_diag2 = 0.5f*(lin(x-1,y+1)+lin(x+1,y-1));
-                        r = g + ((vh > 0.5f) ? rb_diag2 - g : rb_diag1 - g);
-                    } else { // G pixel
-                        g = lin(x,y);
-                        float r_h = 0.5f*(lin(x-1,y)+lin(x+1,y));
-                        float r_v = 0.5f*(lin(x,y-1)+lin(x,y+1));
-                        r = (1.0f-vh)*r_v + vh*r_h;
-                        b = r_v; // simple
+            switch(p.cfaType){
+                case 0: // BGGR
+                    if(ye){
+                        if(xe){ // B pixel
+                            b = lin(x,y);
+                            float g_h = 0.5f*(lin(x-1,y)+lin(x+1,y));
+                            float g_v = 0.5f*(lin(x,y-1)+lin(x,y+1));
+                            g = (1.0f-vh)*g_v + vh*g_h;
+                            float rd1 = 0.5f*(lin(x-1,y-1)+lin(x+1,y+1));
+                            float rd2 = 0.5f*(lin(x-1,y+1)+lin(x+1,y-1));
+                            r = (vh > 0.5f) ? rd2 : rd1;
+                        } else { // G pixel
+                            g = lin(x,y);
+                            float r_h = 0.5f*(lin(x-1,y)+lin(x+1,y));
+                            float r_v = 0.5f*(lin(x,y-1)+lin(x,y+1));
+                            r = (1.0f-vh)*r_v + vh*r_h;
+                            b = r_v;
+                        }
+                    } else {
+                        if(xe){ // G pixel
+                            g = lin(x,y);
+                            float b_h = 0.5f*(lin(x-1,y)+lin(x+1,y));
+                            float b_v = 0.5f*(lin(x,y-1)+lin(x,y+1));
+                            b = (1.0f-vh)*b_v + vh*b_h;
+                            r = b_v;
+                        } else { // R pixel
+                            r = lin(x,y);
+                            float g_h = 0.5f*(lin(x-1,y)+lin(x+1,y));
+                            float g_v = 0.5f*(lin(x,y-1)+lin(x,y+1));
+                            g = (1.0f-vh)*g_v + vh*g_h;
+                            float bd1 = 0.5f*(lin(x-1,y-1)+lin(x+1,y+1));
+                            float bd2 = 0.5f*(lin(x-1,y+1)+lin(x+1,y-1));
+                            b = (vh > 0.5f) ? bd2 : bd1;
+                        }
                     }
-                } else {
-                    if(xe){ // G pixel
-                        g = lin(x,y);
-                        float b_h = 0.5f*(lin(x-1,y)+lin(x+1,y));
-                        float b_v = 0.5f*(lin(x,y-1)+lin(x,y+1));
-                        b = (1.0f-vh)*b_v + vh*b_h;
-                        r = b_v;
-                    } else { // R pixel
-                        r = lin(x,y);
-                        float g_h = 0.5f*(lin(x-1,y)+lin(x+1,y));
-                        float g_v = 0.5f*(lin(x,y-1)+lin(x,y+1));
-                        g = (1.0f-vh)*g_v + vh*g_h;
-                        float rb_diag1 = 0.5f*(lin(x-1,y-1)+lin(x+1,y+1));
-                        float rb_diag2 = 0.5f*(lin(x-1,y+1)+lin(x+1,y-1));
-                        b = g + ((vh > 0.5f) ? rb_diag2 - g : rb_diag1 - g);
+                    break;
+                case 1: // RGGB
+                    if(ye){
+                        if(xe){ // R pixel
+                            r = lin(x,y);
+                            float g_h = 0.5f*(lin(x-1,y)+lin(x+1,y));
+                            float g_v = 0.5f*(lin(x,y-1)+lin(x,y+1));
+                            g = (1.0f-vh)*g_v + vh*g_h;
+                            float bd1 = 0.5f*(lin(x-1,y-1)+lin(x+1,y+1));
+                            float bd2 = 0.5f*(lin(x-1,y+1)+lin(x+1,y-1));
+                            b = (vh > 0.5f) ? bd2 : bd1;
+                        } else { // G pixel
+                            g = lin(x,y);
+                            float b_h = 0.5f*(lin(x-1,y)+lin(x+1,y));
+                            float b_v = 0.5f*(lin(x,y-1)+lin(x,y+1));
+                            b = (1.0f-vh)*b_v + vh*b_h;
+                            r = b_v;
+                        }
+                    } else {
+                        if(xe){ // G pixel
+                            g = lin(x,y);
+                            float r_h = 0.5f*(lin(x-1,y)+lin(x+1,y));
+                            float r_v = 0.5f*(lin(x,y-1)+lin(x,y+1));
+                            r = (1.0f-vh)*r_v + vh*r_h;
+                            b = r_v;
+                        } else { // B pixel
+                            b = lin(x,y);
+                            float g_h = 0.5f*(lin(x-1,y)+lin(x+1,y));
+                            float g_v = 0.5f*(lin(x,y-1)+lin(x,y+1));
+                            g = (1.0f-vh)*g_v + vh*g_h;
+                            float rd1 = 0.5f*(lin(x-1,y-1)+lin(x+1,y+1));
+                            float rd2 = 0.5f*(lin(x-1,y+1)+lin(x+1,y-1));
+                            r = (vh > 0.5f) ? rd2 : rd1;
+                        }
                     }
-                }
-            } else {
-                // fallback to simple bilinear for other patterns
-                if(ye){
-                    if(xe){ g=lin(x,y); r=0.5f*(lin(x-1,y)+lin(x+1,y)); b=0.5f*(lin(x,y-1)+lin(x,y+1)); }
-                    else   { r=lin(x,y); g=0.25f*(lin(x-1,y)+lin(x+1,y)+lin(x,y-1)+lin(x,y+1)); b=0.25f*(lin(x-1,y-1)+lin(x+1,y-1)+lin(x-1,y+1)+lin(x+1,y+1)); }
-                }else{
-                    if(xe){ b=lin(x,y); g=0.25f*(lin(x-1,y)+lin(x+1,y)+lin(x,y-1)+lin(x,y+1)); r=0.25f*(lin(x-1,y-1)+lin(x+1,y-1)+lin(x-1,y+1)+lin(x+1,y+1)); }
-                    else   { g=lin(x,y); r=0.5f*(lin(x-1,y)+lin(x+1,y)); b=0.5f*(lin(x,y-1)+lin(x,y+1)); }
-                }
+                    break;
+                case 2: // GBRG
+                    if(ye){
+                        if(xe){ // G pixel
+                            g = lin(x,y);
+                            float b_h = 0.5f*(lin(x-1,y)+lin(x+1,y));
+                            float b_v = 0.5f*(lin(x,y-1)+lin(x,y+1));
+                            b = (1.0f-vh)*b_h + vh*b_v;
+                            r = b_h;
+                        } else { // B pixel
+                            b = lin(x,y);
+                            float g_h = 0.5f*(lin(x-1,y)+lin(x+1,y));
+                            float g_v = 0.5f*(lin(x,y-1)+lin(x,y+1));
+                            g = (1.0f-vh)*g_h + vh*g_v;
+                            float rd1 = 0.5f*(lin(x-1,y-1)+lin(x+1,y+1));
+                            float rd2 = 0.5f*(lin(x-1,y+1)+lin(x+1,y-1));
+                            r = (vh > 0.5f) ? rd1 : rd2;
+                        }
+                    } else {
+                        if(xe){ // R pixel
+                            r = lin(x,y);
+                            float g_h = 0.5f*(lin(x-1,y)+lin(x+1,y));
+                            float g_v = 0.5f*(lin(x,y-1)+lin(x,y+1));
+                            g = (1.0f-vh)*g_h + vh*g_v;
+                            float bd1 = 0.5f*(lin(x-1,y-1)+lin(x+1,y+1));
+                            float bd2 = 0.5f*(lin(x-1,y+1)+lin(x+1,y-1));
+                            b = (vh > 0.5f) ? bd1 : bd2;
+                        } else { // G pixel
+                            g = lin(x,y);
+                            float r_h = 0.5f*(lin(x-1,y)+lin(x+1,y));
+                            float r_v = 0.5f*(lin(x,y-1)+lin(x,y+1));
+                            r = (1.0f-vh)*r_h + vh*r_v;
+                            b = r_h;
+                        }
+                    }
+                    break;
+                case 3: // GRBG
+                default:
+                    if(ye){
+                        if(xe){ // G pixel
+                            g = lin(x,y);
+                            float r_h = 0.5f*(lin(x-1,y)+lin(x+1,y));
+                            float r_v = 0.5f*(lin(x,y-1)+lin(x,y+1));
+                            r = (1.0f-vh)*r_h + vh*r_v;
+                            b = r_h;
+                        } else { // R pixel
+                            r = lin(x,y);
+                            float g_h = 0.5f*(lin(x-1,y)+lin(x+1,y));
+                            float g_v = 0.5f*(lin(x,y-1)+lin(x,y+1));
+                            g = (1.0f-vh)*g_h + vh*g_v;
+                            float bd1 = 0.5f*(lin(x-1,y-1)+lin(x+1,y+1));
+                            float bd2 = 0.5f*(lin(x-1,y+1)+lin(x+1,y-1));
+                            b = (vh > 0.5f) ? bd1 : bd2;
+                        }
+                    } else {
+                        if(xe){ // B pixel
+                            b = lin(x,y);
+                            float g_h = 0.5f*(lin(x-1,y)+lin(x+1,y));
+                            float g_v = 0.5f*(lin(x,y-1)+lin(x,y+1));
+                            g = (1.0f-vh)*g_h + vh*g_v;
+                            float rd1 = 0.5f*(lin(x-1,y-1)+lin(x+1,y+1));
+                            float rd2 = 0.5f*(lin(x-1,y+1)+lin(x+1,y-1));
+                            r = (vh > 0.5f) ? rd1 : rd2;
+                        } else { // G pixel
+                            g = lin(x,y);
+                            float b_h = 0.5f*(lin(x-1,y)+lin(x+1,y));
+                            float b_v = 0.5f*(lin(x,y-1)+lin(x,y+1));
+                            b = (1.0f-vh)*b_h + vh*b_v;
+                            r = b_h;
+                        }
+                    }
+                    break;
             }
 
             float r_wb = std::clamp(r * p.gainR, 0.0f, 1.0f);


### PR DESCRIPTION
## Summary
- enable RCD demosaicing for all CFA patterns on CPU
- use RCD across all CFA types in GPU shaders
- add placeholder compute shaders for full RCD pipeline
- compile new shaders in CMake

## Testing
- `cmake -S . -B build` succeeded
- `cmake --build build` failed: `fatal error: libavutil/frame.h: No such file or directory`

------
https://chatgpt.com/codex/tasks/task_e_68868049b24083278e59c5c84a8f68b5